### PR TITLE
Incorporate iterators throughout core.

### DIFF
--- a/src/Map.ts
+++ b/src/Map.ts
@@ -1,127 +1,198 @@
-import { ArrayLike } from './array';
+import { hasClass } from './decorators';
+import { forOf, Iterable, IterableIterator, ShimIterator } from './iterator';
+import global from './global';
 import { is } from './object';
+import Symbol from './Symbol';
 
-/**
- * An implementation analogous to the Map specification in ES2015,
- * with the exception of iterators.  The entries, keys, and values methods
- * are omitted, since forEach essentially provides the same functionality.
- */
+export namespace Shim {
+	/**
+	 * An implementation analogous to the Map specification in ES2015.
+	 */
+	export class Map<K, V> {
+		protected _keys: K[] = [];
+		protected _values: V[] = [];
+
+		/**
+		 * An alternative to Array.prototype.indexOf using Object.is
+		 * to check for equality. See http://mzl.la/1zuKO2V
+		 */
+		protected _indexOfKey(keys: K[], key: K): number {
+			for (let i = 0, length = keys.length; i < length; i++) {
+				if (is(keys[i], key)) {
+					return i;
+				}
+			}
+			return -1;
+		}
+
+		/**
+		 * Creates a new Map
+		 *
+		 * @constructor
+		 *
+		 * @param iterator
+		 * Array or iterator containing two-item tuples used to initially populate the map.
+		 * The first item in each tuple corresponds to the key of the map entry.
+		 * The second item corresponds to the value of the map entry.
+		 */
+		constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) {
+			if (iterable) {
+				forOf(iterable, (value: [K, V]) => {
+					this.set(value[0], value[1]);
+				});
+			}
+		}
+
+		/**
+		 * Returns the number of key / value pairs in the Map.
+		 *
+		 * @return the number of key / value pairs in the Map
+		 */
+		get size(): number {
+			return this._keys.length;
+		}
+
+		/**
+		 * Deletes all keys and their associated values.
+		 */
+		clear(): void {
+			this._keys.length = this._values.length = 0;
+		}
+
+		/**
+		 * Deletes a given key and its associated value.
+		 *
+		 * @param key The key to delete
+		 * @return true if the key exists, false if it does not
+		 */
+		delete(key: K): boolean {
+			const index = this._indexOfKey(this._keys, key);
+			if (index < 0) {
+				return false;
+			}
+			this._keys.splice(index, 1);
+			this._values.splice(index, 1);
+			return true;
+		}
+
+		/**
+		 * Returns an iterator that yields each key/value pair as an array.
+		 *
+		 * @return An iterator for each key/value pair in the instance.
+		 */
+		entries(): IterableIterator<[K, V]> {
+			const values = this._keys.map((key: K, i: number): [K, V] => {
+				return [ key, this._values[i] ];
+			});
+
+			return new ShimIterator<[K, V]>(values);
+		}
+
+		/**
+		 * Executes a given function for each map entry. The function
+		 * is invoked with three arguments: the element value, the
+		 * element key, and the associated Map instance.
+		 *
+		 * @param callback The function to execute for each map entry,
+		 * @param context The value to use for `this` for each execution of the calback
+		 */
+		forEach(callback: (value: V, key: K, mapInstance: Map<K, V>) => any, context?: {}) {
+			const keys = this._keys;
+			const values = this._values;
+			for (let i = 0, length = keys.length; i < length; i++) {
+				callback.call(context, values[i], keys[i], this);
+			}
+		}
+
+		/**
+		 * Returns the value associated with a given key.
+		 *
+		 * @param key The key to look up
+		 * @return The value if one exists or undefined
+		 */
+		get(key: K): V {
+			const index = this._indexOfKey(this._keys, key);
+			return index < 0 ? undefined : this._values[index];
+		}
+
+		/**
+		 * Checks for the presence of a given key.
+		 *
+		 * @param key The key to check for
+		 * @return true if the key exists, false if it does not
+		 */
+		has(key: K): boolean {
+			return this._indexOfKey(this._keys, key) > -1;
+		}
+
+		/**
+		 * Returns an iterator that yields each key in the map.
+		 *
+		 * @return An iterator containing the instance's keys.
+		 */
+		keys(): IterableIterator<K> {
+			return new ShimIterator<K>(this._keys);
+		}
+
+		/**
+		 * Sets the value associated with a given key.
+		 *
+		 * @param key The key to define a value to
+		 * @param value The value to assign
+		 * @return The Map instance
+		 */
+		set(key: K, value: V): Map<K, V> {
+			let index = this._indexOfKey(this._keys, key);
+			index = index < 0 ? this._keys.length : index;
+			this._keys[index] = key;
+			this._values[index] = value;
+			return this;
+		}
+
+		/**
+		 * Returns an iterator that yields each value in the map.
+		 *
+		 * @return An iterator containing the instance's values.
+		 */
+		values(): IterableIterator<V> {
+			return new ShimIterator<V>(this._values);
+		}
+
+		[Symbol.iterator](): IterableIterator<[K, V]> {
+			return this.entries();
+		}
+
+		[Symbol.toStringTag]: string = 'Map';
+	}
+}
+
+@hasClass('es6-map', global.Map, Shim.Map)
 export default class Map<K, V> {
-	protected _keys: K[] = [];
-	protected _values: V[] = [];
+	/* istanbul ignore next */
+	constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) { };
 
