### PR TITLE
load: use Require interface from dojo-loader for AMDRequire

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -1,3 +1,4 @@
+import { Require as AMDRequire } from 'dojo-loader/loader';
 import Promise from './Promise';
 
 declare var define: {
@@ -5,9 +6,8 @@ declare var define: {
 	amd: any;
 };
 
-export interface AMDRequire {
-	(moduleIds: string[], callback: (...modules: any[]) => void): void;
-}
+export { Require as AMDRequire } from 'dojo-loader/loader';
+
 export interface NodeRequire {
 	(moduleId: string): any;
 }

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../node_modules/dojo-loader/typings/dojo-loader/dojo-loader-2.0.0-alpha.1.d.ts" />
 /// <reference path="node/node.d.ts" />


### PR DESCRIPTION
The load module was providing an incomplete definition of the `Require` (`AMDRequire`) interface, and duplicating code from `dojo-loader`.

This commit updates `load.ts` to instead use the `Require` interface defined in `dojo-loader/loader`.
