### PR TITLE
removed uses of import = require from tests

### DIFF
--- a/tests/unit/DateObject.ts
+++ b/tests/unit/DateObject.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import DateObject, { KwArgs, OperationKwArgs, DateProperties } from 'src/DateObject';
 
 let date: Date;

--- a/tests/unit/Evented.ts
+++ b/tests/unit/Evented.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import Evented from 'src/Evented';
 
 interface CustomEvent {

--- a/tests/unit/Map.ts
+++ b/tests/unit/Map.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import Map from 'src/Map';
 
 let map: Map<any, any>;

--- a/tests/unit/Promise.ts
+++ b/tests/unit/Promise.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import Promise, { Executor, PromiseShim, State, Thenable } from 'src/Promise';
 
 export interface PromiseType {

--- a/tests/unit/Registry.ts
+++ b/tests/unit/Registry.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import Registry from 'src/Registry';
 
 function stringTest(value: string) {

--- a/tests/unit/UrlSearchParams.ts
+++ b/tests/unit/UrlSearchParams.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import UrlSearchParams from 'src/UrlSearchParams';
 
 registerSuite({

--- a/tests/unit/array.ts
+++ b/tests/unit/array.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as array from 'src/array';
 
 function assertFrom(arrayable: any, expected: any[]) {

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -1,6 +1,6 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
-import sinon = require('sinon');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import * as aspect from 'src/aspect';
 import { Handle } from 'src/interfaces';
 

--- a/tests/unit/async/Task.ts
+++ b/tests/unit/async/Task.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import Task, { Canceled } from 'src/async/Task';
 import Promise from 'src/Promise';
 import { addPromiseTests } from '../Promise';

--- a/tests/unit/async/iteration.ts
+++ b/tests/unit/async/iteration.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as iteration from 'src/async/iteration';
 import Promise from 'src/Promise';
 import { isEventuallyRejected, throwImmediatly } from '../../support/util';

--- a/tests/unit/async/timing.ts
+++ b/tests/unit/async/timing.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as timing from 'src/async/timing';
 import { throwImmediatly } from '../../support/util';
 import { isEventuallyRejected } from '../../support/util';

--- a/tests/unit/encoding.ts
+++ b/tests/unit/encoding.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import { ascii, utf8, hex, base64 } from 'src/encoding';
 import global from 'src/global';
 

--- a/tests/unit/global.ts
+++ b/tests/unit/global.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import global from 'src/global';
 
 registerSuite({

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import has, { add as hasAdd, cache as hasCache } from 'src/has';
 
 let alreadyCached: { [key: string]: boolean } = {};

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as lang from 'src/lang';
 
 registerSuite({

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -1,5 +1,5 @@
-import assert = require('intern/chai!assert');
-import registerSuite = require('intern!object');
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
 import has from 'src/has';
 import load from 'src/load';
 import Promise from 'src/Promise';

--- a/tests/unit/math.ts
+++ b/tests/unit/math.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as math from 'src/math';
 
 function assertIsNaN(...results: number[]) {

--- a/tests/unit/number.ts
+++ b/tests/unit/number.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as numberUtil from 'src/number';
 
 function testEdgeCases(op: (value: any) => boolean) {

--- a/tests/unit/object.ts
+++ b/tests/unit/object.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as object from 'src/object';
 
 registerSuite({

--- a/tests/unit/on/all.ts
+++ b/tests/unit/on/all.ts
@@ -1,6 +1,6 @@
 import common from './common';
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import on, { emit } from 'src/on';
 import Evented from 'src/Evented';
 import 'dojo/has!host-node?./nodeOnly:./browserOnly';

--- a/tests/unit/on/browserOnly.ts
+++ b/tests/unit/on/browserOnly.ts
@@ -1,6 +1,6 @@
 import common from './common';
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import on, { emit } from 'src/on';
 import { EventObject } from 'src/interfaces';
 

--- a/tests/unit/on/common.ts
+++ b/tests/unit/on/common.ts
@@ -1,4 +1,4 @@
-import assert = require('intern/chai!assert');
+import * as assert from 'intern/chai!assert';
 import on, { emit, once, pausable } from 'src/on';
 import { Handle } from 'src/interfaces';
 

--- a/tests/unit/on/nodeOnly.ts
+++ b/tests/unit/on/nodeOnly.ts
@@ -1,6 +1,6 @@
 import common from './common';
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import on, { emit } from 'src/on';
 
 function createTarget() {

--- a/tests/unit/queue.ts
+++ b/tests/unit/queue.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import has from 'src/has';
 import { queueTask, queueAnimationTask, queueMicroTask } from 'src/queue';
 

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import DojoPromise = require('intern/dojo/Promise');
 import has = require('intern/dojo/has');
 import Task from 'src/async/Task';

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -1,8 +1,8 @@
 import BaseStringSource from '../streams/helpers/BaseStringSource';
 import * as http from 'http';
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
-import DojoPromise = require('intern/dojo/Promise');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as DojoPromise from 'intern/dojo/Promise';
 import Promise from 'src/Promise';
 import RequestTimeoutError from 'src/request/errors/RequestTimeoutError';
 import { default as nodeRequest } from 'src/request/node';

--- a/tests/unit/string.ts
+++ b/tests/unit/string.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import * as stringUtil from 'src/string';
 
 function createPaddingErrorTests(func: (text: string, length: number, character?: string) => string) {

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -1,5 +1,5 @@
-import registerSuite = require('intern!object');
-import assert = require('intern/chai!assert');
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import sinon = require('sinon');
 import { Handle } from 'src/interfaces';
 import * as util from 'src/util';


### PR DESCRIPTION
Swapped out `import thing = require('location')` for `import * as thing from 'location'` in test files to fix inconsistencies
