### PR TITLE
added filter to convert Buffer to JSON in node

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -209,7 +209,7 @@ filterRegistry.register(
  */
 filterRegistry.register(
 	function (response: Response<any>, url: string, options: RequestOptions) {
-		return response.data.readDoubleLE !== undefined && options.responseType === 'json';
+		return Buffer.isBuffer(response.data) !== undefined && options.responseType === 'json';
 	},
 	function (response: Response<any>, url: string, options: RequestOptions): Object {
 		return {

--- a/src/request.ts
+++ b/src/request.ts
@@ -208,8 +208,8 @@ filterRegistry.register(
  * Add a filter that automatically parses incoming Buffer responses in Node.
  */
 filterRegistry.register(
-	function (response: Response<any>, url: string, options: RequestOptions) {
-		return Buffer.isBuffer(response.data) !== undefined && options.responseType === 'json';
+	function (response: Response<any>, url: string, options?: RequestOptions) {
+		return options && options.responseType === 'json' && Buffer && typeof Buffer.isBuffer(response.data) !== 'undefined';
 	},
 	function (response: Response<any>, url: string, options: RequestOptions): Object {
 		return {

--- a/src/request.ts
+++ b/src/request.ts
@@ -203,3 +203,17 @@ filterRegistry.register(
 		};
 	}
 );
+
+/**
+ * Add a filter that automatically parses incoming Buffer responses in Node.
+ */
+filterRegistry.register(
+	function (response: Response<any>, url: string, options: RequestOptions) {
+		return response.data.readDoubleLE !== undefined && options.responseType === 'json';
+	},
+	function (response: Response<any>, url: string, options: RequestOptions): Object {
+		return {
+			data: JSON.parse(String(response.data))
+		};
+	}
+);

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import Task from './async/Task';
-import has from './has';
+import has from './request/has';
 import { Handle } from './interfaces';
 import Promise from './Promise';
 import Registry, { Test } from './Registry';
@@ -207,13 +207,15 @@ filterRegistry.register(
 /**
  * Add a filter that automatically parses incoming Buffer responses in Node.
  */
-filterRegistry.register(
-	function (response: Response<any>, url: string, options?: RequestOptions) {
-		return options && options.responseType === 'json' && Buffer && typeof Buffer.isBuffer(response.data) !== 'undefined';
-	},
-	function (response: Response<any>, url: string, options: RequestOptions): Object {
-		return {
-			data: JSON.parse(String(response.data))
-		};
-	}
-);
+if (has('node-buffer')) {
+  filterRegistry.register(
+    function (response: Response<any>, url: string, options?: RequestOptions) {
+      return options && options.responseType === 'json' && typeof Buffer.isBuffer(response.data) !== 'undefined';
+    },
+    function (response: Response<any>, url: string, options: RequestOptions): Object {
+      return {
+        data: JSON.parse(String(response.data))
+      };
+    }
+  );
+}

--- a/src/request/has.ts
+++ b/src/request/has.ts
@@ -1,0 +1,6 @@
+import has, { add } from '../has';
+import global from '../global';
+
+add('node-buffer', () => { 'Buffer' in global && typeof global.Buffer === 'function'; });
+
+export default has;

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -224,6 +224,22 @@ if (has('host-node')) {
 					}),
 					dfd.reject.bind(dfd)
 				);
+		},
+
+		'Buffer filter'() {
+			handle = filterRegistry.register(/foo\.json$/, function (response: Response<any>) {
+				return response;
+			});
+
+			const dfd = this.async();
+      const options: RequestOptions = { responseType: 'json' };
+			request.get(getRequestUrl('foo.json'), options)
+				.then(
+					dfd.callback(function (response: any) {
+						assert.deepEqual(response.data, { foo: 'bar' });
+					}),
+					dfd.reject.bind(dfd)
+				);
 		}
 	};
 }

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -232,7 +232,7 @@ if (has('host-node')) {
 			});
 
 			const dfd = this.async();
-      const options: RequestOptions = { responseType: 'json' };
+			const options: RequestOptions = { responseType: 'json' };
 			request.get(getRequestUrl('foo.json'), options)
 				.then(
 					dfd.callback(function (response: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
 		"./src/queue.ts",
 		"./src/request.ts",
 		"./src/request/errors/RequestTimeoutError.ts",
+		"./src/request/has.ts",
 		"./src/request/node.ts",
 		"./src/request/util.ts",
 		"./src/request/xhr.ts",


### PR DESCRIPTION
I'm developing parts of an API using `dojo-core/request` in Node before moving to browser development. Currently, `request` in node will return all response data as `Buffer`, even if you specify `responseType:"json"`.

I'm assuming users, even in Node, if they specify a json response, would expect json and not a buffer. So I just added another filter to account for this. I'm using `response.data.readDoubleLE` as a Buffer check. I'm not sure what other way to check than on a unique method name.

I have CLA under rrubalcava@odoe.net.
