### PR TITLE
TransformStream: update unit tests

### DIFF
--- a/tests/unit/streams/TransformStream.ts
+++ b/tests/unit/streams/TransformStream.ts
@@ -1,9 +1,10 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import Promise from 'src/Promise';
+
 import { Strategy } from 'src/streams/interfaces';
+import Promise from 'src/Promise';
 import { State as ReadableState } from 'src/streams/ReadableStream';
-import { ReadResult } from 'src/streams/ReadableStreamReader';
+import ReadableStreamReader, { ReadResult } from 'src/streams/ReadableStreamReader';
 import TransformStream, { Transform } from 'src/streams/TransformStream';
 import { State as WritableState } from 'src/streams/WritableStream';
 
@@ -37,14 +38,21 @@ class CharToCodeTransform implements Transform<number, string> {
 	}
 }
 
+let transform: Transform<number, string>;
+let stream: TransformStream<number, string>;
+let reader: ReadableStreamReader<number>;
+
 registerSuite({
 	name: 'TransformStream',
 
+	beforeEach() {
+		transform = new CharToCodeTransform();
+		stream = new TransformStream(transform);
+		reader = stream.readable.getReader();
+	},
+
 	'simple transform'() {
 		let testValue = 'a';
-		let transform = new CharToCodeTransform();
-		let stream = new TransformStream(transform);
-		let reader = stream.readable.getReader();
 
 		return stream.writable.write(testValue).then(function () {
 			return reader.read().then(function (result: ReadResult<number>) {
@@ -55,19 +63,14 @@ registerSuite({
 
 	'async transform'() {
 		let testValues = ['a', 'b', 'c'];
-		let transform = new CharToCodeTransform();
+		let results: number[] = [];
 
-		// This change must be made before instantiating the stream as the stream will immediately create a reference
-		// to the 'transform' method
 		transform.transform = (chunk: string, enqueue: (chunk: number) => void, transformDone: () => void): void => {
 			setTimeout(function () {
 				enqueue(chunk.charCodeAt(0));
 				transformDone();
 			}, 20);
 		};
-		let stream = new TransformStream(transform);
-		let reader = stream.readable.getReader();
-		let results: number[] = [];
 
 		for (let i = 0; i < testValues.length; i++) {
 			stream.writable.write(testValues[i]);
@@ -95,15 +98,9 @@ registerSuite({
 	},
 
 	'transform.flush throws error'() {
-		let transform = new CharToCodeTransform();
-
-		// This change must be made before instantiating the stream as the stream will immediately create a reference
-		// to the 'flush' method
 		transform.flush = function () {
 			throw new Error('Transform#flush test error');
 		};
-
-		let stream = new TransformStream(transform);
 
 		return stream.writable.close().then(function () {
 			assert.fail(null, null, 'Errored stream should not resolve call to \'close\'');
@@ -114,15 +111,9 @@ registerSuite({
 	},
 
 	'transform.transform throws error'() {
-		let transform = new CharToCodeTransform();
-
-		// This change must be made before instantiating the stream as the stream will immediately create a reference
-		// to the 'transform' method
 		transform.transform = function () {
 			throw new Error('Transform#transform test error');
 		};
-
-		let stream = new TransformStream(transform);
 
 		return stream.writable.write('a').then(function () {
 			assert.fail(null, null, 'Errored stream should not resolve call to \'write\'');


### PR DESCRIPTION
- extract common logic into `beforeEach`
- Ed fixed TransformStream to call transformer methods as methods and preserve context, so the unit tests are no longer sensitive to when transformer methods are mocked or modified.
