### PR TITLE
Add IdentityRegistry and rename Registry to MatchRegistry

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "remap-istanbul": "0.6.4",
     "sinon": "1.14.1",
     "tslint": "next",
-    "typescript": "^2.0.2"
+    "typescript": "~2.0.3"
   }
 }

--- a/src/IdentityRegistry.ts
+++ b/src/IdentityRegistry.ts
@@ -1,0 +1,147 @@
+import Map from 'dojo-shim/Map';
+import WeakMap from 'dojo-shim/WeakMap';
+import { Handle } from './interfaces';
+
+const noop = () => {};
+
+interface Entry<V> {
+	handle: Handle;
+	value: V;
+}
+
+interface State<V> {
+	entryMap: Map<Identity, Entry<V>>;
+	idMap: WeakMap<V, Identity>;
+}
+
+const privateStateMap = new WeakMap<IdentityRegistry<any>, State<any>>();
+
+function getState<V>(instance: IdentityRegistry<V>): State<V> {
+	return privateStateMap.get(instance);
+}
+
+/**
+ * Registry identities can be strings or symbols. Note that the empty string is allowed.
+ */
+export type Identity = string | symbol;
+
+/**
+ * A registry of values, mapped by identities.
+ */
+export default class IdentityRegistry<V extends Object> {
+	constructor() {
+		privateStateMap.set(this, {
+			entryMap: new Map<Identity, Entry<V>>(),
+			idMap: new WeakMap<V, Identity>()
+		});
+	}
+
+	/**
+	 * Look up a value by its identifier.
+	 *
+	 * Throws if no value has been registered for the given identifier.
+	 *
+	 * @param id The identifier
+	 * @return The value
+	 */
+	get(id: Identity): V {
+		const entry = getState<V>(this).entryMap.get(id);
+		if (!entry) {
+			throw new Error(`Could not find a value for identity '${id.toString()}'`);
+		}
+
+		return entry.value;
+	}
+
+	/**
+	 * Determine whether the value has been registered.
+	 * @param value The value
+	 * @return `true` if the value has been registered, `false` otherwise
+	 */
+	contains(value: V): boolean {
+		return getState<V>(this).idMap.has(value);
+	}
+
+	/**
+	 * Remove from the registry the value for a given identifier.
+	 * @param id The identifier
+	 * @return `true` if the value was removed, `false` otherwise
+	 */
+	delete(id: Identity): boolean {
+		const entry = getState<V>(this).entryMap.get(id);
+		if (!entry) {
+			return false;
+		}
+
+		entry.handle.destroy();
+		return true;
+	}
+
+	/**
+	 * Determine whether a value has been registered for the given identifier.
+	 * @param id The identifier
+	 * @return `true` if a value has been registered, `false` otherwise
+	 */
+	has(id: Identity): boolean {
+		return getState<V>(this).entryMap.has(id);
+	}
+
+	/**
+	 * Look up the identifier for which the given value has been registered.
+	 *
+	 * Throws if the value hasn't been registered.
+	 *
+	 * @param value The value
+	 * @return The identifier otherwise
+	 */
+	identify(value: V): Identity {
+		if (!this.contains(value)) {
+			throw new Error('Could not identify non-registered value');
+		}
+
+		return getState<V>(this).idMap.get(value);
+	}
+
+	/**
+	 * Register a new value with a new identity.
+	 *
+	 * Throws if a different value has already been registered for the given identity,
+	 * or if the value has already been registered with a different identity.
+	 *
+	 * @param id The identifier
+	 * @param value The value
+	 * @return A handle for deregistering the value. Note that when called repeatedly with
+	 *   the same identifier and value combination, the same handle is returned
+	 */
+	register(id: Identity, value: V): Handle {
+		const entryMap = getState<V>(this).entryMap;
+		const existingEntry = entryMap.get(id);
+		if (existingEntry && existingEntry.value !== value) {
+			const str = id.toString();
+			throw new Error(`A value has already been registered for the given identity (${str})`);
+		}
+
+		const existingId = this.contains(value) ? this.identify(value) : null;
+		if (existingId && existingId !== id) {
+			const str = (<Identity> existingId).toString();
+			throw new Error(`The value has already been registered with a different identity (${str})`);
+		}
+
+		// Adding the same value with the same id is a noop, return the original handle.
+		if (existingEntry && existingId) {
+			return existingEntry.handle;
+		}
+
+		const handle = {
+			destroy: () => {
+				handle.destroy = noop;
+				getState<V>(this).entryMap.delete(id);
+			}
+		};
+
+		entryMap.set(id, { handle, value });
+		getState<V>(this).idMap.set(value, id);
+
+		return handle;
+	}
+};

