### PR TITLE
134: remove handleAs from RequestOptions

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -124,7 +124,6 @@ export interface RequestOptions {
 	auth?: string;
 	cacheBust?: any;
 	data?: any;
-	handleAs?: string;
 	headers?: { [name: string]: string; };
 	method?: string;
 	password?: string;
@@ -195,7 +194,7 @@ export default request;
  */
 filterRegistry.register(
 	function (response: Response<any>, url: string, options: RequestOptions) {
-		return typeof response.data && options && (options.responseType === 'json' || options.handleAs === 'json');
+		return typeof response.data && options && options.responseType === 'json';
 	},
 	function (response: Response<any>, url: string, options: RequestOptions): Object {
 		return {

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -64,7 +64,7 @@ registerSuite({
 				this.skip('No echo server available');
 			}
 			return xhrRequest('/__echo/xhr?color=blue&numbers=one&numbers=two', {
-				handleAs: 'json'
+				responseType: 'json'
 			}).then(function (response: any) {
 				const query = JSON.parse(response.data).query;
 				assert.deepEqual(query, {
@@ -149,7 +149,7 @@ registerSuite({
 						thud: 'thonk',
 						xyzzy: '3'
 					}).toString(),
-					handleAs: 'json'
+					responseType: 'json'
 				}).then(function (response: any) {
 					const query = JSON.parse(response.data).query;
 					assert.deepEqual(query, {
@@ -176,7 +176,7 @@ registerSuite({
 						thud: 'thonk',
 						xyzzy: '3'
 					}).toString(),
-					handleAs: 'json'
+					responseType: 'json'
 				}).then(function (response: any) {
 					const query = JSON.parse(response.data).query;
 					assert.deepEqual(query, {
@@ -201,7 +201,7 @@ registerSuite({
 						thud: 'thonk',
 						xyzzy: '3'
 					},
-					handleAs: 'json'
+					responseType: 'json'
 				}).then(function (response: any) {
 					const query = JSON.parse(response.data).query;
 					assert.deepEqual(query, {

--- a/tests/unit/request_browser.ts
+++ b/tests/unit/request_browser.ts
@@ -23,13 +23,5 @@ registerSuite({
 				assert.deepEqual(response.data, { foo: 'bar' });
 			})
 		;
-	},
-
-	'JSON handleAs filter'() {
-		return request.get(getRequestUrl('foo.json'), { handleAs: 'json' })
-			.then(function (response: any) {
-				assert.deepEqual(response.data, { foo: 'bar' });
-			})
-		;
 	}
 });

--- a/tests/unit/request_node.ts
+++ b/tests/unit/request_node.ts
@@ -93,13 +93,5 @@ registerSuite({
 				assert.deepEqual(response.data, { foo: 'bar' });
 			})
 		;
-	},
-
-	'JSON handleAs filter'() {
-		return request.get(getRequestUrl('foo.json'), { handleAs: 'json' })
-			.then(function(response: any) {
-				assert.deepEqual(response.data, { foo: 'bar' });
-			})
-		;
 	}
 });


### PR DESCRIPTION
Fixes: https://github.com/dojo/core/issues/134

As raised in a support ticket, `RequestOptions` interface describes both `handleAs` and `responseType`. 
`handleAs` is not longer valid and has been replaced with `responseType` thus it should be removed.