-	/*
-	 * An alternative to Array.prototype.indexOf using Object.is
-	 * to check for equality. See http://mzl.la/1zuKO2V
-	 */
-	protected _indexOfKey(keys: K[], key: K): number {
-		for (let i = 0, length = keys.length; i < length; i++) {
-			if (is(keys[i], key)) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	/**
-	 * Creates a new Map
-	 *
-	 * @constructor
-	 *
-	 * @param arrayLike
-	 * Array or array-like object containing two-item tuples used to initially populate the map.
-	 * The first item in each tuple corresponds to the key of the map entry.
-	 * The second item corresponds to the value of the map entry.
-	 */
-	constructor(arrayLike?: ArrayLike<[ K, V ]>) {
-		if (arrayLike) {
-			for (let i = 0, length = arrayLike.length; i < length; i++) {
-				this.set(arrayLike[i][0], arrayLike[i][1]);
-			}
-		}
-	}
-
-	/**
-	 * Returns the number of key / value pairs in the Map.
-	 *
-	 * @return the number of key / value pairs in the Map
-	 */
-	get size(): number {
-		return this._keys.length;
-	}
-
-	/**
-	 * Deletes all keys and their associated values.
-	 */
-	clear(): void {
-		this._keys.length = this._values.length = 0;
-	}
-
-	/**
-	 * Deletes a given key and its associated value.
-	 *
-	 * @param key The key to delete
-	 * @return true if the key exists, false if it does not
-	 */
-	delete(key: K): boolean {
-		const index = this._indexOfKey(this._keys, key);
-		if (index < 0) {
-			return false;
-		}
-		this._keys.splice(index, 1);
-		this._values.splice(index, 1);
-		return true;
-	}
-
-	/**
-	 * Executes a given function for each map entry. The function
-	 * is invoked with three arguments: the element value, the
-	 * element key, and the associated Map instance.
-	 *
-	 * @param callback The function to execute for each map entry,
-	 * @param context The value to use for `this` for each execution of the calback
-	 */
-	forEach(callback: (value: V, key: K, mapInstance: Map<K, V>) => any, context?: {}) {
-		const keys = this._keys;
-		const values = this._values;
-		for (let i = 0, length = keys.length; i < length; i++) {
-			callback.call(context, values[i], keys[i], this);
-		}
-	}
-
-	/**
-	 * Returns the value associated with a given key.
-	 *
-	 * @param key The key to look up
-	 * @return The value if one exists or undefined
-	 */
-	get(key: K): V {
-		const index = this._indexOfKey(this._keys, key);
-		return index < 0 ? undefined : this._values[index];
-	}
-
-	/**
-	 * Checks for the presence of a given key.
-	 *
-	 * @param key The key to check for
-	 * @return true if the key exists, false if it does not
-	 */
-	has(key: K): boolean {
-		return this._indexOfKey(this._keys, key) > -1;
-	}
-
-	/**
-	 * Sets the value associated with a given key.
-	 *
-	 * @param key The key to define a value to
-	 * @param value The value to assign
-	 * @return The Map instance
-	 */
-	set(key: K, value: V): Map<K, V> {
-		let index = this._indexOfKey(this._keys, key);
-		index = index < 0 ? this._keys.length : index;
-		this._keys[index] = key;
-		this._values[index] = value;
-		return this;
-	}
+	/* istanbul ignore next */
+	get size(): number { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	clear(): void { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	delete(key: K): boolean { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	entries(): IterableIterator<[K, V]> { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	forEach(callback: (value: V, key: K, mapInstance: Map<K, V>) => any, context?: {}): void { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	get(key: K): V { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	has(key: K): boolean { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	keys(): IterableIterator<K> { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	set(key: K, value: V): Map<K, V> { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	values(): IterableIterator<V> { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	[Symbol.iterator](): IterableIterator<[K, V]> { throw new Error('Abstract method'); };
+	/* istanbul ignore next */
+	[Symbol.toStringTag]: string = 'Map';
 }

--- a/src/Symbol.ts
+++ b/src/Symbol.ts
@@ -61,11 +61,17 @@ export namespace Shim {
 			desc += String(postfix || '');
 			created[desc] = true;
 			name = '@@' + desc;
-			defineProperty(objPrototype, name, {
-				set: function (value: any) {
-					defineProperty(this, name, getValueDescriptor(value));
-				}
-			});
+
+			// FIXME: Temporary guard until the duplicate execution when testing can be
+			// pinned down.
+			if (!Object.getOwnPropertyDescriptor(objPrototype, name)) {
+				defineProperty(objPrototype, name, {
+					set: function (value: any) {
+						defineProperty(this, name, getValueDescriptor(value));
+					}
+				});
+			}
+
 			return name;
 		};
 	}());

--- a/src/WeakMap.ts
+++ b/src/WeakMap.ts
@@ -1,5 +1,7 @@
 import { hasClass } from './decorators';
 import global from './global';
+import { forOf, Iterable } from './iterator';
+import Symbol from './Symbol';
 
 module Shim {
 	const DELETED: any = {};
@@ -24,14 +26,14 @@ module Shim {
 	export class WeakMap<K, V> {
 		private _name: string;
 
-		constructor(iterable?: any) {
+		constructor(iterable?: Array<[K, V]> | Iterable<[K, V]>) {
 			Object.defineProperty(this, '_name', {
 				value: generateName()
 			});
 			if (iterable) {
-				for (const [ key, value ] of iterable) {
-					this.set(key, value);
-				}
+				forOf(iterable, (value: [K, V]) => {
+					this.set(value[0], value[1]);
+				});
 			}
 		}
 
@@ -72,6 +74,8 @@ module Shim {
 			entry.value = value;
 			return this;
 		}
+
+		[Symbol.toStringTag]: string = 'WeakMap';
 	}
 }
 
@@ -88,4 +92,6 @@ export default class WeakMap<K, V> {
 	has(key: K): boolean { throw new Error(); }
 	/* istanbul ignore next */
 	set(key: K, value?: V): WeakMap<K, V> { throw new Error(); }
+	/* istanbul ignore next */
+	[Symbol.toStringTag]: string = 'WeakMap';
 }

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -1,3 +1,4 @@
+import { Iterable } from '../iterator';
 import Promise, { Executor, State, Thenable, isThenable } from '../Promise';
 
 export const Canceled = <State> 4;
@@ -14,12 +15,12 @@ export function isTask<T>(value: any): value is Task<T> {
  * Task is an extension of Promise that supports cancelation.
  */
 export default class Task<T> extends Promise<T> {
-	static all<T>(items: (T | Thenable<T>)[]): Task<T[]> {
-		return <any> super.all(items);
+	static all<T>(iterator: Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): Task<T[]> {
+		return <any> super.all(iterator);
 	}
 
-	static race<T>(items: (T | Thenable<T>)[]): Task<T> {
-		return <any> super.race(items);
+	static race<T>(iterator: Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): Task<T> {
+		return <any> super.race(iterator);
 	}
 
 	static reject<T>(reason: Error): Task<any> {
@@ -177,5 +178,4 @@ export default class Task<T> extends Promise<T> {
 	catch<U>(onRejected: (reason?: Error) => (U | Thenable<U>)): Task<U> {
 		return <any> super.catch(onRejected);
 	}
-
 }

--- a/src/has.ts
+++ b/src/has.ts
@@ -185,3 +185,12 @@ add('es6-set', () => {
 	}
 	return false;
 });
+add('es6-map', function () {
+	if (typeof global.Map === 'function') {
+		// IE11 and older versions of Safari are missing critical ES6 Map functionality
+		const map = new global.Map([ [0, 1] ]);
+		return map.has(0) && typeof map.keys === 'function' &&
+			typeof map.values === 'function' && typeof map.entries === 'function';
+	}
+	return false;
+});

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -73,7 +73,7 @@ export function isArrayLike(value: any): value is ArrayLike<any> {
 
 /**
  * Returns the iterator for an object
- * @param iterable The iterable object to return the itertator for
+ * @param iterable The iterable object to return the iterator for
  */
 export function get<T>(iterable: Iterable<T> | ArrayLike<T>): Iterator<T> {
 	if (isIterable(iterable)) {
@@ -134,5 +134,4 @@ export function forOf<T>(iterable: Iterable<T> | ArrayLike<T> | string, callback
 			result = iterator.next();
 		}
 	}
-
 }

--- a/tests/unit/Map.ts
+++ b/tests/unit/Map.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { forOf, isIterable, IterableIterator, ShimIterator } from 'src/iterator';
 import Map from 'src/Map';
 
 let map: Map<any, any>;
@@ -27,12 +28,12 @@ registerSuite({
 			});
 		},
 
-		'array-like data'() {
+		'iterator data'() {
 			assert.doesNotThrow(function () {
-				map = new Map<number, string>({
+				map = new Map<number, string>(<any> new ShimIterator<[number, string]>({
 					length: 1,
 					0: [ 3, 'bar' ]
-				});
+				}));
 			});
 		}
 	},
@@ -73,6 +74,31 @@ registerSuite({
 		'key not found'() {
 			assert.isFalse(map.delete('foo'));
 		}
+	},
+
+	entries() {
+		function foo() {}
+		const array: any[] = [];
+		const object = Object.create(null);
+		mapArgs = [
+			[ 0, 0 ],
+			[ 1, '1' ],
+			[ 2, object ],
+			[ 3, array ],
+			[ 4, foo ],
+			[ 5, undefined ]
+		];
+		map = new Map<number, any>(mapArgs);
+		const entries: IterableIterator<[number, any]> = map.entries();
+
+		assert.isTrue(isIterable(entries), 'Returns an iterable.');
+
+		let i: number = 0;
+		forOf(entries, function (value: [ number, any ]): void {
+			assert.strictEqual(value[0], mapArgs[i][0]);
+			assert.strictEqual(value[1], mapArgs[i][1]);
+			i++;
+		});
 	},
 
 	forEach: {
@@ -145,6 +171,23 @@ registerSuite({
 		}
 	},
 
+	keys() {
+		mapArgs = '012345'.split('').map(function (value: string) {
+			const numeric = Number(value);
+			return [ numeric, numeric ];
+		});
+		map = new Map<number, number>(mapArgs);
+		const keys: IterableIterator<number> = map.keys();
+
+		assert.isTrue(isIterable(keys), 'Returns an iterable.');
+
+		let i: number = 0;
+		forOf(keys, function (value: number): void {
+			assert.strictEqual(value, mapArgs[i][0]);
+			i++;
+		});
+	},
+
 	set: {
 		'number key'() {
 			map = new Map<number, string>();
@@ -203,5 +246,29 @@ registerSuite({
 			assert.strictEqual(map.size, 1,
 				'size should remain the same after setting an existing key');
 		}
+	},
+
+	values() {
+		function foo() {}
+		const array: any[] = [];
+		const object = Object.create(null);
+		mapArgs = [
+			[ 0, 0 ],
+			[ 1, '1' ],
+			[ 2, object ],
+			[ 3, array ],
+			[ 4, foo ],
+			[ 5, undefined ]
+		];
+		map = new Map<number, any>(mapArgs);
+		const values: IterableIterator<any> = map.values();
+
+		assert.isTrue(isIterable(values), 'Returns an iterable.');
+
+		let i: number = 0;
+		forOf(values, function (value: any): void {
+			assert.strictEqual(value, mapArgs[i][1]);
+			i++;
+		});
 	}
 });

--- a/tests/unit/WeakMap.ts
+++ b/tests/unit/WeakMap.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { ShimIterator } from 'src/iterator';
 import WeakMap from 'src/WeakMap';
 
 interface Key {}
@@ -14,13 +15,27 @@ registerSuite({
 			assert.instanceOf(map, WeakMap, 'map should be an instance of WeakMap');
 		},
 
-		'iterable'() {
+		'array'() {
 			const key1: Key = {};
 			const key2: Key = {};
 			const map = new WeakMap<Key, number>([
 				[ key1, 1 ],
 				[ key2, 2 ]
 			]);
+
+			assert.isTrue(map.has(key1), 'key1 should be in map');
+			assert.isTrue(map.has(key2), 'key2 should be in map');
+			assert.strictEqual(map.get(key1), 1, 'key1 should equal 1');
+			assert.strictEqual(map.get(key2), 2, 'key2 should equal 2');
+		},
+
+		'iterable'() {
+			const key1: Key = {};
+			const key2: Key = {};
+			const map = new WeakMap<Key, number>(new ShimIterator<[Key, number]>([
+				[ key1, 1 ],
+				[ key2, 2 ]
+			]));
 
 			assert.isTrue(map.has(key1), 'key1 should be in map');
 			assert.isTrue(map.has(key2), 'key2 should be in map');

--- a/tests/unit/array.ts
+++ b/tests/unit/array.ts
@@ -2,6 +2,8 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as array from 'src/array';
 import has, { add as hasAdd, TestResult } from 'src/has';
+import { Iterator, ShimIterator } from 'src/iterator';
+import Symbol from 'src/Symbol';
 import { mixin } from 'dojo/lang';
 
 function assertFrom(arrayable: any, expected: any[]) {
@@ -135,6 +137,31 @@ registerSuite({
 				'1': 'one',
 				'2': 'two'
 			}, []);
+		},
+
+		'from iterator': {
+			'ShimIterator': function () {
+				assertFrom(new ShimIterator({
+					0: 'zero',
+					1: 'one',
+					2: 'two',
+					length: 3
+				}), [ 'zero', 'one', 'two' ]);
+			},
+
+			'Custom iterator': function () {
+				const iterator: Iterator<number> = <any> {
+					[Symbol.iterator]: function () {
+						return {
+							index: 0,
+							next: function () {
+								return this.index < 5 ? { value: this.index++ } : { done: true };
+							}
+						};
+					}
+				};
+				assertFrom(iterator, [ 0, 1, 2, 3, 4 ]);
+			}
 		},
 
 		'from boolean': function () {

--- a/tests/unit/async/iteration.ts
+++ b/tests/unit/async/iteration.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as iteration from 'src/async/iteration';
+import { ShimIterator } from 'src/iterator';
 import Promise from 'src/Promise';
 import { isEventuallyRejected, throwImmediatly } from '../../support/util';
 
@@ -22,7 +23,7 @@ interface ControlledPromise<T> extends Promise<T> {
 function createTriggerablePromise<T>(): ControlledPromise<T> {
 	let resolveFunc: any;
 	let rejectFunc: any;
-	let dfd: ControlledPromise<T>  = <ControlledPromise<T>> new Promise<T>(function (resolve, reject) {
+	const dfd: ControlledPromise<T>  = <ControlledPromise<T>> new Promise<T>(function (resolve, reject) {
 		resolveFunc = <any> resolve;
 		rejectFunc = <any> reject;
 	});
@@ -32,7 +33,7 @@ function createTriggerablePromise<T>(): ControlledPromise<T> {
 }
 
 function createTriggerablePromises<T>(amount: number): ControlledPromise<T>[] {
-	let list = Array(amount);
+	const list = Array(amount);
 	for (amount--; amount >= 0; amount--) {
 		list[amount] = createTriggerablePromise<T>();
 	}
@@ -55,6 +56,10 @@ function assertFalse (value: boolean): void {
 	assert.isFalse(value);
 }
 
+function getIterable(useIterator: boolean, values: any[]): any {
+	return useIterator ? new ShimIterator(values) : values;
+}
+
 function join(current: string, value: string): string {
 	return current + value;
 }
@@ -64,124 +69,141 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 		return solutions[test.parent.name][test.name];
 	}
 
+	function getTests(useIterator: boolean = false): any {
+		return {
+			'synchronous values': {
+				'no matching values; returns undefined': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ 'non-matching' ];
+					const iterable = getIterable(useIterator, values);
+					return findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+				},
+
+				'one matching value': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ 'non-matching', 'hello' ];
+					const iterable = getIterable(useIterator, values);
+					return findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+				},
+
+				'multiple matching values; only returns the first': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ 'non-matching', 'hello', 'world' ];
+					const iterable = getIterable(useIterator, values);
+					return findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+				}
+			},
+
+			'asynchronous values': {
+				'no matching values; returns undefined': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+
+					values[0].resolve('non-matching');
+
+					return promise;
+				},
+
+				'one matching value': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ createTriggerablePromise(), createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+
+					values[0].resolve('non-matching');
+					values[1].resolve('hello');
+
+					return promise;
+				},
+
+				'multiple matching values; only returns the first': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+
+					values[0].resolve('non-matching');
+					values[1].resolve('hello');
+					values[2].resolve('world');
+
+					return promise;
+				},
+
+				'mixed synchronous and asynchronous values': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ createTriggerablePromise(), 'hello', createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+						assert.strictEqual(result, expected);
+					});
+
+					( <ControlledPromise<string>> values[0]).resolve('non-matching');
+					( <ControlledPromise<string>> values[2]).resolve('world');
+
+					return promise;
+				},
+
+				'rejected promise value': function () {
+					const values = [ createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = findMethod(iterable, helloWorldTest);
+
+					values[0].reject();
+
+					return isEventuallyRejected(promise);
+				}
+			},
+
+			'asynchronous callback': {
+				'one asynchronous result': function () {
+					const expected: any = getExpectedSolution(this);
+					const values = [ 'value1' ];
+					const iterable = getIterable(useIterator, values);
+					const result = [ createTriggerablePromise() ];
+					const promise = findMethod(iterable, function (value, i) {
+						return result[i];
+					}).then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+
+					result[0].resolve(true);
+
+					return promise;
+				},
+
+				'asynchronous result with an eventually rejected promise': function () {
+					const values = [ 'value1' ];
+					const iterable = getIterable(useIterator, values);
+					const result = [ createTriggerablePromise() ];
+					const promise = findMethod(iterable, function (value, i) {
+						return result[i];
+					});
+
+					result[0].reject();
+
+					return isEventuallyRejected(promise);
+				}
+			}
+		};
+	}
+
 	return {
-		'synchronous values': {
-			'no matching values; returns undefined': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ 'non-matching' ];
-				return findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-			},
-
-			'one matching value': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ 'non-matching', 'hello' ];
-				return findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-			},
-
-			'multiple matching values; only returns the first': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ 'non-matching', 'hello', 'world' ];
-				return findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-			}
-		},
-
-		'asynchronous values': {
-			'no matching values; returns undefined': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ createTriggerablePromise() ];
-				let promise = findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-
-				values[0].resolve('non-matching');
-
-				return promise;
-			},
-
-			'one matching value': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ createTriggerablePromise(), createTriggerablePromise() ];
-				let promise = findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-
-				values[0].resolve('non-matching');
-				values[1].resolve('hello');
-
-				return promise;
-			},
-
-			'multiple matching values; only returns the first': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				let promise = findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-
-				values[0].resolve('non-matching');
-				values[1].resolve('hello');
-				values[2].resolve('world');
-
-				return promise;
-			},
-
-			'mixed synchronous and asynchronous values': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ createTriggerablePromise(), 'hello', createTriggerablePromise() ];
-				let promise = findMethod(values, helloWorldTest).then(function (result) {
-					assert.strictEqual(result, expected);
-				});
-
-				( <ControlledPromise<string>> values[0]).resolve('non-matching');
-				( <ControlledPromise<string>> values[2]).resolve('world');
-
-				return promise;
-			},
-
-			'rejected promise value': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = findMethod(values, helloWorldTest);
-
-				values[0].reject();
-
-				return isEventuallyRejected(promise);
-			}
-		},
-
-		'asynchronous callback': {
-			'one asynchronous result': function () {
-				let expected: any = getExpectedSolution(this);
-				let values = [ 'value1' ];
-				let result = [ createTriggerablePromise() ];
-				let promise = findMethod(values, function (value, i) {
-					return result[i];
-				}).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				result[0].resolve(true);
-
-				return promise;
-			},
-
-			'asynchronous result with an eventually rejected promise': function () {
-				let values = [ 'value1' ];
-				let result = [ createTriggerablePromise() ];
-				let promise = findMethod(values, function (value, i) {
-					return result[i];
-				});
-
-				result[0].reject();
-
-				return isEventuallyRejected(promise);
-			}
-		}
+		'array-like value': getTests(false),
+		'iterator value': getTests(true)
 	};
 }
 
