### PR TITLE
Add handleAs to JSON filter on request.

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -199,7 +199,7 @@ filterRegistry.register(
 	},
 	function (response: Response<any>, url: string, options: RequestOptions): Object {
 		return {
-			data: JSON.parse(response.data)
+			data: JSON.parse(String(response.data))
 		};
 	}
 );

--- a/src/request.ts
+++ b/src/request.ts
@@ -195,7 +195,7 @@ export default request;
  */
 filterRegistry.register(
 	function (response: Response<any>, url: string, options: RequestOptions) {
-		return typeof response.data === 'string' && options.responseType === 'json';
+		return typeof response.data && options && (options.responseType === 'json' || options.handleAs === 'json');
 	},
 	function (response: Response<any>, url: string, options: RequestOptions): Object {
 		return {
@@ -203,19 +203,3 @@ filterRegistry.register(
 		};
 	}
 );
-
-/**
- * Add a filter that automatically parses incoming Buffer responses in Node.
- */
-if (has('node-buffer')) {
-  filterRegistry.register(
-    function (response: Response<any>, url: string, options?: RequestOptions) {
-      return options && options.responseType === 'json' && typeof Buffer.isBuffer(response.data) !== 'undefined';
-    },
-    function (response: Response<any>, url: string, options: RequestOptions): Object {
-      return {
-        data: JSON.parse(String(response.data))
-      };
-    }
-  );
-}

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -145,8 +145,8 @@ if (has('host-node')) {
 		setup() {
 			const dfd = new DojoPromise.Deferred();
 			const responseData: { [name: string]: any } = {
-				'foo.json': JSON.stringify({ foo: 'bar' }),
-				invalidJson: '<not>JSON</not>'
+				'foo.json': new Buffer(JSON.stringify({ foo: 'bar' }), 'utf8'),
+				invalidJson: new Buffer('<not>JSON</not>', 'utf8')
 			};
 
 			function getResponseData(request: any) {

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -210,36 +210,20 @@ if (has('host-node')) {
 			}
 		},
 
-		'JSON filter'() {
-			handle = filterRegistry.register(/foo\.json$/, function (response: Response<any>) {
-				response.data = JSON.parse(String(response.data));
-				return response;
-			});
-
-			const dfd = this.async();
-			request.get(getRequestUrl('foo.json'))
-				.then(
-					dfd.callback(function (response: any) {
-						assert.deepEqual(response.data, { foo: 'bar' });
-					}),
-					dfd.reject.bind(dfd)
-				);
+		'JSON responseType filter'() {
+			return request.get(getRequestUrl('foo.json'), { responseType: 'json' })
+				.then(function(response: any) {
+					assert.deepEqual(response.data, { foo: 'bar' });
+				})
+			;
 		},
 
-		'Buffer filter'() {
-			handle = filterRegistry.register(/foo\.json$/, function (response: Response<any>) {
-				return response;
-			});
-
-			const dfd = this.async();
-			const options: RequestOptions = { responseType: 'json' };
-			request.get(getRequestUrl('foo.json'), options)
-				.then(
-					dfd.callback(function (response: any) {
-						assert.deepEqual(response.data, { foo: 'bar' });
-					}),
-					dfd.reject.bind(dfd)
-				);
+		'JSON handleAs filter'() {
+			return request.get(getRequestUrl('foo.json'), { handleAs: 'json' })
+				.then(function(response: any) {
+					assert.deepEqual(response.data, { foo: 'bar' });
+				})
+			;
 		}
 	};
 }
@@ -258,13 +242,16 @@ if (has('host-browser')) {
 			;
 		},
 
-		'JSON filter'() {
-			filterRegistry.register(/foo.json$/, function (response: Response<any>) {
-				response.data = JSON.parse(String(response.data));
-				return response;
-			});
+		'JSON responseType filter'() {
+			return request.get(getRequestUrl('foo.json'), { responseType: 'json' })
+				.then(function (response: any) {
+					assert.deepEqual(response.data, { foo: 'bar' });
+				})
+			;
+		},
 
-			return request.get(getRequestUrl('foo.json'))
+		'JSON handleAs filter'() {
+			return request.get(getRequestUrl('foo.json'), { handleAs: 'json' })
 				.then(function (response: any) {
 					assert.deepEqual(response.data, { foo: 'bar' });
 				})


### PR DESCRIPTION
This refactors the filter logic to accept `options.responseType` or `options.handleAs` as values for the filter (and rewrites the test to actually test the filter logic, which they were illogically not testing actually).

Also, simply coerced `response.data` to `String()` in filter to deal with node buffers.  This eliminates the need for a separate filter for NodeJS as previously.
