### PR TITLE
Update to allow testing against Sauce Labs and Browserstack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 script:
   - "grunt"
   - "grunt intern:node --combined"
-  - "grunt intern:remote --combined"
+  - "grunt intern:saucelabs --combined"
   - "grunt remapIstanbul:ci"
   - "grunt uploadCoverage"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,6 +120,12 @@ module.exports = function (grunt) {
 				config: '<%= devDirectory %>/tests/intern',
 				reporters: [ 'Runner' ]
 			},
+			browserstack: {},
+			saucelabs: {
+				options: {
+					config: '<%= devDirectory %>/tests/intern-saucelabs'
+				}
+			},
 			remote: {},
 			local: {
 				options: {

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -1,0 +1,24 @@
+export * from './intern';
+
+export const capabilities = {
+	project: 'Dojo 2',
+	name: 'dojo-core',
+	fixSessionCapabilities: false
+};
+
+export const environments = [
+	{ browserName: 'internet explorer', version: ['9.0', '10.0', '11.0'], platform: 'Windows 7' },
+	/* Intern 3.0.6 sometimes works on Edge */
+	/* { browserName: 'microsoftedge', platform: 'Windows 10' }, */
+	{ browserName: 'firefox', platform: 'Windows 10' },
+	{ browserName: 'chrome', platform: 'Windows 10' },
+	/* Still appear to be issues on Safari on SauceLabs */
+	/* { browserName: 'safari', version: '9', platform: 'OS X 10.11' },*/
+	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }/*,
+	{ browserName: 'iphone', version: '9.1', deviceName: 'iPhone 6' }*/
+];
+
+/* SauceLabs supports more max concurrency */
+export const maxConcurrency = 3;
+
+export const tunnel = 'SauceLabsTunnel';

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -29,32 +29,26 @@ export const proxyUrl = 'http://localhost:9001/';
 // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
 // automatically
 export const capabilities = {
+	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-core',
-	fixSessionCapabilities: false
+	name: 'dojo-core'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
 // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
 // capabilities options specified for an environment will be copied as-is
 export const environments = [
-	{ browserName: 'internet explorer', version: [ '9.0', '10.0', '11.0' ], platform: 'Windows 7' },
-	// Tests are hangling on MicrosoftEdge
-	// { browserName: 'MicrosoftEdge', platform: 'Windows 10' },
-	{ browserName: 'firefox', platform: 'Windows 10' },
-	{ browserName: 'chrome', platform: 'Windows 10' },
-	// tests are hanging on Safari
-	// { browserName: 'safari', version: '9.0', platform: 'OS X 10.11' },
-	{ browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' }/*,
-	// Unstable tests on iPhone
-	{ browserName: 'iphone', version: '7.1' }*/
+	{ browserName: 'internet explorer', version: [ '9', '10', '11' ], platform: 'WINDOWS' },
+	{ browserName: 'firefox', platform: 'WINDOWS' },
+	{ browserName: 'chrome', platform: 'WINDOWS' }/*,
+	{ browserName: 'Safari', version: '9', platform: 'OS X' }*/
 ];
 
 // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
 export const maxConcurrency = 2;
 
 // Name of the tunnel class to use for WebDriver tests
-export const tunnel = 'SauceLabsTunnel';
+export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
 export const initialBaseUrl: string = (function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -78,6 +78,7 @@
 		"./tests/functional/all.ts",
 		"./tests/functional/text/textPlugin.ts",
 		"./tests/intern-local.ts",
+		"./tests/intern-saucelabs.ts",
 		"./tests/intern.ts",
 		"./tests/services/echo.ts",
 		"./tests/support/Reporter.ts",


### PR DESCRIPTION
Updated Gruntfile and intern configurations to allow tests to run against saucelabs and browserstack via grunt command line settings
