### PR TITLE
Update request/node.ts to send options.data value if present and not a stream

### DIFF
--- a/src/request/node.ts
+++ b/src/request/node.ts
@@ -228,7 +228,7 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 					});
 			}
 			else {
-				request.end();
+				request.end(options.data);
 			}
 		}
 		else {

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -128,10 +128,11 @@ registerSuite({
 			'string'(): void {
 				const dfd = this.async();
 				nodeRequest(getRequestUrl('foo.json'), {
-					data: '{ "foo": "bar" }'
+					data: '{ "foo": "bar" }',
+					method: 'POST'
 				}).then(
 					dfd.callback(function (response: any) {
-						assert.deepEqual(JSON.parse(response.data), { foo: 'bar' });
+						assert.deepEqual(requestData, { foo: 'bar' });
 					}),
 					dfd.reject.bind(dfd)
 				);


### PR DESCRIPTION
Update request/node.ts to send options.data value if present and not a string (previous sent empty body)

Updated tests/unit/request/node.ts->request options->string to assert that server received proper data (current test asserts against response)
