### PR TITLE
Export some additional stream types

### DIFF
--- a/src/streams/ArraySource.ts
+++ b/src/streams/ArraySource.ts
@@ -1,6 +1,6 @@
-import Promise from 'src/Promise';
-import { Source } from 'src/streams/ReadableStream';
-import ReadableStreamController from 'src/streams/ReadableStreamController';
+import Promise from '../Promise';
+import { Source } from './ReadableStream';
+import ReadableStreamController from './ReadableStreamController';
 
 const resolved = Promise.resolve();
 

--- a/src/streams/WritableStream.ts
+++ b/src/streams/WritableStream.ts
@@ -5,7 +5,7 @@ import * as util from './util';
 
 // A Record is used internally by the stream to process queued writes. It represents the chunk to be written plus
 // additional metadata used internally.
-interface Record<T> {
+export interface Record<T> {
 	// This flag indicates that this record is the end of the stream and the stream should close when processing it
 	close?: boolean;
 	chunk?: T;

--- a/src/streams/adapters/EventedStreamSource.ts
+++ b/src/streams/adapters/EventedStreamSource.ts
@@ -5,8 +5,8 @@ import Promise from '../../Promise';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 
-type EventTargetTypes = Evented | EventEmitter | EventTarget;
-type EventTypes = string | string[];
+export type EventTargetTypes = Evented | EventEmitter | EventTarget;
+export type EventTypes = string | string[];
 
 export default class EventedStreamSource implements Source<Event> {
 	protected _controller: ReadableStreamController<Event>;


### PR DESCRIPTION
dts-generator was failing to generate some stream typings due to a couple of unexported types.
