### PR TITLE
Task callbacks always receive a value

### DIFF
--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -136,7 +136,7 @@ export default class Task<T> extends Promise<T> {
 		return task;
 	}
 
-	then<U>(onFulfilled?: (value: T | undefined) => U | Thenable<U>,  onRejected?: (error: Error | undefined) => U | Thenable<U>): Task<U> {
+	then<U>(onFulfilled?: (value: T) => U | Thenable<U>,  onRejected?: (error: Error) => U | Thenable<U>): Task<U> {
 		// FIXME
 		// tslint:disable-next-line:no-var-keyword
 		var task = <Task<U>> super.then<U>(


### PR DESCRIPTION
Fix optional typings for callback arguments, they'll always receive a
value / reason. With the old typing strict null checks would always
allow for the value to be undefined.

See also https://github.com/dojo/shim/pull/19.