@@ -190,183 +212,203 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 		return solutions[test.parent.name][test.name];
 	}
 
-	return {
-		'synchronous values': {
-			'reduce an empty array without initial value is eventually rejected': function () {
-				let promise = (<any> reduceMethod)([]);
+	function getTests(useIterator: boolean = false): any {
+		const valueType = useIterator ? 'iterator' : 'array';
 
-				return isEventuallyRejected(promise);
+		return {
+			'synchronous values': {
+				[`reduce an empty ${valueType} without initial value is eventually rejected`]: function () {
+					const value = getIterable(useIterator, []);
+					const promise = (<any> reduceMethod)(value);
+
+					return isEventuallyRejected(promise);
+				},
+
+				'reduce a single value without an initial value; should not call callback': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = [ 'h' ];
+					const iterable = getIterable(useIterator, values);
+					return reduceMethod(iterable, throwImmediatly).then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+				},
+
+				'reduce multiple values': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = [ 'h', 'e', 'l', 'l', 'o' ];
+					const iterable = getIterable(useIterator, values);
+					return reduceMethod(iterable, join).then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+				},
+
+				'reduce multiple values with initializer': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = [ 'w', 'o', 'r', 'l', 'd' ];
+					const iterable = getIterable(useIterator, values);
+					return reduceMethod(iterable, join, 'hello ').then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+				}
 			},
 
-			'reduce a single value without an initial value; should not call callback': function () {
-				let expected: any = getExpectedSolution(this);
+			'asynchronous values': {
+				'reduce a single value without initial value; should not call callback': function () {
+					const expected: any = getExpectedSolution(this);
 
-				let values = [ 'h' ];
-				return reduceMethod(values, throwImmediatly).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-			},
-
-			'reduce multiple values': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = [ 'h', 'e', 'l', 'l', 'o' ];
-				return reduceMethod(values, join).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-			},
-
-			'reduce multiple values with initializer': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = [ 'w', 'o', 'r', 'l', 'd' ];
-				return reduceMethod(values, join, 'hello ').then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-			},
-
-			'reduces a sparse array': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = Array(10);
-				values[1] = 'h';
-				values[3] = 'e';
-				values[5] = 'l';
-				values[7] = 'l';
-				values[9] = 'o';
-				return reduceMethod(values, join).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-			}
-		},
-
-		'asynchronous values': {
-			'reduce a single value without initial value; should not call callback': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = [ createTriggerablePromise() ];
-				let promise = reduceMethod(values, throwImmediatly).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				values[0].resolve('h');
-
-				return promise;
-			},
-
-			'reduce multiple values': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = createTriggerablePromises(5);
-				let promise = reduceMethod(values, join).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				values[0].resolve('h');
-				values[1].resolve('e');
-				values[2].resolve('l');
-				values[3].resolve('l');
-				values[4].resolve('o');
-
-				return promise;
-			},
-
-			'reduce multiple values with initializer': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = createTriggerablePromises(5);
-				let promise = reduceMethod(values, join, 'hello ').then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				values[0].resolve('w');
-				values[1].resolve('o');
-				values[2].resolve('r');
-				values[3].resolve('l');
-				values[4].resolve('d');
-
-				return promise;
-			},
-
-			'reduce multiple mixed values': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = [ 'h', 'e', 'l', 'l', createTriggerablePromise()];
-				let promise = reduceMethod(values, join).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				(<ControlledPromise<{}>> values[4]).resolve('o');
-
-				return promise;
-			},
-
-			'one promised value is rejected': function () {
-				let values = createTriggerablePromises(1);
-				let promise = reduceMethod(values, join);
-
-				values[0].reject();
-
-				return isEventuallyRejected(promise);
-			},
-
-			'reduces a sparse array': function () {
-				let expected: any = getExpectedSolution(this);
-
-				let values = Array(10);
-				values[1] = createTriggerablePromise();
-				values[4] = 'e';
-				values[5] = 'l';
-				values[7] = 'l';
-				values[8] = 'o';
-
-				let promise = reduceMethod(values, join).then(function (value) {
-					assert.strictEqual(value, expected);
-				});
-
-				values[1].resolve('h');
-
-				return promise;
-			}
-		},
-
-		'asynchronous callback': {
-			'multiple asynchronous reductions': function () {
-				let { step, initialIndex, callbackValues } = getExpectedSolution(this);
-				let values: string[] = 'hello'.split('');
-				let results = createTriggerablePromises(values.length);
-				let previousIndex = initialIndex;
-				let promise = reduceMethod(values,
-					function (previous: string, value: string, index: number, array: string[]): Promise<string> {
-						assert.strictEqual(value, values[index]);
-						assert.strictEqual(index, previousIndex + step);
-						previousIndex = index;
-						assert.deepEqual(values, array);
-						if (index !== initialIndex) {
-							return results[index - step].then(function (result) {
-								assert.strictEqual(previous, result);
-								return results[index];
-							});
-						}
-						return results[index];
+					const values = [ createTriggerablePromise() ];
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, throwImmediatly).then(function (value) {
+						assert.strictEqual(value, expected);
 					});
 
-				results.forEach(function (result, i) {
-					result.resolve(callbackValues[i]);
-				});
+					values[0].resolve('h');
 
-				return promise;
+					return promise;
+				},
+
+				'reduce multiple values': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = createTriggerablePromises(5);
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, join).then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+
+					values[0].resolve('h');
+					values[1].resolve('e');
+					values[2].resolve('l');
+					values[3].resolve('l');
+					values[4].resolve('o');
+
+					return promise;
+				},
+
+				'reduce multiple values with initializer': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = createTriggerablePromises(5);
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, join, 'hello ').then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+
+					values[0].resolve('w');
+					values[1].resolve('o');
+					values[2].resolve('r');
+					values[3].resolve('l');
+					values[4].resolve('d');
+
+					return promise;
+				},
+
+				'reduce multiple mixed values': function () {
+					const expected: any = getExpectedSolution(this);
+
+					const values = [ 'h', 'e', 'l', 'l', createTriggerablePromise()];
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, join).then(function (value) {
+						assert.strictEqual(value, expected);
+					});
+
+					(<ControlledPromise<{}>> values[4]).resolve('o');
+
+					return promise;
+				},
+
+				'one promised value is rejected': function () {
+					const values = createTriggerablePromises(1);
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, join);
+
+					values[0].reject();
+
+					return isEventuallyRejected(promise);
+				}
 			},
 
