### PR TITLE
#126: Fixing CI build and Intern browser_module location

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,37 @@
 {
-	"name": "dojo-core",
-	"version": "2.0.0-pre",
-	"description": "Basic utilites for common TypeScript development",
-	"homepage": "http://dojotoolkit.org",
-	"bugs": {
-		"url": "https://github.com/dojo/core/issues"
-	},
-	"license": "BSD-3-Clause",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/dojo/core.git"
-	},
-	"devDependencies": {
-		"benchmark": "^1.0.0",
-		"codecov.io": "0.1.6",
-		"dojo-loader": "2.0.0-beta.2",
-		"dts-generator": "1.7.0",
-		"formidable": "1.0.14",
-		"glob": "7.0.0",
-		"grunt": "0.4.5",
-		"grunt-contrib-clean": "1.0.0",
-		"grunt-contrib-copy": "1.0.0",
-		"grunt-contrib-watch": "0.6.1",
-		"grunt-text-replace": "0.4.0",
-		"grunt-ts": "5.3.2",
-		"grunt-tslint": "3.0.3",
-		"http-proxy": "0.10.3",
-		"intern": "theintern/intern#75c1472d6d1e3fcf7b1ed7f92deb14ea8b631a44",
-		"istanbul": "0.4.2",
-		"remap-istanbul": "0.5.1",
-		"sinon": "1.14.1",
-		"tslint": "3.5.0",
-		"typescript": "1.8.7"
-	}
+  "name": "dojo-core",
+  "version": "2.0.0-pre",
+  "description": "Basic utilites for common TypeScript development",
+  "homepage": "http://dojotoolkit.org",
+  "bugs": {
+    "url": "https://github.com/dojo/core/issues"
+  },
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dojo/core.git"
+  },
+  "devDependencies": {
+    "benchmark": "^1.0.0",
+    "codecov.io": "0.1.6",
+    "dojo-loader": "2.0.0-beta.2",
+    "dts-generator": "1.7.0",
+    "formidable": "1.0.14",
+    "glob": "7.0.0",
+    "grunt": "0.4.5",
+    "grunt-contrib-clean": "1.0.0",
+    "grunt-contrib-copy": "1.0.0",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-text-replace": "0.4.0",
+    "grunt-ts": "5.3.2",
+    "grunt-tslint": "3.0.3",
+    "http-proxy": "0.10.3",
+    "intern": "theintern/intern#75c1472d6d1e3fcf7b1ed7f92deb14ea8b631a44",
+    "istanbul": "0.4.2",
+    "leadfoot": "^1.6.5",
+    "remap-istanbul": "0.5.1",
+    "sinon": "1.14.1",
+    "tslint": "3.5.0",
+    "typescript": "1.8.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,37 +1,37 @@
 {
-  "name": "dojo-core",
-  "version": "2.0.0-pre",
-  "description": "Basic utilites for common TypeScript development",
-  "homepage": "http://dojotoolkit.org",
-  "bugs": {
-    "url": "https://github.com/dojo/core/issues"
-  },
-  "license": "BSD-3-Clause",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dojo/core.git"
-  },
-  "devDependencies": {
-    "benchmark": "^1.0.0",
-    "codecov.io": "0.1.6",
-    "dojo-loader": "2.0.0-beta.2",
-    "dts-generator": "1.7.0",
-    "formidable": "1.0.14",
-    "glob": "7.0.0",
-    "grunt": "0.4.5",
-    "grunt-contrib-clean": "1.0.0",
-    "grunt-contrib-copy": "1.0.0",
-    "grunt-contrib-watch": "0.6.1",
-    "grunt-text-replace": "0.4.0",
-    "grunt-ts": "5.3.2",
-    "grunt-tslint": "3.0.3",
-    "http-proxy": "0.10.3",
-    "intern": "theintern/intern#75c1472d6d1e3fcf7b1ed7f92deb14ea8b631a44",
-    "istanbul": "0.4.2",
-    "leadfoot": "^1.6.5",
-    "remap-istanbul": "0.5.1",
-    "sinon": "1.14.1",
-    "tslint": "3.5.0",
-    "typescript": "1.8.7"
-  }
+	"name": "dojo-core",
+	"version": "2.0.0-pre",
+	"description": "Basic utilites for common TypeScript development",
+	"homepage": "http://dojotoolkit.org",
+	"bugs": {
+		"url": "https://github.com/dojo/core/issues"
+	},
+	"license": "BSD-3-Clause",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dojo/core.git"
+	},
+	"devDependencies": {
+		"benchmark": "^1.0.0",
+		"codecov.io": "0.1.6",
+		"dojo-loader": "2.0.0-beta.2",
+		"dts-generator": "1.7.0",
+		"formidable": "1.0.14",
+		"glob": "7.0.0",
+		"grunt": "0.4.5",
+		"grunt-contrib-clean": "1.0.0",
+		"grunt-contrib-copy": "1.0.0",
+		"grunt-contrib-watch": "0.6.1",
+		"grunt-text-replace": "0.4.0",
+		"grunt-ts": "5.3.2",
+		"grunt-tslint": "3.0.3",
+		"http-proxy": "0.10.3",
+		"intern": "theintern/intern#75c1472d6d1e3fcf7b1ed7f92deb14ea8b631a44",
+		"istanbul": "0.4.2",
+		"leadfoot": "^1.6.5",
+		"remap-istanbul": "0.5.1",
+		"sinon": "1.14.1",
+		"tslint": "3.5.0",
+		"typescript": "1.8.7"
+	}
 }