--- a/src/MatchRegistry.ts
+++ b/src/MatchRegistry.ts
@@ -1,8 +1,8 @@
 import { Handle } from './interfaces';
 
 /**
- * An entry in a Registry. Each Entry contains a test to determine whether the Entry is applicable, and a value for the
- * entry.
+ * An entry in a MatchRegistry. Each Entry contains a test to determine whether the Entry is applicable, and a value for
+ * the entry.
  */
 interface Entry<T> {
 	test: Test | null;
@@ -12,12 +12,12 @@ interface Entry<T> {
 /**
  * A registry of values tagged with matchers.
  */
-export default class Registry<T> {
+export default class MatchRegistry<T> {
 	protected _defaultValue: T | undefined;
 	private _entries: Entry<T>[] | null;
 
 	/**
-	 * Construct a new Registry, optionally containing a given default value.
+	 * Construct a new MatchRegistry, optionally containing a given default value.
 	 */
 	constructor(defaultValue?: T) {
 		this._defaultValue = defaultValue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,9 @@ import Evented from './Evented';
 import global from './global';
 import * as lang from './lang';
 import load from './load';
+import MatchRegistry from './MatchRegistry';
 import on, { emit } from './on';
 import * as queue from './queue';
-import Registry from './Registry';
 import request from './request';
 import Scheduler from './Scheduler';
 import * as stringExtras from './stringExtras';
@@ -35,9 +35,9 @@ export {
 	global,
 	lang,
 	load,
+	MatchRegistry,
 	on,
 	queue,
-	Registry,
 	request,
 	Scheduler,
 	stringExtras,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import DateObject from './DateObject';
 import * as encoding from './encoding';
 import Evented from './Evented';
 import global from './global';
+import IdentityRegistry from './IdentityRegistry';
 import * as lang from './lang';
 import load from './load';
 import MatchRegistry from './MatchRegistry';
@@ -33,6 +34,7 @@ export {
 	encoding,
 	Evented,
 	global,
+	IdentityRegistry,
 	lang,
 	load,
 	MatchRegistry,

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,13 +2,13 @@ import Promise from 'dojo-shim/Promise';
 import Task from './async/Task';
 import has from './request/has';
 import { Handle } from './interfaces';
-import Registry, { Test } from './Registry';
+import MatchRegistry, { Test } from './MatchRegistry';
 import load from './load';
 import { ParamList } from './UrlSearchParams';
 
 declare var require: any;
 
-export class FilterRegistry extends Registry<RequestFilter> {
+export class FilterRegistry extends MatchRegistry<RequestFilter> {
 	register(test: string | RegExp | RequestFilterTest | null, value: RequestFilter, first?: boolean): Handle {
 		let entryTest: Test;
 		const inTest = test;
@@ -36,7 +36,7 @@ if (has('host-node')) {
 	defaultProvider = './request/node';
 }
 
-export class ProviderRegistry extends Registry<RequestProvider> {
+export class ProviderRegistry extends MatchRegistry<RequestProvider> {
 	private _providerPromise: Promise<RequestProvider>;
 
 	constructor() {

--- a/tests/unit/IdentityRegistry.ts
+++ b/tests/unit/IdentityRegistry.ts
@@ -1,0 +1,173 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import Symbol from 'dojo-shim/Symbol';
+
+import IdentityRegistry from 'src/IdentityRegistry';
+
+class Value {}
+
+const idSymbol = Symbol('id');
+// Store the expected string due to <https://github.com/dojo/core/issues/170>.
+const idSymbolString = idSymbol.toString();
+
+registerSuite({
+	name: 'IdentityRegistry',
+
+	'#get': {
+		'string id was not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.throws(
+				() => registry.get('id'),
+				Error,
+				'Could not find a value for identity \'id\''
+			);
+		},
+
+		'symbol id was not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.throws(
+				() => registry.get(idSymbol),
+				Error,
+				'Could not find a value for identity \'' + idSymbolString + '\''
+			);
+		},
+
+		registered() {
+			const registry = new IdentityRegistry<Value>();
+			const expected = new Value();
+			registry.register('id', expected);
+			assert.strictEqual(registry.get('id'), expected);
+		}
+	},
+
+	'#contains': {
+		'not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.isFalse(registry.contains(new Value()));
+		},
+
+		registered() {
+			const registry = new IdentityRegistry<Value>();
+			const value = new Value();
+			registry.register('id', value);
+			assert.isTrue(registry.contains(value));
+		}
+	},
+
+	delete: {
+		'not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.isFalse(registry.delete('id'));
+		},
+
+		registered() {
+			const registry = new IdentityRegistry<Value>();
+			registry.register('id', new Value());
+			assert.isTrue(registry.has('id'));
+			assert.isTrue(registry.delete('id'));
+			assert.isFalse(registry.has('id'));
+		}
+	},
+
+	'#has': {
+		'not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.isFalse(registry.has('id'));
+		},
+
+		registered() {
+			const registry = new IdentityRegistry<Value>();
+			registry.register('id', new Value());
+			assert.isTrue(registry.has('id'));
+		}
+	},
+
+	'#identify': {
+		'not registered'() {
+			const registry = new IdentityRegistry<Value>();
+			assert.throws(
+				() => registry.identify(new Value()),
+				Error,
+				'Could not identify non-registered value'
+			);
+		},
+
+		registered() {
+			const registry = new IdentityRegistry<Value>();
+			const value = new Value();
+			const expected = Symbol();
+			registry.register(expected, value);
+			assert.strictEqual(registry.identify(value), expected);
+		}
+	},
+
+	'#register': {
+		ok() {
+			const registry = new IdentityRegistry<Value>();
+			const expected = new Value();
+			registry.register('id', expected);
+			assert.strictEqual(registry.get('id'), expected);
+		},
+
+		'string id is already used'() {
+			const registry = new IdentityRegistry<Value>();
+			registry.register('id', new Value());
+			assert.throws(() => {
+				registry.register('id', new Value());
+			}, Error, 'A value has already been registered for the given identity (id)');
+		},
+
+		'symbol id is already used'() {
+			const registry = new IdentityRegistry<Value>();
+			const id = idSymbol;
+			registry.register(id, new Value());
+			assert.throws(() => {
+				registry.register(id, new Value());
+			}, Error, 'A value has already been registered for the given identity (' + idSymbolString + ')');
+		},
+
+		'value has already been registered with a different (string) id'() {
+			const registry = new IdentityRegistry<Value>();
+			const value = new Value();
+			registry.register('id1', value);
+			assert.throws(() => {
+				registry.register(Symbol('id2'), value);
+			}, Error, 'The value has already been registered with a different identity (id1)');
+		},
+
+		'value has already been registered with a different (symbol) id'() {
+			const registry = new IdentityRegistry<Value>();
+			const value = new Value();
+			const id1Symbol = Symbol('id1');
+			registry.register(id1Symbol, value);
+			assert.throws(() => {
+				registry.register('id2', value);
+			}, Error, 'The value has already been registered with a different identity (' + id1Symbol.toString() + ')');
+		},
+
+		'value has already been registered with the same id'() {
+			const registry = new IdentityRegistry<Value>();
+			const value = new Value();
+			const expected = registry.register('id', value);
+			const actual = registry.register('id', value);
+			assert.strictEqual(actual, expected);
+		},
+
+		'returns handle'() {
+			const registry = new IdentityRegistry<Value>();
+			const handle = registry.register('id', new Value());
+			assert.isTrue(registry.has('id'));
+			handle.destroy();
+			assert.isFalse(registry.has('id'));
+		},
+
+		'destroying handle more than once is a noop'() {
+			const registry = new IdentityRegistry<Value>();
+			const handle = registry.register('id', new Value());
+			assert.isTrue(registry.has('id'));
+			handle.destroy();
+			handle.destroy();
+			assert.isFalse(registry.has('id'));
+		}
+	}
+});

--- a/tests/unit/MatchRegistry.ts
+++ b/tests/unit/MatchRegistry.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import Registry from 'src/Registry';
+import MatchRegistry from 'src/MatchRegistry';
 
 function stringTest(value: string) {
 	return (...args: any[]): boolean => {
@@ -9,10 +9,10 @@ function stringTest(value: string) {
 }
 
 registerSuite({
-	name: 'Registry',
+	name: 'MatchRegistry',
 
 	'#match'() {
-		const registry = new Registry<any>();
+		const registry = new MatchRegistry<any>();
 		const handler = () => {};
 		registry.register((name: string) => {
 			return name === 'foo';
@@ -23,7 +23,7 @@ registerSuite({
 
 	'#register': {
 		multiple() {
-			const registry = new Registry<any>();
+			const registry = new MatchRegistry<any>();
 			const handler = () => {};
 			registry.register(stringTest('foo'), handler);
 			registry.register(stringTest('foo'), () => {});
@@ -31,7 +31,7 @@ registerSuite({
 		},
 
 		first() {
-			const registry = new Registry<number>();
+			const registry = new MatchRegistry<number>();
 			registry.register(stringTest('foo'), 1);
 			registry.register(stringTest('foo'), 2, true);
 			assert.strictEqual(registry.match('foo'), 2);
@@ -40,7 +40,7 @@ registerSuite({
 		},
 
 		destroy() {
-			const registry = new Registry<number>(2);
+			const registry = new MatchRegistry<number>(2);
 			const handle = registry.register(stringTest('foo'), 1);
 			assert.equal(registry.match('foo'), 1);
 			handle.destroy();
@@ -52,7 +52,7 @@ registerSuite({
 	},
 
 	'default value'() {
-		const registry = new Registry<any>('foo');
+		const registry = new MatchRegistry<any>('foo');
 		assert.strictEqual(registry.match('bar'), 'foo');
 	}
 });

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -5,6 +5,7 @@ import './async/timing';
 import './Evented';
 import './encoding';
 import './global';
+import './IdentityRegistry';
 import './lang';
 import './load';
 import './main';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -9,7 +9,7 @@ import './lang';
 import './load';
 import './main';
 import './on/all';
-import './Registry';
+import './MatchRegistry';
 import './queue';
 import './streams/all';
 import './request';


### PR DESCRIPTION
Include `IdentityRegistry` from `dojo-app`, see https://github.com/dojo/app/issues/7.

**This renames `dojo-core/Registry` to `dojo-core/MatchRegistry`**. @kitsonk seemed OK with that back in June when I proposed the rename, but let me know if it's actually a concern.

I can submit PRs for any other repos that reference `dojo-core/Registry` once the rename is approved.
