### PR TITLE
Capture equals signs in URL query parameters

### DIFF
--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -12,7 +12,14 @@ export type ParamList = Hash<string | string[]>;
 function parseQueryString(input: string): ParamList {
 	const query: Hash<string[]> = {};
 	for (const entry of input.split('&')) {
-		let [ key, value ] = entry.split('=');
+		const indexOfFirstEquals = entry.indexOf('=');
+		let key: string, value: string;
+		if (indexOfFirstEquals >= 0) {
+			key = entry.slice(0, indexOfFirstEquals);
+			value = entry.slice(indexOfFirstEquals + 1);
+		} else {
+			key = entry;
+		}
 		key = key ? decodeURIComponent(key) : '';
 		value = value ? decodeURIComponent(value) : '';
 

--- a/tests/unit/UrlSearchParams.ts
+++ b/tests/unit/UrlSearchParams.ts
@@ -30,9 +30,9 @@ registerSuite({
 				let params = new UrlSearchParams('foo=bar&foo=baz&bar=foo&baz');
 				checkParams(params);
 
-				// Assignments after the first will be ignored
+				// Assignments after the first will be included in the value
 				params = new UrlSearchParams('foo=bar=baz');
-				assert.deepEqual(params.getAll('foo'), [ 'bar' ]);
+				assert.deepEqual(params.getAll('foo'), [ 'bar=baz' ]);
 
 				// Handle empty keys
 				params = new UrlSearchParams('=foo&');


### PR DESCRIPTION
Everything after the first equal sign in a query parameter
should be included in the value.
