### PR TITLE
Fix request/xhr timeout logic

### DIFF
--- a/src/request/xhr.ts
+++ b/src/request/xhr.ts
@@ -2,6 +2,8 @@ import Task from '../async/Task';
 import RequestTimeoutError from './errors/RequestTimeoutError';
 import global from '../global';
 import has from '../has';
+import { Handle } from '../interfaces';
+import { createTimer } from '../util';
 import { RequestOptions, Response, ResponsePromise } from '../request';
 import { generateRequestUrl } from './util';
 
@@ -56,9 +58,11 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 			request.responseType = responseTypeMap[options.responseType];
 		}
 
+		let timeoutHandle: Handle;
 		request.onreadystatechange = function (): void {
 			if (request.readyState === 4) {
 				request.onreadystatechange = function () {};
+				timeoutHandle && timeoutHandle.destroy();
 
 				if (options.responseType === 'xml') {
 					response.data = request.responseXML;
@@ -83,9 +87,13 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 
 		if (options.timeout > 0 && options.timeout !== Infinity) {
 			request.timeout = options.timeout;
-			request.ontimeout = function () {
+			timeoutHandle = createTimer(function () {
+				// Reject first, since aborting will also fire onreadystatechange which would reject with a
+				// less specific error.  (This is also why we set up our own timeout rather than using
+				// native timeout and ontimeout, because that aborts and fires onreadystatechange before ontimeout.)
 				reject(new RequestTimeoutError('The XMLHttpRequest request timed out.'));
-			};
+				request.abort();
+			}, options.timeout);
 		}
 
 		const headers = options.headers;

--- a/src/request/xhr.ts
+++ b/src/request/xhr.ts
@@ -69,7 +69,7 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 
 				response.statusCode = request.status;
 				response.statusText = request.statusText;
-				if (response.statusCode >= 200 && response.statusCode < 400) {
+				if (response.statusCode > 0 && response.statusCode < 400) {
 					resolve(response);
 				}
 				else {

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -103,7 +103,7 @@ registerSuite({
 			if (!echoServerAvailable) {
 				this.skip('No echo server available');
 			}
-			return xhrRequest('/__echo/xhr', { timeout: 1 })
+			return xhrRequest('/__echo/xhr?delay=5000', { timeout: 10 })
 				.then(
 					function () {
 						assert(false, 'Should have timed out');


### PR DESCRIPTION
This PR is based on top of a rebased/squashed version of #66, and additionally fixes #64.

As mentioned in #64, I first tried resolving this using a timestamp comparison, but that didn't turn out too well in IE.  This works across browsers.

The only possible reservation I might have is that historically, large numbers of setTimeouts were bad news for old IE, which is why Dojo 1 had a polling interval and kept track of all in-flight XHRs instead.  This PR opts for simply setting one timeout per XHR (which is also what our code in the node provider is doing), since the code for it is a lot simpler and more straightforward.  If this proves to still be a bad thing for any modern browsers we're actually interested in supporting, we can revisit this.
