### PR TITLE
Add test for `host-rjs` and use it's stored `nodeRequire` value

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -131,6 +131,7 @@ add('host-node', function () {
 		return process.versions.node;
 	}
 });
+add('host-rjs', has('host-node') && global && global.requirejsVars);
 add('float32array', 'Float32Array' in global);
 add('setimmediate', typeof global.setImmediate !== 'undefined');
 add('dom-mutationobserver', function(): boolean {

--- a/src/text.ts
+++ b/src/text.ts
@@ -49,8 +49,16 @@ if (has('host-browser')) {
 		});
 	};
 }
-else if (has('host-node') && require.nodeRequire || !(define && (<any> define).amd)) {
-	const nodeReq = require.nodeRequire || require;
+else if (has('host-node')) {
+	let nodeReq: any;
+
+	if (has('host-rjs')) {
+		nodeReq = global.requirejsVars.nodeRequire;
+	}
+	else {
+		nodeReq = require.nodeRequire || require;
+	}
+
 	const fs = nodeReq('fs');
 	getText = function(url: string, callback: (value: string) => void): void {
 		fs.readFile(url, { encoding: 'utf8' }, function(error: Error, data: string): void {

--- a/src/text.ts
+++ b/src/text.ts
@@ -50,15 +50,7 @@ if (has('host-browser')) {
 	};
 }
 else if (has('host-node')) {
-	let nodeReq: any;
-
-	if (has('host-rjs')) {
-		nodeReq = global.requirejsVars.nodeRequire;
-	}
-	else {
-		nodeReq = require.nodeRequire || require;
-	}
-
+	const nodeReq = has('host-rjs') ? global.requirejsVars.nodeRequire : (require.nodeRequire || require);
 	const fs = nodeReq('fs');
 	getText = function(url: string, callback: (value: string) => void): void {
 		fs.readFile(url, { encoding: 'utf8' }, function(error: Error, data: string): void {


### PR DESCRIPTION
## Overview

Need to test for `rjs`. Can be done by checking for it's saved `requirejsVars` object which contains the `nodeRequire` we need.
### Reason
- Could not previously detect `r.js` build environment
- Typescript adds context `require` to its `UMD` and `AMD` modules, `r.js` only saves `nodeRequire` on the global `require` object.
