### PR TITLE
Set proper content type for xml returned from echo server

### DIFF
--- a/tests/services/echo.ts
+++ b/tests/services/echo.ts
@@ -81,7 +81,10 @@ function retrieveResource(response: any, responseType: string): void {
 			method: 'GET'
 		},
 		function (newResponse: any) {
-			response.writeHead(newResponse.statusCode, newResponse.headers);
+			response.writeHead(
+				newResponse.statusCode,
+				responseType === 'xml' ? {'content-type': 'text/xml'} : newResponse.headers
+			);
 			if (encoding) {
 				newResponse.setEncoding(encoding);
 			}


### PR DESCRIPTION
The content type on the data being returned from the echo server was `application/octet-stream`, as we were just passing the headers from the server-side call to retrieve the xml document through to the client. IE 10 couldn't figure out that it should be treating the response as xml. Setting the content-type header in the case that the requested type is xml resolved the issue.
