### PR TITLE
Add a delay to the timeout request and fix the range of success statuses

### DIFF
--- a/src/request/xhr.ts
+++ b/src/request/xhr.ts
@@ -69,7 +69,7 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 
 				response.statusCode = request.status;
 				response.statusText = request.statusText;
-				if (response.statusCode >= 200 && response.statusCode < 400) {
+				if (response.statusCode > 0 && response.statusCode < 400) {
 					resolve(response);
 				}
 				else {

--- a/tests/services/echo.ts
+++ b/tests/services/echo.ts
@@ -1,4 +1,5 @@
 import Promise from '../../src/Promise';
+import { Hash } from '../../src/interfaces'
 
 import http = require('intern/dojo/node!http');
 import querystring = require('intern/dojo/node!querystring');
@@ -98,7 +99,7 @@ export function start(port?: number): Promise<http.Server> {
 	const echoRequest = wrapWithMultipartHandler(function (request: any, response: any) {
 		try {
 			const queryString = request.url.split('?')[1];
-			let query: { [ name: string ]: string | string[] };
+			let query: Hash<string | string[]>;
 			let responseType = '';
 
 			if (queryString) {
@@ -144,12 +145,8 @@ export function start(port?: number): Promise<http.Server> {
 							payload: data
 						});
 						if (query && query['delay']) {
-							try {
-								let delay = Number(query['delay']);
-								setTimeout(writeSuccessResponse, delay, response, body)
-							} catch (ignore) {
-								writeSuccessResponse(response, body);
-							}
+							let delay = Number(query['delay']);
+							setTimeout(writeSuccessResponse, delay, response, body)
 						} else {
 							writeSuccessResponse(response, body);
 						}

--- a/tests/services/echo.ts
+++ b/tests/services/echo.ts
@@ -45,6 +45,16 @@ function writeErrorResponse(response: any, error?: string) {
 	response.end();
 }
 
+function writeSuccessResponse(response: any, body: string) {
+	response.writeHead(200, {
+		'Content-Length': body.length,
+		'Content-Type': 'application/json'
+	});
+
+	response.write(body);
+	response.end();
+}
+
 function retrieveResource(response: any, responseType: string): void {
 	let resourceName: string;
 	let encoding: string;
@@ -133,14 +143,16 @@ export function start(port?: number): Promise<http.Server> {
 							headers: request.headers,
 							payload: data
 						});
-
-						response.writeHead(200, {
-							'Content-Length': body.length,
-							'Content-Type': 'application/json'
-						});
-
-						response.write(body);
-						response.end();
+						if (query && query['delay']) {
+							try {
+								let delay = Number(query['delay']);
+								setTimeout(writeSuccessResponse, delay, response, body)
+							} catch (ignore) {
+								writeSuccessResponse(response, body);
+							}
+						} else {
+							writeSuccessResponse(response, body);
+						}
 					}
 					else {
 						retrieveResource(response, responseType);

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -103,7 +103,7 @@ registerSuite({
 			if (!echoServerAvailable) {
 				this.skip('No echo server available');
 			}
-			return xhrRequest('/__echo/xhr', { timeout: 1 })
+			return xhrRequest('/__echo/xhr?delay=5000', { timeout: 10 })
 				.then(
 					function () {
 						assert(false, 'Should have timed out');


### PR DESCRIPTION
This includes adding an optional delay in the echo server before resolving requests, which I had hoped would fix the timeout error. It does not, unfortunately. I can remove this if it's not useful or not needed.
