### PR TITLE
Implement shim for registering microtasks.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
 		"./tests/typings/benchmark/benchmark.d.ts",
 		"./tests/typings/chai/chai.d.ts",
 		"./tests/typings/digdug/digdug.d.ts",
+		"./tests/typings/dist/dist.d.ts",
 		"./tests/typings/dojo2/dojo.d.ts",
 		"./tests/typings/intern/intern.d.ts",
 		"./tests/typings/leadfoot/leadfoot.d.ts",


### PR DESCRIPTION
When an environment does not provide a native means of registering callbacks to the microtask queue, the `queueMicroTask` method will push registered callbacks to an internal queue, which will execute all "microtasks" within a single macrotask, before any other macrotasks have been registered.
