### PR TITLE
Fix #95: update intern dependency to point to master branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"grunt-ts": "5.3.2",
 		"grunt-tslint": "3.0.3",
 		"http-proxy": "0.10.3",
-		"intern": "3.0.6",
+		"intern": "theintern/intern",
 		"istanbul": "0.4.2",
 		"remap-istanbul": "0.5.1",
 		"sinon": "1.14.1",


### PR DESCRIPTION
This change sets the Intern dependency to the master branch of that repo. This addresses a network resource conflict that the test suite and Intern are having, causing the timeouts observed in issue #95. However, this ties dojo/core's suite to the head of intern, which means that any instability in Intern could cascade errors from Intern to this repo so another change should be made to update to a stable release of Intern whenever one becomes available.
