### PR TITLE
streams styleguide updates

### DIFF
--- a/src/streams/ArraySink.ts
+++ b/src/streams/ArraySink.ts
@@ -1,5 +1,5 @@
-import { Sink } from './WritableStream';
 import Promise from '../Promise';
+import { Sink } from './WritableStream';
 
 /**
  * A WritableStream sink that collects the chunks it receives and

--- a/src/streams/ReadableStreamController.ts
+++ b/src/streams/ReadableStreamController.ts
@@ -16,7 +16,7 @@ export default class ReadableStreamController<T> {
 			throw new TypeError('3.3.3-1: ReadableStreamController can only be constructed with a ReadableStream instance');
 		}
 
-		if (stream._controller !== undefined) {
+		if (stream.controller !== undefined) {
 			throw new TypeError('ReadableStreamController instances can only be created by the ReadableStream constructor');
 		}
 
@@ -31,8 +31,8 @@ export default class ReadableStreamController<T> {
 			throw new TypeError('3.3.4.2-1: ReadableStreamController#close can only be used on a ReadableStreamController');
 		}
 
-		var stream = this._controlledReadableStream;
-		if (stream._closeRequested) {
+		const stream = this._controlledReadableStream;
+		if (stream.closeRequested) {
 			throw new TypeError('3.3.4.2-3: The stream has already been closed; do not close it again!');
 		}
 
@@ -40,7 +40,7 @@ export default class ReadableStreamController<T> {
 			throw new TypeError('3.3.4.2-4: The stream is in an errored state and cannot be closed');
 		}
 
-		return stream._requestClose();
+		return stream.requestClose();
 	}
 
 	/**
@@ -51,13 +51,13 @@ export default class ReadableStreamController<T> {
 			throw new TypeError('3.3.4.3-1: ReadableStreamController#enqueue can only be used on a ReadableStreamController');
 		}
 
-		var stream = this._controlledReadableStream;
+		const stream = this._controlledReadableStream;
 
 		if (stream.state === State.Errored) {
-			throw stream._storedError;
+			throw stream.storedError;
 		}
 
-		if (stream._closeRequested) {
+		if (stream.closeRequested) {
 			throw new TypeError('3.3.4.3-4: stream is draining');
 		}
 

--- a/src/streams/SizeQueue.ts
+++ b/src/streams/SizeQueue.ts
@@ -4,26 +4,6 @@ interface Pair<T> {
 }
 
 export default class SizeQueue<T> {
-	private _queue: Pair<T>[] = [];
-
-	dequeue(): T {
-		const pair = this._queue.shift();
-		return pair.value;
-	}
-
-	enqueue(value: T, size: number): void {
-		this._queue.push({ value: value, size: size });
-	}
-
-	empty() {
-		this._queue = [];
-	}
-
-	peek(): T {
-		const pair = this._queue[0];
-		return pair.value;
-	}
-
 	get totalSize(): number {
 		let totalSize = 0;
 		this._queue.forEach(pair => totalSize += pair.size);
@@ -32,5 +12,25 @@ export default class SizeQueue<T> {
 
 	get length(): number {
 		return this._queue.length;
+	}
+
+	private _queue: Pair<T>[] = [];
+
+	empty() {
+		this._queue = [];
+	}
+
+	enqueue(value: T, size: number): void {
+		this._queue.push({ value: value, size: size });
+	}
+
+	dequeue(): T {
+		const pair = this._queue.shift();
+		return pair.value;
+	}
+
+	peek(): T {
+		const pair = this._queue[0];
+		return pair.value;
 	}
 }

--- a/src/streams/util.ts
+++ b/src/streams/util.ts
@@ -1,77 +1,11 @@
 import { Strategy } from './interfaces';
 import Promise from '../Promise';
 
-export function promiseInvokeOrFallbackOrNoop(object: any, method1: string, args1: any[], method2: string, args2: any[] = []): Promise<any> {
-	var method: Function;
-
-	try {
-		method = object[method1];
-	}
-	catch (error ) {
-		return Promise.reject(error);
-	}
-
-	if (!method) {
-		return promiseInvokeOrNoop(object, method2, args2);
-	}
-
-	if (!args1) {
-		args1 = [];
-	}
-
-	try {
-		return Promise.resolve(method.apply(object, args1));
-	}
-	catch (error) {
-		return Promise.reject(error);
-	}
-}
-
-/**
- * return a promise that resolves the with result of the method call or undefined
- */
-export function promiseInvokeOrNoop(O: any, P: string, args: any[] = []): Promise<any> {
-	var method: any;
-
-	try {
-		method = O[P];
-	}
-	catch (error) {
-		return Promise.reject(error);
-	}
-
-	if (!method) {
-		return Promise.resolve();
-	}
-
-	try {
-		return Promise.resolve(method.apply(O, args));
-	}
-	catch (error) {
-		return Promise.reject(error);
-	}
-}
-
-/**
- * call the method or return undefined
- */
-export function invokeOrNoop(O: any, P: string, args: any[] = []): any {
-	var method: Function = O[P];
-	return method ? method.apply(O, args) : undefined;
-}
-
 /**
  *
  */
 export function createDataProperty(object: {}, property: string, value: any) {
 	Object.defineProperty(object, property, { value: value, writable: true, enumerable: true, configurable: true });
-}
-
-export function normalizeStrategy<T>({ size, highWaterMark = 1 }: Strategy<T>): Strategy<T> {
-	return <Strategy <T>> {
-		size: size,
-		highWaterMark: highWaterMark > 0 ? highWaterMark : 1
-	};
 }
 
 /*
@@ -134,3 +68,70 @@ export function getApproximateByteSize(object: any): number {
 
 	return size;
 }
+
+/**
+ * call the method or return undefined
+ */
+export function invokeOrNoop(O: any, P: string, args: any[] = []): any {
+	const method: Function = O[P];
+	return method ? method.apply(O, args) : undefined;
+}
+
+export function normalizeStrategy<T>({ size, highWaterMark = 1 }: Strategy<T>): Strategy<T> {
+	return <Strategy <T>> {
+		size: size,
+		highWaterMark: highWaterMark > 0 ? highWaterMark : 1
+	};
+}
+
+export function promiseInvokeOrFallbackOrNoop(object: any, method1: string, args1: any[], method2: string, args2: any[] = []): Promise<any> {
+	let method: Function;
+
+	try {
+		method = object[method1];
+	}
+	catch (error ) {
+		return Promise.reject(error);
+	}
+
+	if (!method) {
+		return promiseInvokeOrNoop(object, method2, args2);
+	}
+
+	if (!args1) {
+		args1 = [];
+	}
+
+	try {
+		return Promise.resolve(method.apply(object, args1));
+	}
+	catch (error) {
+		return Promise.reject(error);
+	}
+}
+
+/**
+ * return a promise that resolves the with result of the method call or undefined
+ */
+export function promiseInvokeOrNoop(O: any, P: string, args: any[] = []): Promise<any> {
+	let method: any;
+
+	try {
+		method = O[P];
+	}
+	catch (error) {
+		return Promise.reject(error);
+	}
+
+	if (!method) {
+		return Promise.resolve();
+	}
+
+	try {
+		return Promise.resolve(method.apply(O, args));
+	}
+	catch (error) {
+		return Promise.reject(error);
+	}
+}
+