-			'one promised reduction is rejected': function () {
-				let values: string[] = 'hello'.split('');
-				let promise = reduceMethod(values, function (): Promise<string> {
-					throw new Error('expected');
-				});
+			'asynchronous callback': {
+				'multiple asynchronous reductions': function () {
+					const { step, initialIndex, callbackValues } = getExpectedSolution(this);
+					const values: string[] = 'hello'.split('');
+					const iterable = getIterable(useIterator, values);
+					const results = createTriggerablePromises(values.length);
+					let previousIndex = initialIndex;
+					const promise = reduceMethod(iterable,
+						function (previous: string, value: string, index: number, array: string[]): Promise<string> {
+							assert.strictEqual(value, values[index]);
+							assert.strictEqual(index, previousIndex + step);
+							previousIndex = index;
+							assert.deepEqual(values, array);
+							if (index !== initialIndex) {
+								return results[index - step].then(function (result) {
+									assert.strictEqual(previous, result);
+									return results[index];
+								});
+							}
+							return results[index];
+						});
 
-				return isEventuallyRejected(promise);
+					results.forEach(function (result, i) {
+						result.resolve(callbackValues[i]);
+					});
+
+					return promise;
+				},
+
+				'one promised reduction is rejected': function () {
+					const values: string[] = 'hello'.split('');
+					const iterable = getIterable(useIterator, values);
+					const promise = reduceMethod(iterable, function (): Promise<string> {
+						throw new Error('expected');
+					});
+
+					return isEventuallyRejected(promise);
+				}
 			}
-		}
+		};
+	}
+
+	const arrayLikeTests = getTests(false);
+	arrayLikeTests['synchronous values']['reduces a sparse array'] = function () {
+		const expected: any = getExpectedSolution(this);
+
+		const values = Array(10);
+		values[1] = 'h';
+		values[3] = 'e';
+		values[5] = 'l';
+		values[7] = 'l';
+		values[9] = 'o';
+		return reduceMethod(values, join).then(function (value) {
+			assert.strictEqual(value, expected);
+		});
+	};
+	arrayLikeTests['asynchronous values']['reduces a sparse array'] = function () {
+		const expected: any = getExpectedSolution(this);
+
+		const values = Array(10);
+		values[1] = createTriggerablePromise();
+		values[4] = 'e';
+		values[5] = 'l';
+		values[7] = 'l';
+		values[8] = 'o';
+
+		const promise = reduceMethod(values, join).then(function (value) {
+			assert.strictEqual(value, expected);
+		});
+
+		values[1].resolve('h');
+
+		return promise;
+	};
+
+	return {
+		'array-like value': arrayLikeTests,
+		'iterator value': getTests(true)
 	};
 };
 
