### PR TITLE
Remove EventTarget interface since TS already has one

### DIFF
--- a/src/on.ts
+++ b/src/on.ts
@@ -11,12 +11,6 @@ export interface EventEmitter {
 	removeListener(event: string, listener: EventCallback): EventEmitter;
 }
 
-export interface EventTarget {
-	accessKey?: string;
-	addEventListener(event: string, listener: EventCallback, capture?: boolean): void;
-	removeEventListener(event: string, listener: EventCallback, capture?: boolean): void;
-}
-
 interface DOMEventObject extends EventObject {
 	bubbles: boolean;
 	cancelable: boolean;

--- a/src/streams/adapters/EventedStreamSource.ts
+++ b/src/streams/adapters/EventedStreamSource.ts
@@ -1,17 +1,17 @@
 import Evented from '../../Evented';
 import { Handle } from '../../interfaces';
-import on, { EventEmitter, EventTarget, ExtensionEvent } from '../../on';
+import on, { EventEmitter } from '../../on';
 import Promise from '../../Promise';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 
 type EventTargetTypes = Evented | EventEmitter | EventTarget;
-type EventTypes = Array<ExtensionEvent | string> | ExtensionEvent | string;
+type EventTypes = string | string[];
 
 export default class EventedStreamSource implements Source<Event> {
 	protected _controller: ReadableStreamController<Event>;
 	protected _target: EventTargetTypes;
-	protected _events: Array<ExtensionEvent | string>;
+	protected _events: string[];
 	protected _handles: Handle[];
 
 	constructor(target: EventTargetTypes, type: EventTypes) {


### PR DESCRIPTION
I noticed that we have our own `EventTarget` interface defined in `on.ts`, but TS already has one of its own:

``` ts
interface EventTarget {
    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
    dispatchEvent(evt: Event): boolean;
    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
}
```

The main differences are that TS's interface has `dispatchEvent` while ours doesn't, and ours has `accessKey` (though I'm not entirely sure why) while TS's doesn't (it exists on `HTMLElement` in TS's typings).

I figured I'd throw this PR out there in case it's worth the cleanup.  If there is a legitimate reason why we were doing what we're doing, feel free to just close this.  But as far as I can tell, nothing was explicitly relying on our definition and tests still pass.