--- a/tests/functional/text/textPlugin.ts
+++ b/tests/functional/text/textPlugin.ts
@@ -2,8 +2,7 @@ import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import * as Suite from 'intern/lib/Suite';
 import * as Command from 'leadfoot/Command';
-
-import pollUntil = require('intern/dojo/node!leadfoot/helpers/pollUntil');
+import * as pollUntil from 'leadfoot/helpers/pollUntil';
 
 function executeTest(suite: Suite, htmlTestPath: string, testFn: (result: any) => void, timeout = 5000): Command<any> {
 	return suite.remote

--- a/tests/functional/text/textPlugin.ts
+++ b/tests/functional/text/textPlugin.ts
@@ -3,7 +3,7 @@ import * as registerSuite from 'intern!object';
 import * as Suite from 'intern/lib/Suite';
 import * as Command from 'leadfoot/Command';
 
-import pollUntil = require('leadfoot/helpers/pollUntil');
+import pollUntil = require('intern/dojo/node!leadfoot/helpers/pollUntil');
 
 function executeTest(suite: Suite, htmlTestPath: string, testFn: (result: any) => void, timeout = 5000): Command<any> {
 	return suite.remote

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -75,7 +75,7 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
+		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	]
 };

--- a/tests/module.d.ts
+++ b/tests/module.d.ts
@@ -1,0 +1,4 @@
+declare module 'intern/dojo/node!leadfoot/helpers/pollUntil' {
+	import pollUntil = require('leadfoot/helpers/pollUntil');
+	export = pollUntil;
+}

--- a/tests/module.d.ts
+++ b/tests/module.d.ts
@@ -1,4 +1,0 @@
-declare module 'intern/dojo/node!leadfoot/helpers/pollUntil' {
-	import pollUntil = require('leadfoot/helpers/pollUntil');
-	export = pollUntil;
-}

--- a/tests/typings/leadfoot/leadfoot.d.ts
+++ b/tests/typings/leadfoot/leadfoot.d.ts
@@ -414,7 +414,7 @@ declare module 'leadfoot/helpers/pollUntil' {
 	 */
 	function pollUntil<T>(poller: Function | string, args?: any[], timeout?: number, pollInterval?: number): (value: any) => Promise<T>;
 	function pollUntil<T>(poller: Function | string, timeout?: number, pollInterval?: number): (value: any) => Promise<T>;
-
+	namespace pollUntil { }
 	export = pollUntil;
 }
 

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -2,8 +2,8 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import has from 'src/has';
 import * as text from 'src/text';