@@ -375,91 +417,106 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 		return solutions[test.parent.name][test.name];
 	}
 
-	function testAsynchronousValues() {
-		let { results, assertion } = getParameters(this);
-		let values = createTriggerablePromises(results.length);
-		let promise = haltingMethod(values, helloWorldTest).then(assertion);
+	function getTests(useIterator: boolean = false): any {
+		function testAsynchronousValues() {
+			const { results, assertion } = getParameters(this);
+			const values = createTriggerablePromises(results.length);
+			const iterable = getIterable(useIterator, values);
+			const promise = haltingMethod(iterable, helloWorldTest).then(assertion);
 
-		values.forEach(function (value, index) {
-			value.resolve(results[index]);
-		});
-		return promise;
+			values.forEach(function (value, index) {
+				value.resolve(results[index]);
+			});
+			return promise;
+		}
+
+		return {
+			'synchronous values': {
+				'one synchronous value': function () {
+					const { values, assertion } = getParameters(this);
+					const iterable = getIterable(useIterator, values);
+					return haltingMethod(iterable, helloWorldTest).then(assertion);
+				},
+
+				'multiple synchronous values': function () {
+					const { values, assertion } = getParameters(this);
+					const iterable = getIterable(useIterator, values);
+					return haltingMethod(iterable, helloWorldTest).then(assertion);
+				},
+
+				'multiple synchronous values with failure': function () {
+					const { values, assertion } = getParameters(this);
+					const iterable = getIterable(useIterator, values);
+					return haltingMethod(iterable, helloWorldTest).then(assertion);
+				}
+			},
+
+			'asynchronous values': {
+				'one asynchronous value': function () {
+					return testAsynchronousValues.call(this);
+				},
+
+				'multiple asynchronous values': function () {
+					return testAsynchronousValues.call(this);
+				},
+
+				'multiple asynchronous values with failure': function () {
+					return testAsynchronousValues.call(this);
+				},
+
+				'mixed synchronous and asynchronous values': function () {
+					const { results, assertion } = getParameters(this);
+					const values: any[] = [
+						results[0],
+						createTriggerablePromise<string>()
+					];
+					const iterable = getIterable(useIterator, values);
+					const promise = haltingMethod(iterable, helloWorldTest).then(assertion);
+
+					values[1].resolve(results[1]);
+					return promise;
+				},
+
+				'rejected promise value': function () {
+					const values: any[] = [
+						'hello',
+						createTriggerablePromise<string>()
+					];
+					const iterable = getIterable(useIterator, values);
+					const promise = haltingMethod(iterable, helloWorldTest);
+
+					values[1].reject();
+
+					return isEventuallyRejected(promise);
+				}
+			},
+
+			'asynchronous callback': {
+				'callback returns asynchronous results': function () {
+					const { resolution, assertion } = getParameters(this);
+					const values: any[] = [ 'unimportant', 'values' ];
+					const iterable = getIterable(useIterator, values);
+					return haltingMethod(iterable, function () {
+						return Promise.resolve(resolution);
+					}).then(assertion);
+				},
+
+				'callback returns asynchronous results with eventually rejected promise': function () {
+					const values: any[] = [ 'unimportant', 'values' ];
+					const iterable = getIterable(useIterator, values);
+					const promise = haltingMethod(iterable, <any> function () {
+						throw new Error('kablewie!');
+					});
+
+					return isEventuallyRejected(promise);
+				}
+			}
+		};
 	}
 
 	return {
-		'synchronous values': {
-			'one synchronous value': function () {
-				let { values, assertion } = getParameters(this);
-				return haltingMethod(values, helloWorldTest).then(assertion);
-			},
-
-			'multiple synchronous values': function () {
-				let { values, assertion } = getParameters(this);
-				return haltingMethod(values, helloWorldTest).then(assertion);
-			},
-
-			'multiple synchronous values with failure': function () {
-				let { values, assertion } = getParameters(this);
-				return haltingMethod(values, helloWorldTest).then(assertion);
-			}
-		},
-
-		'asynchronous values': {
-			'one asynchronous value': function () {
-				return testAsynchronousValues.call(this);
-			},
-
-			'multiple asynchronous values': function () {
-				return testAsynchronousValues.call(this);
-			},
-
-			'multiple asynchronous values with failure': function () {
-				return testAsynchronousValues.call(this);
-			},
-
-			'mixed synchronous and asynchronous values': function () {
-				let { results, assertion } = getParameters(this);
-				let values: any[] = [
-					results[0],
-					createTriggerablePromise<string>()
-				];
-				let promise = haltingMethod(values, helloWorldTest).then(assertion);
-
-				values[1].resolve(results[1]);
-				return promise;
-			},
-
-			'rejected promise value': function () {
-				let values: any[] = [
-					'hello',
-					createTriggerablePromise<string>()
-				];
-				let promise = haltingMethod(values, helloWorldTest);
-
-				values[1].reject();
-
-				return isEventuallyRejected(promise);
-			}
-		},
-
-		'asynchronous callback': {
-			'callback returns asynchronous results': function () {
-				let { resolution, assertion } = getParameters(this);
-				let values: any[] = ['unimportant', 'values'];
-				return haltingMethod(values, function () {
-					return Promise.resolve(resolution);
-				}).then(assertion);
-			},
-
-			'callback returns asynchronous results with eventually rejected promise': function () {
-				let values: any[] = ['unimportant', 'values'];
-				let promise = haltingMethod(values, <any> function () {
-					throw new Error('kablewie!');
-				});
-
-				return isEventuallyRejected(promise);
-			}
-		}
+		'array-like value': getTests(false),
+		'iterator value': getTests(true)
 	};
 }
 
