### PR TITLE
Simplify lang's object copying (addresses issue #26: https://github.com/dojo/core/issues/26)

### DIFF
--- a/src/lang.ts
+++ b/src/lang.ts
@@ -10,95 +10,55 @@ function isObject(item: any): boolean {
 	return item && typeof item === 'object' && !Array.isArray(item) && !(item instanceof RegExp);
 }
 
-function copyArray(array: any[], kwArgs: CopyArgs): any[] {
+function copyArray(array: any[], inherited: boolean): any[] {
 	return array.map(function (item: any): any {
 		if (Array.isArray(item)) {
-			return copyArray(item, kwArgs);
+			return copyArray(item, inherited);
 		}
 
-		return isObject(item) ?
-			copy({
+		return !isObject(item) ?
+			item :
+			_mixin({
+				deep: true,
+				inherited: inherited,
 				sources: [ item ],
-				deep: kwArgs.deep,
-				descriptors: kwArgs.descriptors,
-				inherited: kwArgs.inherited,
-				assignPrototype: kwArgs.assignPrototype
-			}) :
-			item;
+				target: {}
+			});
 	});
 }
 
-export function copy(kwArgs: CopyArgs): any {
-	const sources: Hash<any>[] = kwArgs.sources;
-	let target: any;
+interface MixinArgs {
+	deep: boolean;
+	inherited: boolean;
+	sources: {}[];
+	target: {};
+}
 
-	if (!sources.length) {
-		throw new RangeError('lang.copy requires at least one source object.');
-	}
+function _mixin(kwArgs: MixinArgs): {} {
+	const deep = kwArgs.deep;
+	const inherited = kwArgs.inherited;
+	const target = kwArgs.target;
 
-	if (kwArgs.assignPrototype) {
-		// create from the same prototype
-		target = Object.create(Object.getPrototypeOf(sources[0]));
-	}
-	else {
-		// use the target or create a new object
-		target = kwArgs.target || {};
-	}
+	for (let source of kwArgs.sources) {
+		for (let key in source) {
+			if (inherited || hasOwnProperty.call(source, key)) {
+				let value: any = (<any> source)[key];
 
-	for (let source of sources) {
-		if (kwArgs.descriptors) {
-			// if we are copying descriptors, use to get{Own}PropertyNames so we get every property
-			// (including non enumerables).
-			const names = (kwArgs.inherited ? getPropertyNames : Object.getOwnPropertyNames)(source);
-
-			for (let name of names) {
-				// get the descriptor
-				const descriptor = (kwArgs.inherited ?
-					getPropertyDescriptor : Object.getOwnPropertyDescriptor)(source, name);
-				let value = descriptor.value;
-
-				if (kwArgs.deep) {
+				if (deep) {
 					if (Array.isArray(value)) {
-						descriptor.value = copyArray(value, kwArgs);
+						value = copyArray(value, inherited);
 					}
 					else if (isObject(value)) {
-						descriptor.value = copy({
-							sources: [ value ],
+						value = _mixin({
 							deep: true,
-							descriptors: true,
-							inherited: kwArgs.inherited,
-							assignPrototype: kwArgs.assignPrototype
+							inherited: inherited,
+							sources: [ value ],
+							target: {}
 						});
 					}
 				}
 
-				// and copy to the target
-				Object.defineProperty(target, name, descriptor);
-			}
-		}
-		else {
-			// If we aren't using descriptors, we use a standard for-in to simplify skipping
-			// non-enumerables and inheritance. We could use Object.keys when we aren't inheriting.
-			for (let name in source) {
-				if (kwArgs.inherited || hasOwnProperty.call(source, name)) {
-					let value = source[name];
-
-					if (kwArgs.deep) {
-						if (Array.isArray(value)) {
-							value = copyArray(value, kwArgs);
-						}
-						else if (isObject(value)) {
-							value = copy({
-								sources: [ value ],
-								deep: true,
-								inherited: kwArgs.inherited,
-								assignPrototype: kwArgs.assignPrototype
-							});
-						}
-					}
-
-					target[name] = value;
-				}
+				(<any> target)[key] = value;
 			}
 		}
 	}
@@ -106,76 +66,95 @@ export function copy(kwArgs: CopyArgs): any {
 	return target;
 }
 
-export interface CopyArgs {
-	deep?: boolean;
-	descriptors?: boolean;
-	inherited?: boolean;
-	assignPrototype?: boolean;
-	target?: any;
-	sources: any[];
+/**
+ * Copies the values of all enumerable own properties of one or more source objects to the target object.
+ * @return The modified target object.
+ */
+export function assign(target: {}, ...sources: {}[]): {} {
+	return _mixin({
+		deep: false,
+		inherited: false,
+		sources: sources,
+		target: target
+	});
 }
 
+/**
+ * Creates a new object from the given prototype, and copies all enumerable own properties of one or more
+ * source objects to the newly created target object.
+ * @return The new target object.
+ */
 export function create(prototype: {}, ...mixins: {}[]): {} {
 	if (!mixins.length) {
 		throw new RangeError('lang.create requires at least one mixin object.');
 	}
 
-	return copy({
-		assignPrototype: false,
-		deep: false,
-		descriptors: false,
-		inherited: false,
-		target: Object.create(prototype),
-		sources: mixins
-	});
+	const args = mixins.slice(0);
+	args.unshift(Object.create(prototype));
+
+	return assign.apply(null, args);
 }
 
-export function duplicate(source: {}): {} {
-	return copy({
-		assignPrototype: true,
+/**
+ * Copies the values of all enumerable own properties of one or more source objects to the target object,
+ * recursively copying all nested objects and arrays as well.
+ * @return The modified target object.
+ */
+export function deepAssign(target: {}, ...sources: {}[]): {} {
+	return _mixin({
 		deep: true,
-		descriptors: true,
-		sources: [ source ]
+		inherited: false,
+		sources: sources,
+		target: target
 	});
 }
 
-export function getPropertyNames(object: {}): string[] {
-	const names : string[] = [];
-	const setOfNames: Hash<any> = {};
-
-	do {
-		// go through each prototype to add the property names
-		const ownNames = Object.getOwnPropertyNames(object);
-		for (let name of ownNames) {
-			// check to make sure we haven't added it yet
-			if (setOfNames[name] !== true) {
-				setOfNames[name] = true;
-				names.push(name);
-			}
-		}
-		object = Object.getPrototypeOf(object);
-	}
-	while (object && object !== Object.prototype);
-
-	return names;
+/**
+ * Copies the values of all enumerable properties of one or more source objects to the target object,
+ * recursively copying all nested objects and arrays as well.
+ * @return The modified target object.
+ */
+export function deepMixin(target: {}, ...sources: {}[]): {} {
+	return _mixin({
+		deep: true,
+		inherited: true,
+		sources: sources,
+		target: target
+	});
 }
 
-export function getPropertyDescriptor(object: Object, property: string): PropertyDescriptor {
-	let descriptor: PropertyDescriptor;
-	do {
-		descriptor = Object.getOwnPropertyDescriptor(object, property);
-	}
-	while (!descriptor && (object = Object.getPrototypeOf(object)));
+/**
+ * Creates a new object using the provided source's prototype as the prototype for the new object, and then
+ * deep copies the provided source's values into the new target.
+ * @return The new target object.
+ */
+export function duplicate(source: {}): {} {
+	const target = Object.create(Object.getPrototypeOf(source));
 
-	return descriptor;
+	return deepMixin(target, source);
 }
 
+/**
+ * Determines whether two values are the same value.
+ * @return true if the values are the same; false otherwise.
+ */
 export function isIdentical(a: any, b: any): boolean {
 	return a === b ||
 		/* both values are NaN */
 		(a !== a && b !== b);
 }
 
+/**
+ * Returns a function that binds a method to the specified object at runtime. This is similar to
+ * `Function.prototype.bind`, but instead of a function it takes the name of a method on an object.
+ * As a result, even should the underlying function change, the function returned by `lateBind` will
+ * always call it in the context of the original object.
+ *
+ * @param instance The context object.
+ * @param method The name of the method that should be bound to `instance`.
+ * @param {...suppliedArgs} An optional list of values to prepend to the `instance[methods]` arguments list.
+ * @return The bound function.
+ */
 export function lateBind(instance: {}, method: string, ...suppliedArgs: any[]): (...args: any[]) => any {
 	return suppliedArgs.length ?
 		function () {
@@ -188,6 +167,19 @@ export function lateBind(instance: {}, method: string, ...suppliedArgs: any[]): 
 			// TS7017
 			return (<any> instance)[method].apply(instance, arguments);
 		};
+}
+
+/**
+ * Copies the values of all enumerable properties of one or more source objects to the target object.
+ * @return The modified target object.
+ */
+export function mixin(target: {}, ...sources: {}[]): {} {
+	return _mixin({
+		deep: false,
+		inherited: true,
+		sources: sources,
+		target: target
+	});
 }
 
 export function observe(kwArgs: ObserveArgs): Observer {
@@ -203,6 +195,13 @@ export interface ObserveArgs {
 	target: {}
 }
 
+/**
+ * Similar to `Function.prototype.bind` but always calls its function within the current context.
+ *
+ * @param targetFunction The function that needs to be bound.
+ * @param {...suppliedArgs} An optional list of values to prepend to the `targetFunction` arguments list.
+ * @return The bound function.
+ */
 export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs: any[]): (...args: any[]) => any {
 	return function () {
 		const args: any[] = arguments.length ? suppliedArgs.concat(slice.call(arguments)) : suppliedArgs;
@@ -211,6 +210,14 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
 	};
 }
 
+/**
+ * Returns an object with a destroy method that, when called, calls the passed-in destructor.
+ * This is intended to provide a unified interface for creating "remove"/"destroy" handlers for
+ * event listeners, timers, etc.
+ *
+ * @param destructor A function that will be called when the handle's `destroy` method is invoked.
+ * @return The handle object.
+ */
 export function createHandle(destructor: () => void): Handle {
 	return {
 		destroy: function () {
@@ -220,6 +227,12 @@ export function createHandle(destructor: () => void): Handle {
 	};
 }
 
+/**
+ * Returns a single handle that can be used to destroy multiple handles simultaneously.
+ *
+ * @param {...handles} A list of handles with `destroy` methods.
+ * @return The handle object.
+ */
 export function createCompositeHandle(...handles: Handle[]): Handle {
 	return createHandle(function () {
 		for (let handle of handles) {

--- a/tests/benchmark/lang.ts
+++ b/tests/benchmark/lang.ts
@@ -1,178 +1,142 @@
 import Benchmark = require('benchmark');
 import lang = require('../../src/lang');
 
-let benchmarks: Benchmark[] = [];
-
 function onComplete() {
 	console.log(this.name + ': ' + this.hz + ' with a margin of error of ' + this.stats.moe);
 }
 
-benchmarks.push(new Benchmark('lang.copy (single source, all options false)',
-	// The `setup` option cannot be used, as the TypeScript compiler does not know
-	// that `setup`'s local variables are made available to the test function.
-	(function () {
-		const options = {
-			sources: [ <any> { a: 1, b: 'Lorem ipsum', c: [], d: 4 } ]
-		};
+const simpleSource = { a: 1, b: 'Lorem ipsum', c: 4 };
+const simpleSourceWithArray = {
+		a: 1,
+		b: 'Dolor sit amet.',
+		c: [ 1, 2, 3 ],
+		d: 5
+	};
+const sourceFromConstructor = (function () {
+		function Answers(kwArgs: { [key: string]: any }) {
+			Object.keys(kwArgs).forEach(function (key: string): void {
+				(<any> this)[key] = kwArgs[key];
+			}, this);
+		}
 
-		return function () {
-			lang.copy(options);
-		};
-	})(), {
+		return new (<any> Answers)({
+			universe: 42
+		});
+	})();
+const sourceWithInherited = Object.create(Object.create(null, {
+		x: {
+			value: ('1234567890').split('')
+		},
+		y: {
+			enumerable: true,
+			value: /\s/
+		}
+	}), {
+		a: {
+			value: 1,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		},
+		b: {
+			value: 'Lorem ipsum',
+			enumerable: true,
+			configurable: true,
+			writable: true
+		},
+		c: {
+			value: [],
+			enumerable: true,
+			configurable: true,
+			writable: true
+		},
+		d: {
+			value: 4,
+			enumerable: true,
+			configurable: true,
+			writable: true
+		}
+	});
+
+let benchmarks: Benchmark[] = [];
+
+benchmarks.push(new Benchmark('lang.assign (single source)', function () {
+		lang.assign(Object.create(null), simpleSource);
+	}, {
 		onComplete: onComplete
 	}));
 
-benchmarks.push(new Benchmark('lang.copy (single source, descriptors true)', (function () {
-	const options = {
-		descriptors: true,
-		sources: [
-			Object.create(Object.prototype, {
-				a: {
-					value: 1,
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				b: {
-					value: 'Lorem ipsum',
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				c: {
-					value: [],
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				d: {
-					value: 4,
-					enumerable: true,
-					configurable: true,
-					writable: true
-				}
-			})
-		]
-	};
+benchmarks.push(new Benchmark('lang.assign (multiple sources)', function () {
+		lang.assign(
+			Object.create(null),
+			simpleSource,
+			simpleSourceWithArray,
+			sourceWithInherited,
+			sourceFromConstructor
+		);
+	}, {
+		onComplete: onComplete
+	}));
 
-	return function () {
-		lang.copy(options);
-	};
-})(), {
-	onComplete: onComplete
-}));
+benchmarks.push(new Benchmark('lang.deepAssign (single source)', function () {
+		lang.deepAssign(Object.create(null), simpleSource);
+	}, {
+		onComplete: onComplete
+	}));
 
-benchmarks.push(new Benchmark('lang.copy (multiple sources, all options true)', (function () {
-	const options = {
-		assignPrototype: true,
-		deep: true,
-		descriptors: true,
-		sources: [
-			Object.create(Object.create(null, {
-				x: {
-					value: ('1234567890').split('')
-				},
-				y: {
-					enumerable: true,
-					value: /\s/
-				}
-			}), {
-				a: {
-					value: 1,
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				b: {
-					value: 'Lorem ipsum',
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				c: {
-					value: [],
-					enumerable: true,
-					configurable: true,
-					writable: true
-				},
-				d: {
-					value: 4,
-					enumerable: true,
-					configurable: true,
-					writable: true
-				}
-			}),
+benchmarks.push(new Benchmark('lang.deepAssign (multiple sources)', function () {
+		lang.deepAssign(
+			Object.create(null),
+			simpleSource,
+			simpleSourceWithArray,
+			sourceWithInherited,
+			sourceFromConstructor
+		);
+	}, {
+		onComplete: onComplete
+	}));
 
-			{
-				b: 'Dolor sit amet.',
-				c: [ 1, 2, 3 ],
-				d: 5
-			},
+benchmarks.push(new Benchmark('lang.mixin (single source)', function () {
+		lang.mixin(Object.create(null), simpleSource);
+	}, {
+		onComplete: onComplete
+	}));
 
-			(function () {
-				function Answers(kwArgs: { [key: string]: any }) {
-					Object.keys(kwArgs).forEach(function (key: string): void {
-						(<any> this)[key] = kwArgs[key];
-					}, this);
-				}
+benchmarks.push(new Benchmark('lang.mixin (multiple sources)', function () {
+		lang.mixin(
+			Object.create(null),
+			simpleSource,
+			simpleSourceWithArray,
+			sourceWithInherited,
+			sourceFromConstructor
+		);
+	}, {
+		onComplete: onComplete
+	}));
 
-				return new (<any> Answers)({
-					universe: 42
-				});
-			})()
-		]
-	};
+benchmarks.push(new Benchmark('lang.deepMixin (single source)', function () {
+		lang.deepMixin(Object.create(null), simpleSource);
+	}, {
+		onComplete: onComplete
+	}));
 
-	return function () {
-		lang.copy(options);
-	};
-})(), {
-	onComplete: onComplete
-}));
+benchmarks.push(new Benchmark('lang.deepMixin (multiple sources)', function () {
+		lang.deepMixin(
+			Object.create(null),
+			simpleSource,
+			simpleSourceWithArray,
+			sourceWithInherited,
+			sourceFromConstructor
+		);
+	}, {
+		onComplete: onComplete
+	}));
 
-benchmarks.push(new Benchmark('lang.create', (function () {
-	let object = <any> { a: 1, b: 'Lorem ipsum', c: [], d: 4 };
-
-	return function () {
-		lang.create(object, object, object, object);
-	};
-})(), {
-	onComplete: onComplete
-}));
-
-benchmarks.push(new Benchmark('lang.duplicate', (function () {
-	let object = <any> { a: 1, b: 'Lorem ipsum', c: [], d: 4 };
-
-	return function () {
-		lang.duplicate(object);
-	};
-})(), {
-	onComplete: onComplete
-}));
-
-benchmarks.push(new Benchmark('lang.getPropertyDescriptor', (function () {
-	let prototype = <any> { a: 1, b: 'Lorem ipsum', c: [], d: 4 };
-	let object = prototype;
-	let i = 10;
-
-	while (i > 0) {
-		object = Object.create(object);
-		--i;
-	}
-
-	Object.defineProperty(prototype, 'e', {
-		value: 5,
-		configurable: false,
-		enumerable: true,
-		writable: false
-	});
-
-	return function () {
-		lang.getPropertyDescriptor(object, 'e');
-	};
-})(), {
-	onComplete: onComplete
-}));
+benchmarks.push(new Benchmark('lang.create', function () {
+		lang.create(simpleSource, simpleSource, simpleSource, simpleSource);
+	}, {
+		onComplete: onComplete
+	}));
 
 benchmarks.push(new Benchmark('lang.isIdentical', (function () {
 	let a = Number('asdfx{}');

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -8,104 +8,110 @@ import { Es5Observer, Es7Observer } from 'src/observers/ObjectObserver';
 registerSuite({
 	name: 'lang functions',
 
-	'.copy() invalid arguments': function () {
-		assert.throw(function () {
-			lang.copy({
-				sources: []
-			});
-		});
-	},
-
-	'.copy() simple': function () {
-		const copyOfObject = lang.copy({
-			sources: [{ a: 1 }]
-		});
-		assert.equal(copyOfObject.a, 1);
-	},
-
-	'.copy() inherited': function () {
-		const prototype = {
-			a: 1
-		};
-		const inheriting = Object.create(prototype);
-		inheriting.b = 2;
-		const copyofInherited = lang.copy({
-			inherited: true,
-			sources: [ inheriting ]
-		});
-		assert.equal(copyofInherited.a, 1);
-		assert.equal(copyofInherited.b, 2);
-	},
-
-	'.copy() deep': function () {
-		const nested = {
-			a: {
-				b: 1
-			}
-		};
-		const copyOfObject: any = lang.copy({
-			deep: true,
-			sources: [ nested ]
-		});
-		assert.equal(copyOfObject.a.b, 1);
-		assert.notEqual(copyOfObject.a, nested.a);
-	},
-
-	'.copy() deep arrays': function () {
-		const nested = {
-			a: {
-				b: [ 1 ]
-			}
-		};
-		const copyOfObject: any = lang.copy({
-			deep: true,
-			sources: [ nested ]
-		});
-
-		assert.equal(copyOfObject.a.b[0], 1);
-		assert.notEqual(copyOfObject.a.b, nested.a.b);
-	},
-
-	'.copy() descriptors': function () {
-		const object: any = {
-			a: 1
-		};
-		Object.defineProperty(object, 'b', {
-				get: function () {
-					return 2;
-				}
-			});
-		Object.defineProperty(object, 'c', {
-				enumerable: true,
+	'.assign()'(): void {
+		const source = Object.create({ a: 1 }, {
+			b: {
+				enumerable: false,
 				configurable: true,
 				writable: true,
-				value: 3
-			});
-		Object.defineProperty(object, 'hidden', {
-				enumerable: false,
-				value: 4
-			});
-		Object.defineProperty(object, 'nested', {
-				value: {
-					a: 5
-				}
-			});
-		const copyOfObject: any = lang.copy({
-			descriptors: true,
-			inherited: true,
-			sources: [ object ]
+				value: 2
+			}
 		});
-		assert.equal(copyOfObject.a, 1);
-		assert.equal(copyOfObject.b, 2);
-		assert.isFunction(Object.getOwnPropertyDescriptor(copyOfObject, 'b').get);
-		assert.equal(copyOfObject.c, 3);
-		assert.equal(copyOfObject.hidden, 4);
-		assert.equal(copyOfObject.nested, object.nested);
-		assert.equal(copyOfObject.nested.a, 5);
-		assert.sameMembers(Object.getOwnPropertyNames(copyOfObject), [ 'a', 'b', 'c', 'hidden', 'nested' ]);
+		source.c = 3;
+		source.nested = { a: 5 };
+
+		const copyOfObject: any = lang.assign(Object.create(null), source);
+		assert.isUndefined(copyOfObject.a);
+		assert.isUndefined(copyOfObject.b);
+		assert.strictEqual(copyOfObject.c, 3);
+		assert.strictEqual(copyOfObject.nested, source.nested);
+		assert.strictEqual(copyOfObject.nested.a, 5);
 	},
 
-	'.create()': function () {
+	'.deepAssign()'(): void {
+		const source = Object.create({ a: 1 }, {
+			b: {
+				enumerable: false,
+				configurable: true,
+				writable: true,
+				value: 2
+			}
+		});
+
+		source.c = {
+			d: 3,
+			e: [ 4, [ 5 ], { f: 6 } ]
+		};
+
+		const copyOfObject: any = lang.deepAssign(Object.create(null), source);
+		assert.isUndefined(copyOfObject.a);
+		assert.isUndefined(copyOfObject.b);
+		assert.strictEqual(copyOfObject.c.d, 3);
+		assert.strictEqual(copyOfObject.c.e.length, 3);
+		assert.notStrictEqual(copyOfObject.c.e[1], source.c.e[1]);
+		assert.notStrictEqual(copyOfObject.c.d[2], source.c.e[2]);
+		assert.notStrictEqual(copyOfObject.c.e, source.c.e);
+	},
+
+	'.mixin()'(): void {
+		const source = Object.create({
+			a: 1
+		});
+		source.c = 3;
+		source.nested = { a: 5 };
+		Object.defineProperty(source, 'b', {
+			enumerable: true,
+			get: function () {
+				return 2;
+			}
+		});
+		Object.defineProperty(source, 'hidden', {
+			enumerable: false,
+			value: 4
+		});
+		const copyOfObject: any = lang.mixin(Object.create(null), source);
+
+		assert.strictEqual(copyOfObject.a, 1);
+		assert.strictEqual(copyOfObject.b, 2);
+		assert.strictEqual(copyOfObject.c, 3);
+		assert.isUndefined(copyOfObject.hidden);
+		assert.strictEqual(copyOfObject.nested, source.nested);
+		assert.strictEqual(copyOfObject.nested.a, 5);
+	},
+
+	'.deepMixin()'(): void {
+		const source = Object.create({
+			nested: {
+				a: 1,
+				b: [ 2, [ 3 ], { f: 4 } ]
+			}
+		});
+		source.a = 1;
+		source.c = 3;
+		Object.defineProperty(source, 'b', {
+			enumerable: true,
+			get: function () {
+				return 2;
+			}
+		});
+		Object.defineProperty(source, 'hidden', {
+			enumerable: false,
+			value: 4
+		});
+		const copyOfObject: any = lang.deepMixin(Object.create(null), source);
+
+		assert.strictEqual(copyOfObject.a, 1);
+		assert.strictEqual(copyOfObject.b, 2);
+		assert.strictEqual(copyOfObject.c, 3);
+		assert.isUndefined(copyOfObject.hidden);
+		assert.strictEqual(copyOfObject.nested.a, 1);
+		assert.notStrictEqual(copyOfObject.nested, source.nested);
+		assert.notStrictEqual(copyOfObject.nested.b, source.nested.b);
+		assert.notStrictEqual(copyOfObject.nested.b[1], source.nested.b[1]);
+		assert.notStrictEqual(copyOfObject.nested.b[2], source.nested.b[2]);
+	},
+
+	'.create()'(): void {
 		const prototype = {
 			a: 1
 		};
@@ -128,8 +134,8 @@ registerSuite({
 		});
 		const object: any = lang.create(prototype, mixin);
 
-		assert.equal(Object.getPrototypeOf(object), prototype);
-		assert.equal(object.b, mixin.b);
+		assert.strictEqual(Object.getPrototypeOf(object), prototype);
+		assert.strictEqual(object.b, mixin.b);
 		assert.isTrue(Object.getOwnPropertyDescriptor(object, 'd').writable);
 		assert.isUndefined(object.e);
 		assert.isUndefined(object.lorem);
@@ -142,27 +148,17 @@ registerSuite({
 		const prototype = {
 			a: 1
 		};
-		const object: any = Object.create(prototype, {
-			b: { value: 2 },
-			c: {
-				configurable: false,
-				value: 3
-			},
-			d: {
-				value: {
-					e: 4
-				}
-			}
+		const source: any = Object.create(prototype, {
+			b: { value: 2 }
 		});
-		const copyOfObject: any = lang.duplicate(object);
+		source.c = { d: 4 };
+		const copyOfObject: any = lang.duplicate(source);
 
-		assert.equal(Object.getPrototypeOf(copyOfObject), prototype);
-		assert.equal(copyOfObject.a, 1);
-		assert.equal(copyOfObject.b, 2);
-		assert.equal(copyOfObject.c, 3);
-		assert.equal(copyOfObject.d.e, 4);
-		assert.notEqual(copyOfObject.d, object.d);
-		assert.isFalse(Object.getOwnPropertyDescriptor(copyOfObject, 'c').configurable);
+		assert.strictEqual(Object.getPrototypeOf(copyOfObject), prototype);
+		assert.strictEqual(copyOfObject.a, 1);
+		assert.isUndefined(copyOfObject.b);
+		assert.strictEqual(copyOfObject.c.d, 4);
+		assert.notStrictEqual(copyOfObject.c, source.c);
 	},
 
 	'.observe() when nextTurn is true': function () {
@@ -203,46 +199,6 @@ registerSuite({
 			onlyReportObserved: true
 		});
 		assert.isTrue(observer.onlyReportObserved, 'onlyReportObserved should be passed to the observer instance.');
-	},
-
-	'.getPropertyDescriptor()': function () {
-		const object1 = {
-			get foo() { return 'bar'; }
-		};
-		const object2 = Object.create(object1);
-		const object3 = Object.create(object1, {
-			foo: {
-				get: function () {
-					return 'baz';
-				}
-			}
-		});
-
-		assert.deepEqual(lang.getPropertyDescriptor(object1, 'foo'), Object.getOwnPropertyDescriptor(object1, 'foo'));
-		assert.deepEqual(lang.getPropertyDescriptor(object2, 'foo'), Object.getOwnPropertyDescriptor(object1, 'foo'));
-		assert.deepEqual(lang.getPropertyDescriptor(object3, 'foo'), Object.getOwnPropertyDescriptor(object3, 'foo'));
-	},
-
-	'.getPropertyNames()': function () {
-		const prototype = {
-			a: 1,
-			b: 7
-		};
-		const object: any = Object.create(prototype, {
-			b: { value: 2 },
-			c: {
-				configurable: false,
-				value: 3
-			},
-			d: {
-				value: {
-					e: 4
-				}
-			}
-		});
-		const names: string[] = lang.getPropertyNames(object);
-
-		assert.sameMembers(names, [ 'a', 'b', 'c', 'd' ]);
 	},
 
 	'.isIdentical()': function () {


### PR DESCRIPTION
- Remove inheritance checking from lang.copy.
- Break lang.copy into lang.assign, lang.assignDeep, lang.copy, and lang.copyDeep.
