### PR TITLE
Fix timeout failures on IE

### DIFF
--- a/src/request/xhr.ts
+++ b/src/request/xhr.ts
@@ -86,7 +86,6 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 		};
 
 		if (options.timeout > 0 && options.timeout !== Infinity) {
-			request.timeout = options.timeout;
 			timeoutHandle = createTimer(function () {
 				// Reject first, since aborting will also fire onreadystatechange which would reject with a
 				// less specific error.  (This is also why we set up our own timeout rather than using


### PR DESCRIPTION
Our custom timeout handling code was still setting the
request timeout parameter. This was creating a race
condition between the custom timeout handler function and
the actual XMLHttpRequest's timeout logic which results in
us throwing a generic error, as the failure is not specific
to a timeout. Removing the line that sets that value fixes
the failure.

Fixes #83