@@ -467,7 +524,7 @@ registerSuite({
 	name: 'async/iteration',
 
 	'.every<T>()': (function () {
-		let tests: any = haltImmediatelyTests(iteration.every, {
+		const tests: any = haltImmediatelyTests(iteration.every, {
 				'synchronous values': {
 					'one synchronous value': { values: [ 'hello' ], assertion: assertTrue },
 					'multiple synchronous values': { values: [ 'hello', 'world' ], assertion: assertTrue },
@@ -484,14 +541,15 @@ registerSuite({
 				}
 			}
 		);
+		const asyncArrayTests = tests['array-like value']['asynchronous callback'];
 
-		tests['asynchronous callback']['callback returns multiple asynchronous results with a failure and every exits immediately'] = function () {
-			let values: any[] = ['unimportant', 'values'];
-			let response: Promise<boolean>[] = [
+		asyncArrayTests['callback returns multiple asynchronous results with a failure and every exits immediately'] = function () {
+			const values: any[] = ['unimportant', 'values'];
+			const response: Promise<boolean>[] = [
 				createTriggerablePromise(),
 				createTriggerablePromise()
 			];
-			let promise = iteration.every<any>(values, function (value: any, i: number) {
+			const promise = iteration.every<any>(values, function (value: any, i: number) {
 				return response[i];
 			}).then(assertFalse);
 
@@ -503,112 +561,131 @@ registerSuite({
 		return tests;
 	})(),
 
-	'.filter()': {
-		'synchronous values': {
-			'one passing value': function () {
-				let values = ['hello'];
-				return iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, values);
-				});
-			},
+	'.filter()': (function () {
+		function getTests(useIterator: boolean = false): any {
+			return {
+				'synchronous values': {
+					'one passing value': function () {
+						const values = [ 'hello' ];
+						const iterable = getIterable(useIterator, values);
+						return iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, values);
+						});
+					},
 
-			'one failing value': function () {
-				let values = ['failing value'];
-				return iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, []);
-				});
-			},
+					'one failing value': function () {
+						const values = [ 'failing value' ];
+						const iterable = getIterable(useIterator, values);
+						return iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, []);
+						});
+					},
 
-			'mixed passing and failing values': function () {
-				let values = ['hello', 'failing value', 'world'];
-				return iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, ['hello', 'world']);
-				});
-			}
-		},
+					'mixed passing and failing values': function () {
+						const values = [ 'hello', 'failing value', 'world' ];
+						const iterable = getIterable(useIterator, values);
+						return iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, [ 'hello', 'world' ]);
+						});
+					}
+				},
 
