### PR TITLE
Support applying aspects to MapLike objects

### DIFF
--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -5,10 +5,12 @@ import * as assert from 'intern/chai!assert';
 import * as sinon from 'sinon';
 import * as aspect from 'src/aspect';
 import { Handle } from 'src/interfaces';
+import Map from 'dojo-shim/Map';
 
 const slice = Array.prototype.slice;
 let obj: any;
 let methodSpy: any;
+let map: Map<string, (...args: any[]) => any>;
 
 function createBeforeSpy() {
 	return sinon.spy(function (a: number) {
@@ -17,9 +19,11 @@ function createBeforeSpy() {
 }
 
 registerSuite({
-		name: 'aspect',
+	name: 'aspect',
 
-		'beforeEach'() {
+	'with indexable objects': {
+
+		beforeEach() {
 			methodSpy = sinon.spy(function (a: number) {
 				return a + 1;
 			});
@@ -81,12 +85,11 @@ registerSuite({
 			'multiple aspect.before() with removal inside handler'() {
 				let count = 0;
 
-				// FIXME
-				var handle1 = aspect.before(obj, 'method', function () {
+				const handle1 = aspect.before(obj, 'method', function () {
 					count++;
 				});
 
-				// FIXME
+				// FIXME: TDZ
 				var handle2 = aspect.before(obj, 'method', function () {
 					handle2.destroy();
 					handle1.destroy();
@@ -126,7 +129,8 @@ registerSuite({
 				let count = 0;
 
 				let handle2: Handle;
-				// FIXME
+
+				// FIXME: TDZ
 				var handle1 = aspect.after(obj, 'method', function () {
 					handle1.destroy();
 					handle2.destroy();
@@ -278,5 +282,284 @@ registerSuite({
 				assert.isFalse(aroundFunction.called);
 			}
 		}
+
+	},
+
+	'with maps': {
+
+		beforeEach() {
+			methodSpy = sinon.spy(function (a: number) {
+				return a + 1;
+			});
+			map = new Map([ [ 'method', methodSpy ] ]);
+		},
+
+		'.before': {
+			'return value passed as arguments'() {
+				let aspectSpy = createBeforeSpy();
+
+				aspect.before(map, 'method', aspectSpy);
+
+				const method = map.get('method');
+				method && method(0);
+				assert.isTrue(aspectSpy.calledBefore(methodSpy));
+				assert.isTrue(aspectSpy.calledOnce);
+				assert.isTrue(methodSpy.calledOnce);
+				assert.strictEqual(aspectSpy.lastCall.args[0], 0);
+				assert.strictEqual(methodSpy.lastCall.args[0], 1);
+				assert.strictEqual(methodSpy.returnValues[0], 2);
+			},
+
+			'no return value from advising function'() {
+				let receivedArgs: string[] = [];
+				let beforeCalled = false;
+				map = new Map([ [ 'method', function (...args: string[]) {
+						receivedArgs = args;
+					} ] ]);
+
+				aspect.before(map, 'method', function () {
+					beforeCalled = true;
+				});
+
+				const method = map.get('method');
+				method && method('foo', 'bar');
+
+				assert.isTrue(beforeCalled,
+					'Before advice should be called before original function');
+				assert.deepEqual(receivedArgs, [ 'foo', 'bar' ],
+					'Arguments passed to original method should be unaltered if before advice returns undefined');
+			},
+
+			'multiple aspect.before()'() {
+				const aspectSpy1 = createBeforeSpy();
+				const aspectSpy2 = createBeforeSpy();
+
+				aspect.before(map, 'method', aspectSpy1);
+				aspect.before(map, 'method', aspectSpy2);
+
+				const method = map.get('method');
+				method && method(5);
+				assert.isTrue(aspectSpy2.calledBefore(aspectSpy1));
+				assert.isTrue(aspectSpy1.calledBefore(methodSpy));
+				assert.strictEqual(aspectSpy2.lastCall.args[0], 5);
+				assert.strictEqual(aspectSpy1.lastCall.args[0], 6);
+				assert.strictEqual(methodSpy.lastCall.args[0], 7);
+				assert.strictEqual(methodSpy.returnValues[0], 8);
+			},
+
+			'multiple aspect.before() with removal inside handler'() {
+				let count = 0;
+
+				const handle1 = aspect.before(map, 'method', function () {
+					count++;
+				});
+
+				// FIXME: TDZ
+				var handle2 = aspect.before(map, 'method', function () {
+					handle2.destroy();
+					handle1.destroy();
+					count++;
+				});
+
+				assert.doesNotThrow(function () {
+					const method = map.get('method');
+					method && method();
+				});
+				assert.strictEqual(count, 1, 'Only one advising function should be called');
+			}
+		},
+
+		'.after': {
+			'overriding return value from original method'() {
+				const expected = 'override!';
+				const aspectSpy = sinon.stub().returns(expected);
+
+				aspect.after(map, 'method', aspectSpy);
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), expected);
+				assert.isTrue(aspectSpy.calledAfter(methodSpy));
+			},
+
+			'multiple aspect.after()'() {
+				const aspectStub1 = sinon.stub();
+				const aspectStub2 = sinon.stub();
+
+				aspect.after(map, 'method', aspectStub1);
+				aspect.after(map, 'method', aspectStub2);
+
+				const method = map.get('method');
+				method && method(0);
+				assert.isTrue(aspectStub1.calledAfter(methodSpy));
+				assert.isTrue(aspectStub2.calledAfter(aspectStub1));
+			},
+
+			'multiple aspect.after() with removal inside handler'() {
+				let count = 0;
+
+				let handle2: Handle;
+
+				// FIXME: TDZ
+				var handle1 = aspect.after(map, 'method', function () {
+					handle1.destroy();
+					handle2.destroy();
+					count++;
+				});
+
+				handle2 = aspect.after(map, 'method', function () {
+					count++;
+				});
+
+				assert.doesNotThrow(function () {
+					const method = map.get('method');
+					method && method();
+				});
+				assert.strictEqual(count, 1, 'Only one advising function should be called');
+			},
+
+			'provides the original arguments to the aspect method'() {
+				const expected = 'expected';
+				const aspectStub = sinon.stub().returns(expected);
+
+				aspect.after(map, 'method', aspectStub);
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), expected);
+				assert.isTrue(aspectStub.calledAfter(methodSpy));
+				assert.strictEqual(aspectStub.lastCall.args[0], 1);
+				assert.deepEqual(slice.call(aspectStub.lastCall.args[1]), methodSpy.lastCall.args);
+			}
+		},
+
+		'.around': {
+			'single around'() {
+				const expected = 5;
+				const aroundFunction = sinon.stub().returns(expected);
+				const aspectStub = sinon.stub().returns(aroundFunction);
+
+				aspect.around(map, 'method', aspectStub);
+
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), expected);
+				assert.isTrue(aspectStub.calledOnce);
+				assert.isTrue(aroundFunction.calledOnce);
+				assert.strictEqual(aroundFunction.firstCall.args[0], 0);
+				assert.isFalse(methodSpy.called);
+
+				// test that the original method was provided
+				aspectStub.callArgWith(0, 10);
+				assert.isTrue(methodSpy.calledOnce);
+				assert.strictEqual(methodSpy.firstCall.args[0], 10);
+			}
+		},
+
+		'.on()': {
+			'advising function returns undefined, returns original result'() {
+				const aspectStub = sinon.stub();
+
+				aspect.on(map, 'method', aspectStub);
+
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), 1);
+
+				assert.deepEqual(aspectStub.lastCall.args, methodSpy.lastCall.args);
+				assert.isTrue(methodSpy.calledOnce);
+				assert.isTrue(aspectStub.calledOnce);
+				assert.isTrue(aspectStub.calledAfter(methodSpy));
+			},
+
+			'advising function returns defined values, returns advising function result'() {
+				const aspectStub = sinon.stub().returns(2);
+
+				aspect.on(map, 'method', aspectStub);
+
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), 2);
+				assert.deepEqual(aspectStub.lastCall.args, methodSpy.lastCall.args);
+				assert.isTrue(methodSpy.calledOnce);
+				assert.isTrue(aspectStub.calledOnce);
+				assert.isTrue(aspectStub.calledAfter(methodSpy));
+			},
+
+			'there are previous advising functions (covering previous.next)'() {
+				const aspectStub1 = sinon.stub().returns(2);
+				const aspectStub2 = sinon.stub();
+				const aspectStub3 = sinon.stub().returns(6);
+
+				aspect.on(map, 'method', aspectStub1);
+				aspect.on(map, 'method', aspectStub2);
+				aspect.on(map, 'method', aspectStub3);
+
+				const method = map.get('method');
+				assert.strictEqual(method && method(0), 6);
+
+				assert.deepEqual(aspectStub1.lastCall.args, methodSpy.lastCall.args);
+				assert.deepEqual(aspectStub2.lastCall.args, methodSpy.lastCall.args);
+				assert.deepEqual(aspectStub3.lastCall.args, methodSpy.lastCall.args);
+
+				assert.isTrue(methodSpy.calledOnce);
+				assert.isTrue(aspectStub1.calledOnce);
+				assert.isTrue(aspectStub2.calledOnce);
+				assert.isTrue(aspectStub3.calledOnce);
+
+				sinon.assert.callOrder(methodSpy, aspectStub1, aspectStub2, aspectStub3);
+			}
+		},
+
+		'handle.destroy()': {
+			'prevents aspect from being called'() {
+				const aspectSpy = createBeforeSpy();
+				const handle = aspect.before(map, 'method', aspectSpy);
+
+				let method = map.get('method');
+				method && method(0);
+				assert.notEqual(map.get('method'), methodSpy);
+
+				handle.destroy();
+				method = map.get('method');
+				method && method(1);
+				assert.notEqual(map.get('method'), methodSpy);
+				assert.isTrue(methodSpy.calledTwice);
+				assert.isTrue(aspectSpy.calledOnce);
+			},
+
+			'can remove an aspect from the middle of a list'() {
+				const aspectSpy1 = createBeforeSpy();
+				const aspectSpy2 = createBeforeSpy();
+				const handle = aspect.before(map, 'method', aspectSpy1);
+
+				aspect.before(map, 'method', aspectSpy2);
+				handle.destroy();
+
+				const method = map.get('method');
+				method && method(0);
+				assert.isTrue(methodSpy.called);
+				assert.isTrue(aspectSpy2.called);
+				assert.isFalse(aspectSpy1.called);
+			},
+
+			'removing a aspect stub'() {
+				const map = new Map();
+				const aspectSpy = sinon.stub();
+				aspect.before(map, 'method', sinon.stub());
+				const handle = aspect.before(map, 'method', aspectSpy);
+
+				handle.destroy();
+				const method: any = map.get('method');
+				method && method(0);
+				assert.isFalse(aspectSpy.called);
+			},
+
+			'removing the first of multiple aspects'() {
+				const aroundFunction = sinon.stub();
+				const aspectStub = sinon.stub().returns(aroundFunction);
+				const handle = aspect.around(map, 'method', aspectStub);
+
+				handle.destroy();
+				const method = map.get('method');
+				method && method(0);
+				assert.isTrue(aspectStub.calledOnce);
+				assert.isTrue(methodSpy.calledOnce);
+				assert.isFalse(aroundFunction.called);
+			}
+		}
 	}
-);
+});


### PR DESCRIPTION
`aspect` now supports applying advice to Map like objects (e.g. ones that utilise key value pairs using a `.set()` and `.get()` functionality).

This is to support allowing `Map`s to be used when keeping a map of listeners, thereby supporting dojo/compose#52.

Also, this PR cleans up `aspect` to align it to current coding standards, including using string literals, eliminates the "ugliness" of the `null` assignments when unassigning values, removing `<any>` casting and adding comments to provide clarity.