-import { spy, stub } from 'sinon';
-import * as fs from 'fs';
+import { stub } from 'sinon';
+import 'intern/dojo/has!host-node?./text_node:./text_browser';
 
 // The exported get function from the text module
 // uses fs.readFile on node systems, which resolves
@@ -19,9 +19,7 @@ const basePath = (function() {
 		return '_build/tests/support/data/';
 	}
 })();
-
 const absPathMock = (val: string) => val;
-let fsSpy: Sinon.SinonSpy;
 
 registerSuite({
 		name: 'text',
@@ -52,28 +50,7 @@ registerSuite({
 				assert.include(normalized, '!strip', 'Strip flag should be present');
 			}
 		},
-
 		'load': {
-			beforeEach() {
-				fsSpy = spy(fs, 'readFile');
-			},
-
-			afterEach() {
-				fsSpy.restore && fsSpy.restore();
-			},
-
-			'should return text and call require'() {
-				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
-					assert.isTrue(fsSpy.calledOnce, 'Read file should be called once');
-					assert.strictEqual(val, 'test', 'Correct text should be returned');
-				}));
-			},
-			'should return text from cache'() {
-				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
-					assert.isTrue(fsSpy.notCalled, 'Read file should not be called');
-					assert.strictEqual(val, 'test', 'Correct text should be returned');
-				}));
-			},
 			'should strip xml'() {
 				text.load(basePath + 'strip.xml!strip', (<DojoLoader.Require> require), this.async().callback((val: string) => {
 					assert.strictEqual(val, 'abc', 'Should have stripped the XML');

--- a/tests/unit/text_browser.ts
+++ b/tests/unit/text_browser.ts
@@ -1,0 +1,18 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as text from 'src/text';
+
+const basePath = '../../_build/tests/support/data/';
+
+registerSuite({
+		name: 'text',
+
+		'load': {
+			'should return text'() {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+					assert.strictEqual(val, 'test', 'Correct text should be returned');
+				}));
+			}
+		}
+	}
+);

--- a/tests/unit/text_node.ts
+++ b/tests/unit/text_node.ts
@@ -1,0 +1,36 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as text from 'src/text';
+import { spy } from 'sinon';
+import * as fs from 'fs';
+
+const basePath = '_build/tests/support/data/';
+let fsSpy: Sinon.SinonSpy;
+
+registerSuite({
+		name: 'text',
+
+		'load': {
+			beforeEach() {
+				fsSpy = spy(fs, 'readFile');
+			},
+
+			afterEach() {
+				fsSpy.restore && fsSpy.restore();
+			},
+
+			'should return text and call fs'() {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+					assert.isTrue(fsSpy.calledOnce, 'Read file should be called once');
+					assert.strictEqual(val, 'test', 'Correct text should be returned');
+				}));
+			},
+			'should return text from cache'() {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+					assert.isTrue(fsSpy.notCalled, 'Read file should not be called');
+					assert.strictEqual(val, 'test', 'Correct text should be returned');
+				}));
+			}
+		}
+	}
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,7 +76,6 @@
 		"./tests/functional/text/textPlugin.ts",
 		"./tests/intern-local.ts",
 		"./tests/intern.ts",
-		"./tests/module.d.ts",
 		"./tests/services/echo.ts",
 		"./tests/support/Reporter.ts",
 		"./tests/support/util.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
 		"./tests/functional/text/textPlugin.ts",
 		"./tests/intern-local.ts",
 		"./tests/intern.ts",
+		"./tests/module.d.ts",
 		"./tests/services/echo.ts",
 		"./tests/support/Reporter.ts",
 		"./tests/support/util.ts",
@@ -149,6 +150,8 @@
 		"./tests/unit/streams/util.ts",
 		"./tests/unit/string.ts",
 		"./tests/unit/text.ts",
+		"./tests/unit/text_browser.ts",
+		"./tests/unit/text_node.ts",
 		"./tests/unit/util.ts",
 		"./typings/tsd.d.ts"
 	]


### PR DESCRIPTION
fixes: https://github.com/dojo/core/issues/126
- intern dojo moved to `browser_modules`
- added node / browser separation to `text` tests
- added npm dev dependency of `leadfoot@1.6.5`
