### PR TITLE
Change isThenable to a type guard

### DIFF
--- a/src/Promise.ts
+++ b/src/Promise.ts
@@ -28,8 +28,10 @@ export interface Executor<T> {
 
 /**
  * Returns true if a given value has a `then` method.
+ * @param {any} value The value to check if is Thenable
+ * @returns {is Thenable<T>} A type guard if the value is thenable
  */
-export function isThenable(value: any) {
+export function isThenable<T>(value: any): value is Thenable<T> {
 	return value && typeof value.then === 'function';
 }
 


### PR DESCRIPTION
This modifies `dojo-core/Promise::isThenable` to be a custom type guard when used under TypeScript.  Passing in a variable that can be narrowed to the Thenable interface, will then be within the scope of the block where the type guard is used.  For example:

``` typescript
import { Thenable, isThenable } from 'dojo-core/Promise';

let t: string|Thenable<string>;

if (isThenable(t)) {
  t.then; // it will behave as Thenable in this block
}
else {
  t.length; // it will behave as a string in this block
}
```
