### PR TITLE
loader #59 - updated typings of `DojoLoader.Require` to `DojoLoader.RootRequire`

### DIFF
--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -169,31 +169,31 @@ registerSuite({
 		'has loader tests': {
 			'both feature and no-feature modules provided'() {
 				const expectedHasBrowser = has('host-browser') ? 'intern/main' : 'intern!object';
-				const actualHasBrowser = hasNormalize('host-browser?intern:intern!object', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasBrowser = hasNormalize('host-browser?intern:intern!object', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasBrowser, expectedHasBrowser);
 
 				const expectedHasNode = has('host-node') ? 'intern/main' : 'intern!object';
-				const actualHasNode = hasNormalize('host-node?intern:intern!object', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasNode = hasNormalize('host-node?intern:intern!object', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasNode, expectedHasNode);
 			},
 
 			'only feature module provided'() {
 				const expectedHasBrowser = has('host-browser') ? 'intern/main' : undefined;
-				const actualHasBrowser = hasNormalize('host-browser?intern', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasBrowser = hasNormalize('host-browser?intern', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasBrowser, expectedHasBrowser);
 
 				const expectedHasNode = has('host-node') ? 'intern/main' : undefined;
-				const actualHasNode = hasNormalize('host-node?intern', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasNode = hasNormalize('host-node?intern', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasNode, expectedHasNode);
 			},
 
 			'only no-feature module provided'() {
 				const expectedHasBrowser = has('host-browser') ? 'intern/main' : null;
-				const actualHasBrowser = hasNormalize('host-node?:intern', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasBrowser = hasNormalize('host-node?:intern', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasBrowser, expectedHasBrowser);
 
 				const expectedHasNode = has('host-node') ? 'intern/main' : null;
-				const actualHasNode = hasNormalize('host-browser?:intern', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasNode = hasNormalize('host-browser?:intern', (<DojoLoader.RootRequire> require).toAbsMid);
 				assert.strictEqual(actualHasNode, expectedHasNode);
 			},
 
@@ -205,9 +205,9 @@ registerSuite({
 				hasAdd('abc', true);
 				hasAdd('def', false);
 
-				const actual1 = hasNormalize('abc?def?one:two:three', (<DojoLoader.Require> require).toAbsMid);
-				const actual2 = hasNormalize('abc?abc?one:two:three', (<DojoLoader.Require> require).toAbsMid);
-				const actual3 = hasNormalize('def?abc?one:two:three', (<DojoLoader.Require> require).toAbsMid);
+				const actual1 = hasNormalize('abc?def?one:two:three', (<DojoLoader.RootRequire> require).toAbsMid);
+				const actual2 = hasNormalize('abc?abc?one:two:three', (<DojoLoader.RootRequire> require).toAbsMid);
+				const actual3 = hasNormalize('def?abc?one:two:three', (<DojoLoader.RootRequire> require).toAbsMid);
 
 				assert.strictEqual(expected1, actual1);
 				assert.strictEqual(expected2, actual2);
@@ -221,8 +221,8 @@ registerSuite({
 				hasAdd('abc', true);
 				hasAdd('def', false);
 
-				const actualHasFeatureModule = hasNormalize('abc?intern:intern!object', (<DojoLoader.Require> require).toAbsMid);
-				const actualHasNoFeatureModule = hasNormalize('def?intern:intern!object', (<DojoLoader.Require> require).toAbsMid);
+				const actualHasFeatureModule = hasNormalize('abc?intern:intern!object', (<DojoLoader.RootRequire> require).toAbsMid);
+				const actualHasNoFeatureModule = hasNormalize('def?intern:intern!object', (<DojoLoader.RootRequire> require).toAbsMid);
 
 				assert.strictEqual(expectedHasFeatureModule, actualHasFeatureModule);
 				assert.strictEqual(expectedHasNoFeatureModule, actualHasNoFeatureModule);
@@ -244,7 +244,7 @@ registerSuite({
 				const loadedStub = sinon.stub();
 				const resourceId = 'src/has!host-browser?intern:intern!object';
 
-				hasLoad(resourceId, <DojoLoader.Require> <any> stubbedRequire, loadedStub);
+				hasLoad(resourceId, <DojoLoader.RootRequire> <any> stubbedRequire, loadedStub);
 				assert.isTrue(stubbedRequire.calledOnce, 'Require should be called once');
 				assert.isTrue(loadedStub.calledOnce, 'Load stub should be called once');
 				assert.isTrue(loadedStub.calledAfter(stubbedRequire), 'Load stub should be called after require');

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -52,12 +52,12 @@ registerSuite({
 		},
 		'load': {
 			'should strip xml'() {
-				text.load(basePath + 'strip.xml!strip', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+				text.load(basePath + 'strip.xml!strip', (<DojoLoader.RootRequire> require), this.async().callback((val: string) => {
 					assert.strictEqual(val, 'abc', 'Should have stripped the XML');
 				}));
 			},
 			'should strip html'() {
-				text.load(basePath + 'strip.html!strip', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+				text.load(basePath + 'strip.html!strip', (<DojoLoader.RootRequire> require), this.async().callback((val: string) => {
 					assert.strictEqual(val, 'abc', 'Should have stripped the XML');
 				}));
 			}

--- a/tests/unit/text_browser.ts
+++ b/tests/unit/text_browser.ts
@@ -9,7 +9,7 @@ registerSuite({
 
 		'load': {
 			'should return text'() {
-				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.RootRequire> require), this.async().callback((val: string) => {
 					assert.strictEqual(val, 'test', 'Correct text should be returned');
 				}));
 			}

--- a/tests/unit/text_node.ts
+++ b/tests/unit/text_node.ts
@@ -20,13 +20,13 @@ registerSuite({
 			},
 
 			'should return text and call fs'() {
-				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.RootRequire> require), this.async().callback((val: string) => {
 					assert.isTrue(fsSpy.calledOnce, 'Read file should be called once');
 					assert.strictEqual(val, 'test', 'Correct text should be returned');
 				}));
 			},
 			'should return text from cache'() {
-				text.load(basePath + 'textLoad.txt', (<DojoLoader.Require> require), this.async().callback((val: string) => {
+				text.load(basePath + 'textLoad.txt', (<DojoLoader.RootRequire> require), this.async().callback((val: string) => {
 					assert.isTrue(fsSpy.notCalled, 'Read file should not be called');
 					assert.strictEqual(val, 'test', 'Correct text should be returned');
 				}));


### PR DESCRIPTION
Related to: https://github.com/dojo/loader/issues/59
Requires `loader` release.