-		'asynchronous values': {
-			'one passing value': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, [ 'hello' ]);
-				});
+				'asynchronous values': {
+					'one passing value': function () {
+						const values = [ createTriggerablePromise() ];
+						const iterable = getIterable(useIterator, values);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, [ 'hello' ]);
+						});
 
-				values[0].resolve('hello');
+						values[0].resolve('hello');
 
-				return promise;
-			},
+						return promise;
+					},
 
-			'one failing value': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, [ ]);
-				});
+					'one failing value': function () {
+						const values = [ createTriggerablePromise() ];
+						const iterable = getIterable(useIterator, values);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, [ ]);
+						});
 
-				values[0].resolve('failing value');
+						values[0].resolve('failing value');
 
-				return promise;
-			},
+						return promise;
+					},
 
-			'mixed passing and failing values': function () {
-				let values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				let promise = iteration.filter(values, helloWorldTest).then(function (results) {
-					assert.deepEqual(results, [ 'hello', 'world' ]);
-				});
+					'mixed passing and failing values': function () {
+						const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+						const iterable = getIterable(useIterator, values);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
+							assert.deepEqual(results, [ 'hello', 'world' ]);
+						});
 
-				values[0].resolve('hello');
-				values[2].resolve('world');
-				values[1].resolve('failing value');
+						values[0].resolve('hello');
+						values[2].resolve('world');
+						values[1].resolve('failing value');
 
-				return promise;
-			},
+						return promise;
+					},
 
-			'rejected value': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = iteration.filter(values, helloWorldTest);
+					'rejected value': function () {
+						const values = [ createTriggerablePromise() ];
+						const iterable = getIterable(useIterator, values);
+						const promise = iteration.filter(iterable, helloWorldTest);
 
-				values[0].reject(new Error('kaboom!'));
+						values[0].reject(new Error('kaboom!'));
 
-				return isEventuallyRejected(promise);
-			}
-		},
+						return isEventuallyRejected(promise);
+					}
+				},
 
-		'asynchronous callback': {
-			'one asynchronous result': function () {
-				let values = [ 'unimportant' ];
-				return iteration.filter(values, function () {
-					return Promise.resolve(true);
-				}).then(function (results) {
-					assert.deepEqual(results, values);
-				});
-			},
+				'asynchronous callback': {
+					'one asynchronous result': function () {
+						const values = [ 'unimportant' ];
+						const iterable = getIterable(useIterator, values);
+						return iteration.filter(iterable, function () {
+							return Promise.resolve(true);
+						}).then(function (results) {
+							assert.deepEqual(results, values);
+						});
+					},
 
-			'asynchronous results with an eventually rejected promise': function () {
-				let values = [ 'unimportant' ];
-				let promise = iteration.filter(values, <any> function () {
-					throw new Error('kaboom!');
-				});
+					'asynchronous results with an eventually rejected promise': function () {
+						const values = [ 'unimportant' ];
+						const iterable = getIterable(useIterator, values);
+						const promise = iteration.filter(iterable, <any> function () {
+							throw new Error('kaboom!');
+						});
 
-				return isEventuallyRejected(promise);
-			},
+						return isEventuallyRejected(promise);
+					},
 
-			'mixed matched/unmatched asynchronous results': function () {
-				let values = [ 'hello', 'world', 'non-matching' ];
-				let pass = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
-				let promise = iteration.filter(values, function (value, i) {
-					return pass[i];
-				}).then(function (results) {
-					assert.deepEqual(results, [ 'hello', 'world' ]);
-				});
+					'mixed matched/unmatched asynchronous results': function () {
+						const values = [ 'hello', 'world', 'non-matching' ];
+						const iterable = getIterable(useIterator, values);
+						const pass = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
+						const promise = iteration.filter(iterable, function (value, i) {
+							return pass[i];
+						}).then(function (results) {
+							assert.deepEqual(results, [ 'hello', 'world' ]);
+						});
 
-				pass[0].resolve(true);
-				pass[1].resolve(true);
-				pass[2].resolve(false);
+						pass[0].resolve(true);
+						pass[1].resolve(true);
+						pass[2].resolve(false);
 
-				return promise;
-			}
+						return promise;
+					}
+				}
+			};
 		}
