### PR TITLE
Use native `Object.assign` when available. Fixes #54.

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -64,6 +64,7 @@ add('dom-mutationobserver', function(): boolean {
 add('microtasks', function () {
 	return has('promise') || has('host-node') || has('dom-mutationobserver');
 });
+add('object-assign', typeof (<any> Object).assign === 'function');
 add('object-observe', typeof (<any> Object).observe === 'function');
 add('postmessage', typeof postMessage === 'function');
 add('promise', typeof global.Promise !== 'undefined');

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -34,6 +34,10 @@ interface MixinArgs {
 	target: {};
 }
 
+interface ObjectAssignConstructor extends ObjectConstructor {
+	assign(target: {}, ...sources: {}[]): {}
+}
+
 function _mixin(kwArgs: MixinArgs): {} {
 	const deep = kwArgs.deep;
 	const inherited = kwArgs.inherited;
@@ -73,10 +77,10 @@ function _mixin(kwArgs: MixinArgs): {} {
  * @param sources Any number of objects whose enumerable own properties will be copied to the target object
  * @return The modified target object
  */
-export let assign = has('object-assign') ?
-	(<any> Object).assign :
-	function assign(target: {}, ...sources: {}[]): {} {
-		return (typeof (<any> Object).assign === 'function') ? (<any> Object).assign.apply(null, arguments) : _mixin({
+export const assign = has('object-assign') ?
+	(<ObjectAssignConstructor> Object).assign :
+	function (target: {}, ...sources: {}[]): {} {
+		return _mixin({
 			deep: false,
 			inherited: false,
 			sources: sources,

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -73,14 +73,16 @@ function _mixin(kwArgs: MixinArgs): {} {
  * @param sources Any number of objects whose enumerable own properties will be copied to the target object
  * @return The modified target object
  */
-export function assign(target: {}, ...sources: {}[]): {} {
-	return _mixin({
-		deep: false,
-		inherited: false,
-		sources: sources,
-		target: target
-	});
-}
+export let assign = has('object-assign') ?
+	(<any> Object).assign :
+	function assign(target: {}, ...sources: {}[]): {} {
+		return (typeof (<any> Object).assign === 'function') ? (<any> Object).assign.apply(null, arguments) : _mixin({
+			deep: false,
+			inherited: false,
+			sources: sources,
+			target: target
+		});
+	}
 
 /**
  * Creates a new object from the given prototype, and copies all enumerable own properties of one or more


### PR DESCRIPTION
- `lang.assign` delegates to `Object.assign` when avaialble.
- Implement `has('object-assign')` test.
