### PR TITLE
editorconfig: remove EOL setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
EOL is already handled in .gitattributes; this setting is not only
redundant, but causes conflicts on Windows