-	},
+
+		return {
+			'array-like value': getTests(false),
+			'iterator value': getTests(true)
+		};
+	})(),
 
 	'.find()': findTests(iteration.find, { // solutions
 		'synchronous values': {
@@ -647,14 +724,14 @@ registerSuite({
 	'.map()': {
 		'synchronous values': {
 			'transform a single value': function () {
-				let values = [ 1 ];
+				const values = [ 1 ];
 				return iteration.map(values, doublerMapper).then(function (values) {
 					assert.deepEqual(values, [ 2 ]);
 				});
 			},
 
 			'transform multiple values': function () {
-				let values = [ 1, 2, 3 ];
+				const values = [ 1, 2, 3 ];
 				return iteration.map(values, doublerMapper).then(function (values) {
 					assert.deepEqual(values, [ 2, 4, 6 ]);
 				});
@@ -663,8 +740,8 @@ registerSuite({
 
 		'asynchronous values': {
 			'transform a single value': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = iteration.map(values, doublerMapper).then(function (values) {
+				const values = [ createTriggerablePromise() ];
+				const promise = iteration.map(values, doublerMapper).then(function (values) {
 					assert.deepEqual(values, [ 2 ]);
 				});
 
@@ -674,8 +751,8 @@ registerSuite({
 			},
 
 			'transform multiple values': function () {
-				let values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				let promise = iteration.map(values, doublerMapper).then(function (values) {
+				const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+				const promise = iteration.map(values, doublerMapper).then(function (values) {
 					assert.deepEqual(values, [ 2, 4, 6 ]);
 				});
 
@@ -687,8 +764,8 @@ registerSuite({
 			},
 
 			'transform multiple mixed values': function () {
-				let values: any[] = [ createTriggerablePromise(), 2, createTriggerablePromise(), 4 ];
-				let promise = iteration.map(values, doublerMapper).then(function (values) {
+				const values: any[] = [ createTriggerablePromise(), 2, createTriggerablePromise(), 4 ];
+				const promise = iteration.map(values, doublerMapper).then(function (values) {
 					assert.deepEqual(values, [ 2, 4, 6, 8 ]);
 				});
 
@@ -699,8 +776,8 @@ registerSuite({
 			},
 
 			'one promised value is rejected': function () {
-				let values = [ createTriggerablePromise() ];
-				let promise = iteration.map(values, doublerMapper);
+				const values = [ createTriggerablePromise() ];
+				const promise = iteration.map(values, doublerMapper);
 
 				values[0].reject();
 
@@ -710,9 +787,9 @@ registerSuite({
 
 		'asynchronous callback': {
 			'one asynchronous mapping': function () {
-				let values = [ 'unused' ];
-				let results = [ createTriggerablePromise() ];
-				let promise = iteration.map(values, function (value, i) {
+				const values = [ 'unused' ];
+				const results = [ createTriggerablePromise() ];
+				const promise = iteration.map(values, function (value, i) {
 					return results[i];
 				}).then(function (values) {
 					assert.deepEqual(values, [ 2 ]);
@@ -724,9 +801,9 @@ registerSuite({
 			},
 
 			'multiple asynchronous mappings': function () {
-				let values = [ 'unused', 'unused', 'unused' ];
-				let results = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				let promise = iteration.map(values, function (value, i) {
+				const values = [ 'unused', 'unused', 'unused' ];
+				const results = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+				const promise = iteration.map(values, function (value, i) {
 					return results[i];
 				}).then(function (values) {
 					assert.deepEqual(values, [ 2, 4, 6 ]);
@@ -740,9 +817,9 @@ registerSuite({
 			},
 
 			'one promised mapping is rejected': function () {
-				let values = [ 'unused' ];
-				let results = [ createTriggerablePromise() ];
-				let promise = iteration.map(values, function (value, i) {
+				const values = [ 'unused' ];
+				const results = [ createTriggerablePromise() ];
+				const promise = iteration.map(values, function (value, i) {
 					return results[i];
 				});
 
@@ -805,10 +882,10 @@ registerSuite({
 		},
 
 		'synchronous values': function () {
-			let values = 'hello'.split('');
-			let expected = values;
+			const values = 'hello'.split('');
+			const expected = values;
 
-			let composite: number[] = [];
+			const composite: number[] = [];
 			return iteration.series(values, function (value, index, array) {
 				composite.push(index);
 				assert.deepEqual(array, expected);
@@ -820,11 +897,11 @@ registerSuite({
 		},
 
 		'asynchronous values': function () {
-			let values = createTriggerablePromises(5);
-			let expected = 'hello'.split('');
+			const values = createTriggerablePromises(5);
+			const expected = 'hello'.split('');
 
-			let composite: number[] = [];
-			let promise = iteration.series(values, function (value, index, array) {
+			const composite: number[] = [];
+			const promise = iteration.series(values, function (value, index, array) {
 				composite.push(index);
 				assert.deepEqual(array, expected);
 				return value;
@@ -843,9 +920,9 @@ registerSuite({
 		},
 
 		'asynchronous callback': function () {
-			let values = 'hello'.split('');
-			let results = createTriggerablePromises(5);
-			let promise = iteration.series(values, function (value, index, array) {
+			const values = 'hello'.split('');
+			const results = createTriggerablePromises(5);
+			const promise = iteration.series(values, function (value, index, array) {
 				assert.strictEqual(value, array[index]);
 				return results[index].then(function () {
 					return index;
@@ -865,7 +942,7 @@ registerSuite({
 	},
 
 	'.some()': (function () {
-		let tests: any = haltImmediatelyTests(iteration.some, {
+		const tests: any = haltImmediatelyTests(iteration.some, {
 				'synchronous values': {
 					'one synchronous value': { values: [ 'hello' ], assertion: assertTrue },
 					'multiple synchronous values': { values: [ 'non-matching', 'world' ], assertion: assertTrue },
@@ -882,11 +959,12 @@ registerSuite({
 				}
 			}
 		);
+		const asyncArrayTests = tests['array-like value']['asynchronous callback'];
 
-		tests['asynchronous callback']['callback returns multiple asynchronous results with a match and every exits immediately'] = function (): Promise<any> {
-			let values: any[] = [ 'unused', 'unused' ];
-			let response: Promise<boolean>[] = createTriggerablePromises(2);
-			let promise = iteration.some<any>(values, function (value: any, i: number) {
+		asyncArrayTests['callback returns multiple asynchronous results with a match and every exits immediately'] = function (): Promise<any> {
+			const values: any[] = [ 'unused', 'unused' ];
+			const response: Promise<boolean>[] = createTriggerablePromises(2);
+			const promise = iteration.some<any>(values, function (value: any, i: number) {
 				return response[i];
 			}).then(assertTrue);
 


### PR DESCRIPTION
- Allow an iterable to be passed to `array.from`.
- Convert `Map` to a shim that allows iterables and offloads to native.
- Allow iterables to be passed to the WeakMap constructor, and add
  `Symbol.toStringTag` definition.
- Add iterators to Promise and Task implementations.
- Add iterators to async/iteration.