--- a/tests/unit/streams/ReadableStreamController.ts
+++ b/tests/unit/streams/ReadableStreamController.ts
@@ -23,7 +23,7 @@ registerSuite({
 	beforeEach() {
 		source = new BaseStringSource();
 		stream = new ReadableStream<string>(source, strategy);
-		controller = stream._controller;
+		controller = stream.controller;
 	},
 
 	'constructor': {
@@ -58,13 +58,13 @@ registerSuite({
 		};
 		var source = new BaseStringSource();
 		var stream = new ReadableStream<string>(source, strategy);
-		assert.equal(10, stream._controller.desiredSize);
+		assert.strictEqual(stream.controller.desiredSize, 10);
 	},
 
 	'close()': {
 		'calls close() on the ReadableStream'() {
 			var closeCalled = false;
-			stream._requestClose = () => { closeCalled = true; };
+			stream.requestClose = () => { closeCalled = true; };
 			controller.close();
 			assert.isTrue(closeCalled);
 		},
@@ -104,7 +104,7 @@ registerSuite({
 		},
 
 		'throws an error if a close has been requested'() {
-			stream._requestClose();
+			stream.requestClose();
 			assert.throws(() => {
 				controller.enqueue('foo');
 			});

--- a/tests/unit/streams/ReadableStreamReader.ts
+++ b/tests/unit/streams/ReadableStreamReader.ts
@@ -68,7 +68,7 @@ registerSuite({
 				dfd.callback(() => { /* passed */}),
 				dfd.rejectOnError(() => { assert.fail(); })
 			);
-			stream._close();
+			stream.close();
 		}
 
 	},
@@ -95,7 +95,7 @@ registerSuite({
 
 		'calls the stream cancel method'() {
 			var cancelCalled = false;
-			stream._cancel = () => { cancelCalled = true; return Promise.resolve(); };
+			(<any> stream)._cancel = () => { cancelCalled = true; return Promise.resolve(); };
 			reader.cancel('reason');
 			assert.isTrue(cancelCalled);
 		},
@@ -131,7 +131,7 @@ registerSuite({
 
 		'resolves with the chunk value'() {
 			var chunkValue = 'test';
-			stream._controller.enqueue(chunkValue);
+			stream.controller.enqueue(chunkValue);
 			return reader.read().then((result: ReadResult<string>) => {
 				assert.strictEqual(result.value, chunkValue);
 			});


### PR DESCRIPTION
Update code per the Dojo 2 styleguide.
- update property, method ordering
- properly mark private/public/protected methods
- properly mark private/public/protected properties
- update unit tests format
- use const and let where appropriate
- remove unnecessary use of fat arrows
- use lengthOf assertion where appropriate
