### PR TITLE
updated lang.isObject to work in ES6 Fixes #62

### DIFF
--- a/src/lang.ts
+++ b/src/lang.ts
@@ -7,7 +7,7 @@ const slice = Array.prototype.slice;
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 function isObject(item: any): boolean {
-	return Object.prototype.toString.call(item) === '[object Object]';
+	return item === Object(item);
 }
 
 function copyArray(array: any[], inherited: boolean): any[] {


### PR DESCRIPTION
Updated and ran tests against Chrome 44. Tests pass. Coverage reports it was run 25 time, although it's not directly called in tests. Related to #45 Fixes #62 
