### PR TITLE
#137: Headers should not be Normalised

### DIFF
--- a/src/request/node.ts
+++ b/src/request/node.ts
@@ -64,15 +64,6 @@ export interface NodeRequestOptions<T> extends RequestOptions {
 	streamTarget?: WritableStream<T>;
 }
 
-function normalizeHeaders(headers: { [name: string]: string }): { [name: string]: string } {
-	const normalizedHeaders: { [name: string]: string } = {};
-	for (let key in headers) {
-		normalizedHeaders[key.toLowerCase()] = headers[key];
-	}
-
-	return normalizedHeaders;
-}
-
 export default function node<T>(url: string, options: NodeRequestOptions<T> = {}): ResponsePromise<T> {
 	const requestUrl = generateRequestUrl(url, options);
 	const parsedUrl = urlUtil.parse(options.proxy || requestUrl);
@@ -82,7 +73,7 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 		ca: options.ca,
 		cert: options.cert,
 		ciphers: options.ciphers,
-		headers: normalizeHeaders(options.headers || {}),
+		headers: options.headers || {},
 		host: parsedUrl.host,
 		hostname: parsedUrl.hostname,
 		key: options.key,

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -291,6 +291,24 @@ registerSuite({
 	},
 
 	headers: {
+		'request headers should not be normalized'(): void {
+			const dfd = this.async();
+			nodeRequest(getRequestUrl('foo.json'), {
+				headers: {
+					someThingCrAzY: 'some-arbitrary-value'
+				}
+			}).then(
+				dfd.callback(function (response: any) {
+					const header: any = response.nativeResponse.req._header;
+
+					assert.notInclude(header, 'somethingcrazy: some-arbitrary-value');
+					assert.include(header, 'someThingCrAzY: some-arbitrary-value');
+					assert.match(header, /dojo\/[^\s]+ Node\.js/);
+				}),
+				dfd.reject.bind(dfd)
+			);
+		},
+
 		'response headers': {
 			'before response'(): void {
 				const dfd = this.async();

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -291,23 +291,6 @@ registerSuite({
 	},
 
 	headers: {
-		'request header normalization'(): void {
-			const dfd = this.async();
-			nodeRequest(getRequestUrl('foo.json'), {
-				headers: {
-					someThingCrAzY: 'some-arbitrary-value'
-				}
-			}).then(
-				dfd.callback(function (response: any) {
-					const header: any = response.nativeResponse.req._header;
-
-					assert.include(header, 'somethingcrazy: some-arbitrary-value');
-					assert.match(header, /dojo\/[^\s]+ Node\.js/);
-				}),
-				dfd.reject.bind(dfd)
-			);
-		},
-
 		'response headers': {
 			'before response'(): void {
 				const dfd = this.async();


### PR DESCRIPTION
Fixes: https://github.com/dojo/core/issues/137

No longer normalises headers in `request/node.ts`
