### PR TITLE
Account for slow environments in tests that utilize `setTimeout`.

### DIFF
--- a/tests/typings/chai/chai.d.ts
+++ b/tests/typings/chai/chai.d.ts
@@ -1,9 +1,12 @@
-// Type definitions for chai 2.0.0
+// Type definitions for chai 3.2.0
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao/>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,
-//                 Andrew Brown <https://github.com/AGBrown>
+//                 Andrew Brown <https://github.com/AGBrown>,
+//                 Olivier Chevet <https://github.com/olivr70>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+// <reference path="../assertion-error/assertion-error.d.ts"/>
 
 declare module Chai {
 
@@ -16,9 +19,11 @@ declare module Chai {
         use(fn: (chai: any, utils: any) => void): any;
         assert: AssertStatic;
         config: Config;
+        AssertionError: typeof AssertionError;
     }
 
     export interface ExpectStatic extends AssertionStatic {
+        fail(actual?: any, expected?: any, message?: string, operator?: string): void;
     }
 
     export interface AssertStatic extends Assert {
@@ -49,15 +54,20 @@ declare module Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
         not: Assertion;
         deep: Deep;
+        any: KeyFilter;
+        all: KeyFilter;
         a: TypeComparison;
         an: TypeComparison;
         include: Include;
+        includes: Include;
         contain: Include;
+        contains: Include;
         ok: Assertion;
         true: Assertion;
         false: Assertion;
         null: Assertion;
         undefined: Assertion;
+        NaN: Assertion;
         exist: Assertion;
         empty: Assertion;
         arguments: Assertion;
@@ -70,20 +80,35 @@ declare module Chai {
         property: Property;
         ownProperty: OwnProperty;
         haveOwnProperty: OwnProperty;
+        ownPropertyDescriptor: OwnPropertyDescriptor;
+        haveOwnPropertyDescriptor: OwnPropertyDescriptor;
         length: Length;
         lengthOf: Length;
-        match(regexp: RegExp|string, message?: string): Assertion;
+        match: Match;
+        matches: Match;
         string(string: string, message?: string): Assertion;
         keys: Keys;
         key(string: string): Assertion;
         throw: Throw;
         throws: Throw;
         Throw: Throw;
-        respondTo(method: string, message?: string): Assertion;
+        respondTo: RespondTo;
+        respondsTo: RespondTo;
         itself: Assertion;
-        satisfy(matcher: Function, message?: string): Assertion;
+        satisfy: Satisfy;
+        satisfies: Satisfy;
         closeTo(expected: number, delta: number, message?: string): Assertion;
         members: Members;
+        increase: PropertyChange;
+        increases: PropertyChange;
+        decrease: PropertyChange;
+        decreases: PropertyChange;
+        change: PropertyChange;
+        changes: PropertyChange;
+        extensible: Assertion;
+        sealed: Assertion;
+        frozen: Assertion;
+
     }
 
     interface LanguageChains {
@@ -134,6 +159,11 @@ declare module Chai {
         equal: Equal;
         include: Include;
         property: Property;
+        members: Members;
+    }
+
+    interface KeyFilter {
+        keys: Keys;
     }
 
     interface Equal {
@@ -148,6 +178,11 @@ declare module Chai {
         (name: string, message?: string): Assertion;
     }
 
+    interface OwnPropertyDescriptor {
+        (name: string, descriptor: PropertyDescriptor, message?: string): Assertion;
+        (name: string, message?: string): Assertion;
+    }
+
     interface Length extends LanguageChains, NumericComparison {
         (length: number, message?: string): Assertion;
     }
@@ -158,11 +193,18 @@ declare module Chai {
         (value: number, message?: string): Assertion;
         keys: Keys;
         members: Members;
+        any: KeyFilter;
+        all: KeyFilter;
+    }
+
+    interface Match {
+        (regexp: RegExp|string, message?: string): Assertion;
     }
 
     interface Keys {
         (...keys: string[]): Assertion;
         (keys: any[]): Assertion;
+        (keys: Object): Assertion;
     }
 
     interface Throw {
@@ -175,8 +217,20 @@ declare module Chai {
         (constructor: Function, expected?: RegExp, message?: string): Assertion;
     }
 
+    interface RespondTo {
+        (method: string, message?: string): Assertion;
+    }
+
+    interface Satisfy {
+        (matcher: Function, message?: string): Assertion;
+    }
+
     interface Members {
         (set: any[], message?: string): Assertion;
+    }
+
+    interface PropertyChange {
+        (object: Object, prop: string, msg?: string): Assertion;
     }
 
     export interface Assert {
@@ -189,7 +243,9 @@ declare module Chai {
         fail(actual?: any, expected?: any, msg?: string, operator?: string): void;
 
         ok(val: any, msg?: string): void;
+        isOk(val: any, msg?: string): void;
         notOk(val: any, msg?: string): void;
+        isNotOk(val: any, msg?: string): void;
 
         equal(act: any, exp: any, msg?: string): void;
         notEqual(act: any, exp: any, msg?: string): void;
@@ -208,6 +264,12 @@ declare module Chai {
 
         isUndefined(val: any, msg?: string): void;
         isDefined(val: any, msg?: string): void;
+
+        isNaN(val: any, msg?: string): void;
+        isNotNaN(val: any, msg?: string): void;
+
+        isAbove(val: number, abv: number, msg?: string): void;
+        isBelow(val: number, blw: number, msg?: string): void;
 
         isFunction(val: any, msg?: string): void;
         isNotFunction(val: any, msg?: string): void;
@@ -279,9 +341,27 @@ declare module Chai {
         closeTo(act: number, exp: number, delta: number, msg?: string): void;
 
         sameMembers(set1: any[], set2: any[], msg?: string): void;
-        includeMembers(set1: any[], set2: any[], msg?: string): void;
+        sameDeepMembers(set1: any[], set2: any[], msg?: string): void;
+        includeMembers(superset: any[], subset: any[], msg?: string): void;
 
         ifError(val: any, msg?: string): void;
+
+        isExtensible(obj: {}, msg?: string): void;
+        extensible(obj: {}, msg?: string): void;
+        isNotExtensible(obj: {}, msg?: string): void;
+        notExtensible(obj: {}, msg?: string): void;
+
+        isSealed(obj: {}, msg?: string): void;
+        sealed(obj: {}, msg?: string): void;
+        isNotSealed(obj: {}, msg?: string): void;
+        notSealed(obj: {}, msg?: string): void;
+
+        isFrozen(obj: Object, msg?: string): void;
+        frozen(obj: Object, msg?: string): void;
+        isNotFrozen(obj: Object, msg?: string): void;
+        notFrozen(obj: Object, msg?: string): void;
+
+
     }
 
     export interface Config {
@@ -306,3 +386,4 @@ declare module "chai" {
 interface Object {
     should: Chai.Assertion;
 }
+

--- a/tests/unit/async/timing.ts
+++ b/tests/unit/async/timing.ts
@@ -11,8 +11,8 @@ registerSuite({
 	'delay()': {
 		'resolves a promise after the given timeout': function () {
 			return timing.delay(250)(Date.now()).then(function (start: number) {
-				let diff: number = Date.now() - start;
-				assert.closeTo(diff, 250, 25);
+				const diff: number = Date.now() - start;
+				assert.isAbove(diff, 250);
 			});
 		}
 	},
@@ -32,20 +32,20 @@ registerSuite({
 
 	'DelayedRejection': {
 		'is eventually rejected': function () {
-			let start = Date.now();
+			const start = Date.now();
 			return new timing.DelayedRejection(100).then<any>(throwImmediatly, function (reason) {
 				assert.isUndefined(reason);
-				assert.closeTo(Date.now(), start + 100, 50);
+				assert.isAbove(Date.now(), start + 100);
 				return true;
 			});
 		},
 
 		'is eventually rejected with error': function () {
-			let start = Date.now();
-			let expectedError = new Error('boom!');
+			const start = Date.now();
+			const expectedError = new Error('boom!');
 			return new timing.DelayedRejection(100, expectedError).then<any>(throwImmediatly, function (reason) {
 				assert.strictEqual(reason, expectedError);
-				assert.closeTo(Date.now(), start + 100, 50);
+				assert.isAbove(Date.now(), start + 100);
 				return true;
 			});
 		},


### PR DESCRIPTION
Resolves #85. Replaces usage of `assert.closeTo` with `assert.isAbove` in tests that use `setTimeout` to measure delays. Initial attempts involved finding a more accurate delta, but as there is no way to pin down an accurate delta across all enviroments, using `isAbove` seems to be the "less accurate, but more correct" test method.

Finally, since Intern uses Chai v3, the corresponding d.ts file in this package has been updated with these typings from the older 2.0.0 typings.
