### PR TITLE
Restore ReadableStream#cancel precondition checks

### DIFF
--- a/src/streams/ReadableStream.ts
+++ b/src/streams/ReadableStream.ts
@@ -180,13 +180,9 @@ export default class ReadableStream<T> {
 	 * @returns {null}
 	 */
 	cancel(reason?: any): Promise<void> {
-		// if (!this.hasSource) {
-		// 	return Promise.reject(new TypeError('3.2.4.1-1: Must be a ReadableStream'));
-		// }
-
-		// if (this.locked) {
-		// 	return Promise.reject(new TypeError('3.2.4.1-2: The stream is locked'));
-		// }
+		 if (!this.hasSource) {
+		 	return Promise.reject(new TypeError('3.2.4.1-1: Must be a ReadableStream'));
+		 }
 
 		return this._cancel(reason);
 	}
@@ -205,7 +201,7 @@ export default class ReadableStream<T> {
 		this.state = State.Closed;
 
 		if (this.locked) {
-			return this.reader.release();
+			this.reader.release();
 		}
 	}
 

--- a/tests/unit/streams/ReadableStream.ts
+++ b/tests/unit/streams/ReadableStream.ts
@@ -308,16 +308,13 @@ registerSuite({
 			);
 		},
 
-		// 'locked'() {
-		// 	var dfd = this.async(asyncTimeout);
-		// 	var stream = new ReadableStream(new BaseStringSource(), strategy);
-		// 	stream.getReader();
-		// 	assert.isTrue(stream.locked);
-		// 	stream.cancel().then(
-		// 		dfd.rejectOnError(() => { assert.fail(); }),
-		// 		dfd.callback((error: Error) => { assert.isObject(error); })
-		// 	);
-		// },
+		'locked'() {
+			var stream = new ReadableStream(new BaseStringSource(), strategy);
+			stream.getReader();
+			assert.isTrue(stream.locked);
+			// cancel should work just fine.
+			return stream.cancel();
+		},
 
 		'closed'() {
 			var dfd = this.async(asyncTimeout);


### PR DESCRIPTION
I restored the ReadableStream#cancel hasSource precondition check but I removed the locked check.  The cancel method ends up calling close with unlocks the reader.  I see no reason why that precondition is being tested in the spec.

I would wait to merge this until Ken commits his style guide changes.  
