### PR TITLE
Use native array objects when available

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -70,7 +70,7 @@ export function from<T>(arrayLike: ArrayLike<T>, mapFunction?: MapCallback<T>, t
  */
 export function from<T>(arrayLike: (string | ArrayLike<T>), mapFunction?: MapCallback<T>, thisArg?: {}): ArrayLike<T> {
 	// Use the native Array.from() if it exists
-	if (has('array-from')) {
+	if (has('es6-array-from')) {
 		return (<any> Array).from.apply(null, arguments);
 	}
 
@@ -106,7 +106,7 @@ export function of(...items: any[]): any[];
  * @return An array from the given arguments
  */
 export function of() {
-	if (has('array-of')) {
+	if (has('es6-array-of')) {
 		return (<any> Array).of.apply(null, arguments);
 	}
 
@@ -123,7 +123,7 @@ export function of() {
  * @return The filled target
  */
 export function fill<T>(target: ArrayLike<T>, value: any, start?: number, end?: number): ArrayLike<T> {
-	if (has('array-fill')) {
+	if (has('es6-array-fill')) {
 		const method = (<any> Array.prototype).fill;
 		return method.call.apply(method, arguments);
 	}
@@ -149,7 +149,7 @@ export function fill<T>(target: ArrayLike<T>, value: any, start?: number, end?: 
  * @return The first index whose value satisfies the passed callback, or -1 if no values satisfy it
  */
 export function findIndex<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): number {
-	if (has('array-findIndex')) {
+	if (has('es6-array-findIndex')) {
 		const method = (<any> Array.prototype).findIndex;
 		return method.call.apply(method, arguments);
 	}
@@ -182,7 +182,7 @@ export function findIndex<T>(target: ArrayLike<T>, callback: FindCallback<T>, th
  * @return The first element matching the callback, or undefined if one does not exist
  */
 export function find<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): T {
-	if (has('array-find')) {
+	if (has('es6-array-find')) {
 		const method = (<any> Array.prototype).find;
 		return method.call.apply(method, arguments);
 	}
@@ -200,8 +200,8 @@ export function find<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg
  * @param end The last (exclusive) index to copy; if negative, it counts backwards from length
  * @return The target
  */
-export function copyWithin<T>(target: ArrayLike<T>, offset: number, start?: number, end?: number): ArrayLike<T> {
-	if (has('array-copyWithin')) {
+export function copyWithin<T>(target: ArrayLike<T>, offset: number, start: number, end?: number): ArrayLike<T> {
+	if (has('es6-array-copyWithin')) {
 		const method = (<any> Array.prototype).copyWithin;
 		return method.call.apply(method, arguments);
 	}
@@ -246,7 +246,7 @@ export function copyWithin<T>(target: ArrayLike<T>, offset: number, start?: numb
  * @param fromIndex the starting index to search from
  */
 export function includes<T>(target: ArrayLike<T>, searchElement: T, fromIndex: number = 0): boolean {
-	if (has('array-includes')) {
+	if (has('es7-array-includes')) {
 		const method = (<any> Array.prototype).includes;
 		return method.call.apply(method, arguments);
 	}

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,4 +1,5 @@
 import { MAX_SAFE_INTEGER as maxSafeInteger } from './number';
+import has from './has';
 
 export interface ArrayLike<T> {
 	length: number;
@@ -68,6 +69,11 @@ export function from<T>(arrayLike: ArrayLike<T>, mapFunction?: MapCallback<T>, t
  * @return The new Array
  */
 export function from<T>(arrayLike: (string | ArrayLike<T>), mapFunction?: MapCallback<T>, thisArg?: {}): ArrayLike<T> {
+	// Use the native Array.from() if it exists
+	if (has('array-from')) {
+		return (<any> Array).from.apply(null, arguments);
+	}
+
 	if (arrayLike == null) {
 		throw new TypeError('from: requires an array-like object');
 	}
@@ -100,6 +106,10 @@ export function of(...items: any[]): any[];
  * @return An array from the given arguments
  */
 export function of() {
+	if (has('array-of')) {
+		return (<any> Array).of.apply(null, arguments);
+	}
+
 	return Array.prototype.slice.call(arguments);
 }
 
@@ -113,9 +123,14 @@ export function of() {
  * @return The filled target
  */
 export function fill<T>(target: ArrayLike<T>, value: any, start?: number, end?: number): ArrayLike<T> {
+	if (has('array-fill')) {
+		const method = (<any> Array.prototype).fill;
+		return method.call.apply(method, arguments);
+	}
+
 	const length = toLength(target.length);
 	let i = normalizeOffset(toInteger(start), length);
-	end = normalizeOffset(end ? toInteger(end) : length, length);
+	end = normalizeOffset(end === undefined ? length : toInteger(end), length);
 
 	while (i < end) {
 		target[i++] = value;
@@ -134,6 +149,11 @@ export function fill<T>(target: ArrayLike<T>, value: any, start?: number, end?: 
  * @return The first index whose value satisfies the passed callback, or -1 if no values satisfy it
  */
 export function findIndex<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): number {
+	if (has('array-findIndex')) {
+		const method = (<any> Array.prototype).findIndex;
+		return method.call.apply(method, arguments);
+	}
+
 	const length = toLength(target.length);
 
 	if (!callback) {
@@ -162,6 +182,11 @@ export function findIndex<T>(target: ArrayLike<T>, callback: FindCallback<T>, th
  * @return The first element matching the callback, or undefined if one does not exist
  */
 export function find<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg?: {}): T {
+	if (has('array-find')) {
+		const method = (<any> Array.prototype).find;
+		return method.call.apply(method, arguments);
+	}
+
 	const index = findIndex<T>(target, callback, thisArg);
 	return index !== -1 ? target[index] : undefined;
 }
@@ -176,6 +201,11 @@ export function find<T>(target: ArrayLike<T>, callback: FindCallback<T>, thisArg
  * @return The target
  */
 export function copyWithin<T>(target: ArrayLike<T>, offset: number, start?: number, end?: number): ArrayLike<T> {
+	if (has('array-copyWithin')) {
+		const method = (<any> Array.prototype).copyWithin;
+		return method.call.apply(method, arguments);
+	}
+
 	if (target == null) {
 		throw new TypeError('copyWithin: target must be an array-like object');
 	}
@@ -183,7 +213,7 @@ export function copyWithin<T>(target: ArrayLike<T>, offset: number, start?: numb
 	const length = toLength(target.length);
 	offset = normalizeOffset(toInteger(offset), length);
 	start = normalizeOffset(toInteger(start), length);
-	end = normalizeOffset(end ? toInteger(end) : length, length);
+	end = normalizeOffset(end === undefined ? length : toInteger(end), length);
 	let count = Math.min(end - start, length - offset);
 
 	let direction = 1;
@@ -216,6 +246,11 @@ export function copyWithin<T>(target: ArrayLike<T>, offset: number, start?: numb
  * @param fromIndex the starting index to search from
  */
 export function includes<T>(target: ArrayLike<T>, searchElement: T, fromIndex: number = 0): boolean {
+	if (has('array-includes')) {
+		const method = (<any> Array.prototype).includes;
+		return method.call.apply(method, arguments);
+	}
+
 	let len = toLength(target.length);
 
 	for (let i = fromIndex; i < len; ++i) {

--- a/src/has.ts
+++ b/src/has.ts
@@ -169,10 +169,10 @@ add('xhr2-blob', function () {
 	return request.responseType === 'blob';
 });
 // Native Array methods
-add('array-from', 'from' in global.Array);
-add('array-of', 'of' in global.Array);
-add('array-fill', 'fill' in global.Array.prototype);
-add('array-findIndex', 'findIndex' in global.Array.prototype);
-add('array-find', 'find' in global.Array.prototype);
-add('array-copy-within', 'copyWithin' in global.Array.prototype);
-add('array-includes', 'includes' in global.Array.prototype);
+add('es6-array-from', 'from' in global.Array);
+add('es6-array-of', 'of' in global.Array);
+add('es6-array-fill', 'fill' in global.Array.prototype);
+add('es6-array-findIndex', 'findIndex' in global.Array.prototype);
+add('es6-array-find', 'find' in global.Array.prototype);
+add('es6-array-copyWithin', 'copyWithin' in global.Array.prototype);
+add('es7-array-includes', 'includes' in global.Array.prototype);

--- a/src/has.ts
+++ b/src/has.ts
@@ -168,3 +168,11 @@ add('xhr2-blob', function () {
 	request.abort();
 	return request.responseType === 'blob';
 });
+// Native Array methods
+add('array-from', 'from' in global.Array);
+add('array-of', 'of' in global.Array);
+add('array-fill', 'fill' in global.Array.prototype);
+add('array-findIndex', 'findIndex' in global.Array.prototype);
+add('array-find', 'find' in global.Array.prototype);
+add('array-copy-within', 'copyWithin' in global.Array.prototype);
+add('array-includes', 'includes' in global.Array.prototype);

--- a/tests/unit/array.ts
+++ b/tests/unit/array.ts
@@ -70,7 +70,7 @@ function createNativeAndDojoArrayTests(feature: string, tests: {}) {
 registerSuite({
 	name: 'array',
 
-	'.from()': createNativeAndDojoArrayTests('array-from', {
+	'.from()': createNativeAndDojoArrayTests('es6-array-from', {
 		'from undefined: throws': function () {
 			assert.throws(function () {
 				array.from(undefined);
@@ -176,7 +176,7 @@ registerSuite({
 		}
 	}),
 
-	'.of()': createNativeAndDojoArrayTests('array-of', {
+	'.of()': createNativeAndDojoArrayTests('es6-array-of', {
 		'empty arguments': function () {
 			assert.deepEqual(array.of(), []);
 		},
@@ -191,7 +191,7 @@ registerSuite({
 		}
 	}),
 
-	'#fill()': createNativeAndDojoArrayTests('array-fill', {
+	'#fill()': createNativeAndDojoArrayTests('es6-array-fill', {
 		'basic fill array': function () {
 			let actual = array.fill([ 1, 2, 3 ], 9);
 			assert.deepEqual(actual, [ 9, 9, 9 ]);
@@ -259,7 +259,7 @@ registerSuite({
 		}
 	}),
 
-	'#findIndex()': createNativeAndDojoArrayTests('array-findIndex', (function () {
+	'#findIndex()': createNativeAndDojoArrayTests('es6-array-findIndex', (function () {
 		function callback(element: string) {
 			return element === 'goose';
 		}
@@ -304,7 +304,7 @@ registerSuite({
 		};
 	})()),
 
-	'#find()': createNativeAndDojoArrayTests('array-find', (function () {
+	'#find()': createNativeAndDojoArrayTests('es6-array-find', (function () {
 		function callback(element: number) {
 			return element > 5;
 		}
@@ -322,15 +322,15 @@ registerSuite({
 		};
 	})()),
 
-	'#copyWithin()': createNativeAndDojoArrayTests('array-copyWithin', {
+	'#copyWithin()': createNativeAndDojoArrayTests('es6-array-copyWithin', {
 		'returns source array': function () {
 			let arr: any[] = [];
-			assert.equal(array.copyWithin(arr, 0), arr);
+			assert.equal(array.copyWithin(arr, 0, 0), arr);
 		},
 
 		'null target: throws': function () {
 			assert.throws(function () {
-				array.copyWithin(null, 0);
+				array.copyWithin(null, 0, 0);
 			}, TypeError);
 		},
 
@@ -379,7 +379,7 @@ registerSuite({
 				2: 'two',
 				'length': NaN
 			};
-			let actual = array.copyWithin(obj, 1);
+			let actual = array.copyWithin(obj, 1, 0);
 			assert.deepEqual(actual, expected);
 		},
 
@@ -396,9 +396,10 @@ registerSuite({
 				[ 'non-number end leaves data unchanged', [1, 2, 3, 4, 5], 0, 0, NaN]
 			];
 			parameters.forEach(function ([ name, expected, offset, start, end ]: [ string, number[], number, number, number ]) {
-				let arr = [ 1, 2, 3, 4, 5 ];
 				tests[name] = function () {
+					let arr = [ 1, 2, 3, 4, 5 ];
 					let actual = array.copyWithin(arr, offset, start, end);
+					assert.strictEqual(actual, arr, 'a new array should not be created');
 					assert.deepEqual(actual, expected);
 				};
 			});
@@ -407,7 +408,7 @@ registerSuite({
 		})()
 	}),
 
-	'#includes': createNativeAndDojoArrayTests('array-includes', (function() {
+	'#includes': createNativeAndDojoArrayTests('es7-array-includes', (function() {
 		let arr: number[];
 		return {
 			beforeEach() {
@@ -437,7 +438,7 @@ registerSuite({
 		};
 	})()),
 
-	'extension support': createDojoTests('array-from', {
+	'extension support': createDojoTests('es6-array-from', {
 		'.from()': function () {
 			let actual = MyArray.from([ 1, 2, 3 ]);
 			assert.instanceOf(actual, MyArray);


### PR DESCRIPTION
array now uses native objects by default when available. Fixed a small bug for non-integer end values in `copyWithin()` and `fill()`.

 Fixes #114
