### PR TITLE
emit clarifications for `Evented` and `on`

### DIFF
--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -10,7 +10,7 @@ export default class Evented {
 		const type = '__on' + data.type;
 		const method: Function = (<any> this)[type];
 		if (method) {
-			return method.call(this, data);
+			method.call(this, data);
 		}
 	}
 

--- a/src/on.ts
+++ b/src/on.ts
@@ -20,7 +20,8 @@ interface DOMEventObject extends EventObject {
  * Provides a normalized mechanism for dispatching events for event emitters, Evented objects, or DOM nodes.
  * @param target The target to emit the event from
  * @param event The event object to emit
- * @return Boolean indicating Whether the event was canceled (this will always be false for event emitters)
+ * @return Boolean indicating if preventDefault was called on the event object (only relevant for DOM events;
+ *     always false for other event emitters)
  */
 export function emit<T extends EventObject>(target: Evented | EventTarget | EventEmitter, event: T | EventObject): boolean;
 export function emit<T extends EventObject>(target: any, event: T | EventObject): boolean {
@@ -48,10 +49,12 @@ export function emit<T extends EventObject>(target: any, event: T | EventObject)
 
 	if (target.emit) {
 		if (target.removeListener) {
+			// Node.js EventEmitter
 			target.emit(event.type, event);
 			return false;
 		}
 		else if (target.on) {
+			// Dojo Evented or similar
 			target.emit(event);
 			return false;
 		}


### PR DESCRIPTION
`Evented#emit`: do not return any value (as it has no reliable significance)
`on.emit`: clarify return value documentation

`on.emit` supports a Boolean return value since it can be called on DOM elements, and the `dispatchEvent` method [supports a Boolean return value](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent) to indicate if `preventDefault` was called on the event object by any of the handlers.

While DOM events use a [standard event object](https://developer.mozilla.org/en-US/docs/Web/API/Event) with a `preventDefault` method, `Evented#emit` accepts an arbitrary event object, or none. DOM events are typically associated with a DOM element that may have default handlers, hence the necessity of the `preventDefault` API. Dojo `Evented` objects have no default handlers, nor do Node.js `EventEmitters`.

Because of this the inconsistency between the return types of `Evented#emit` (`void`) and `on.emit` (`Boolean`) makes sense.

closes #105 
