### PR TITLE
Add deprecated instrumentation API

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-has": ">=2.0.0-alpha.4",
+    "dojo-has": ">=2.0.0-alpha.6",
     "dojo-shim": ">=2.0.0-alpha.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "http-proxy": "0.10.3",
     "intern": "^3.3.1",
     "istanbul": "0.4.3",
-    "sinon": "~1.16.0",
+    "sinon": "~1.17.6",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3"
   }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -33,6 +33,7 @@ export interface DeprecatedOptions {
  * @param options Provide options which change the display of the message
  */
 export function deprecated({ message, name, warn, url }: DeprecatedOptions = {}): void {
+	/* istanbul ignore else: testing with debug off is difficult */
 	if (has('debug')) {
 		message = message || DEFAULT_DEPRECATED_MESSAGE;
 		let warning = `DEPRECATED: ${name ? name + ': ' : ''}${message}`;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -28,11 +28,6 @@ export interface DeprecatedOptions {
 }
 
 /**
- * Reference to console.warn
- */
-let consoleWarn = console.warn;
-
-/**
  * A function that will console warn that a function has been deprecated
  *
  * @param options Provide options which change the display of the message
@@ -44,7 +39,12 @@ export function deprecated({ message, name, warn, url }: DeprecatedOptions = {})
 		if (url) {
 			warning += `\n\n    See ${url} for more details.\n\n`;
 		}
-		(warn || consoleWarn)(warning);
+		if (warn) {
+			warn(warning);
+		}
+		else {
+			console.warn(warning);
+		}
 	}
 }
 
@@ -79,11 +79,4 @@ export function deprecatedDecorator(options?: DeprecatedOptions): MethodDecorato
 		}
 		return descriptor;
 	};
-}
-
-/**
- * Overwrite the console.warn, needed for some browsers which have issues when calling global objects.
- */
-export function setConsoleWarn(warn: (message?: any, ...optionalParams: any[]) => void): void {
-	consoleWarn = warn;
 }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,76 @@
+import has from './has';
+
+/**
+ * The default message to warn when no other is provided
+ */
+const DEFAULT_DEPRECATED_MESSAGE = 'This function will be removed in future versions.';
+
+export interface DeprecatedOptions {
+	/**
+	 * The message to use when warning
+	 */
+	message?: string;
+
+	/**
+	 * The name of the method or function to use
+	 */
+	name?: string;
+
+	/**
+	 * An alternative function to log the warning to
+	 */
+	warn?: (...args: any[]) => void;
+
+	/**
+	 * Reference an URL for more information when warning
+	 */
+	url?: string;
+}
+
+/**
+ * A function that will console warn that a function has been deprecated
+ *
+ * @param options Provide options which change the display of the message
+ */
+export function deprecated({ message, name, warn, url }: DeprecatedOptions = {}): void {
+	if (has('debug')) {
+		message = message || DEFAULT_DEPRECATED_MESSAGE;
+		let warning = `DEPRECATED: ${name ? name + ': ' : ''}${message}`;
+		if (url) {
+			warning += `\n\n    See ${url} for more details.\n\n`;
+		}
+		(warn || console.warn)(warning);
+	}
+}
+
+/**
+ * A function that generates before advice that can be used to warn when an API has been deprecated
+ *
+ * @param options Provide options which change the display of the message
+ */
+export function deprecatedAdvice(options?: DeprecatedOptions): (...args: any[]) => any[] {
+	return function(...args: any[]): any[] {
+		deprecated(options);
+		return args;
+	};
+}
+
+/**
+ * A method decorator that will console warn when a method if invoked that is deprecated
+ *
+ * @param options Provide options which change the display of the message
+ */
+export function deprecatedDecorator(options?: DeprecatedOptions): MethodDecorator {
+	return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+		if (has('debug')) {
+			const { value: originalFn } = descriptor;
+			options = options || {};
+			options.name = `${target.constructor.name}#${propertyKey}`;
+			descriptor.value = function(...args: any[]) {
+				deprecated(options);
+				return originalFn.apply(target, args);
+			};
+		}
+		return descriptor;
+	};
+}

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -5,6 +5,11 @@ import has from './has';
  */
 const DEFAULT_DEPRECATED_MESSAGE = 'This function will be removed in future versions.';
 
+/**
+ * When set, globalWarn will be used instead of `console.warn`
+ */
+let globalWarn: ((message?: any, ...optionalParams: any[]) => void) | undefined;
+
 export interface DeprecatedOptions {
 	/**
 	 * The message to use when warning
@@ -43,6 +48,9 @@ export function deprecated({ message, name, warn, url }: DeprecatedOptions = {})
 		if (warn) {
 			warn(warning);
 		}
+		else if (globalWarn) {
+			globalWarn(warning);
+		}
 		else {
 			console.warn(warning);
 		}
@@ -80,4 +88,14 @@ export function deprecatedDecorator(options?: DeprecatedOptions): MethodDecorato
 		}
 		return descriptor;
 	};
+}
+
+/**
+ * A function that will set the warn function that will be used instead of `console.warn` when
+ * logging warning messages
+ *
+ * @param warn The function (or `undefined`) to use instead of `console.warn`
+ */
+export function setWarn(warn?: ((message?: any, ...optionalParams: any[]) => void)): void {
+	globalWarn = warn;
 }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -28,6 +28,11 @@ export interface DeprecatedOptions {
 }
 
 /**
+ * Reference to console.warn
+ */
+let consoleWarn = console.warn;
+
+/**
  * A function that will console warn that a function has been deprecated
  *
  * @param options Provide options which change the display of the message
@@ -39,7 +44,7 @@ export function deprecated({ message, name, warn, url }: DeprecatedOptions = {})
 		if (url) {
 			warning += `\n\n    See ${url} for more details.\n\n`;
 		}
-		(warn || console.warn)(warning);
+		(warn || consoleWarn)(warning);
 	}
 }
 
@@ -65,7 +70,8 @@ export function deprecatedDecorator(options?: DeprecatedOptions): MethodDecorato
 		if (has('debug')) {
 			const { value: originalFn } = descriptor;
 			options = options || {};
-			options.name = `${target.constructor.name}#${propertyKey}`;
+			/* IE 10/11 don't have the name property on functions */
+			options.name = target.constructor.name ? `${target.constructor.name}#${propertyKey}` : propertyKey;
 			descriptor.value = function(...args: any[]) {
 				deprecated(options);
 				return originalFn.apply(target, args);
@@ -73,4 +79,11 @@ export function deprecatedDecorator(options?: DeprecatedOptions): MethodDecorato
 		}
 		return descriptor;
 	};
+}
+
+/**
+ * Overwrite the console.warn, needed for some browsers which have issues when calling global objects.
+ */
+export function setConsoleWarn(warn: (message?: any, ...optionalParams: any[]) => void): void {
+	consoleWarn = warn;
 }

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -12,3 +12,16 @@ export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean>
 export function throwImmediatly() {
 	throw new Error('unexpected code path');
 }
+
+let _hasClassName: boolean;
+
+/**
+ * Detects if the runtime environment supports a class name
+ */
+export function hasClassName(): boolean {
+	if (_hasClassName !== undefined) {
+		return _hasClassName;
+	}
+	class Foo {}
+	return _hasClassName = Boolean((<any> Foo.constructor).name);
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -6,6 +6,7 @@ import './Evented';
 import './encoding';
 import './global';
 import './IdentityRegistry';
+import './instrument';
 import './lang';
 import './load';
 import './main';

--- a/tests/unit/instrument.ts
+++ b/tests/unit/instrument.ts
@@ -1,0 +1,143 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { spy, SinonSpy } from 'sinon';
+import {
+	deprecated,
+	deprecatedAdvice,
+	deprecatedDecorator
+} from '../../src/instrument';
+
+let consoleWarnSpy: SinonSpy;
+
+registerSuite({
+	name: 'instrument',
+
+	beforeEach() {
+		consoleWarnSpy = spy(console, 'warn');
+	},
+
+	afterEach() {
+		consoleWarnSpy && consoleWarnSpy.restore && consoleWarnSpy.restore();
+	},
+
+	'deprecated()': {
+		'no options'() {
+			deprecated();
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
+		},
+
+		'message in options'() {
+			const message = 'foo';
+			deprecated({ message });
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], `DEPRECATED: ${message}`);
+		},
+
+		'name in options'() {
+			const name = 'foo';
+			deprecated({ name });
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], `DEPRECATED: ${name}: This function will be removed in future versions.`);
+		},
+
+		'url in options'() {
+			const url = 'foo';
+			deprecated({ url });
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], `DEPRECATED: This function will be removed in future versions.\n\n    See ${url} for more details.\n\n`);
+		},
+
+		'warn in options'() {
+			const callStack: any[][] = [];
+
+			function warn(...args: any[]): void {
+				callStack.push(args);
+			}
+
+			deprecated({ warn });
+			assert.isTrue(consoleWarnSpy.notCalled);
+			assert.strictEqual(callStack.length, 1);
+			assert.strictEqual(callStack[0].length, 1);
+			assert.strictEqual(callStack[0][0], 'DEPRECATED: This function will be removed in future versions.');
+		}
+	},
+
+	'deprecatedAdvice()': {
+		'no options'() {
+			const advice = deprecatedAdvice();
+			assert.isTrue(consoleWarnSpy.notCalled);
+
+			const args: any[] = [ 'foo' ];
+			const result = advice.apply(null, args);
+			assert.deepEqual(args, result);
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
+		},
+
+		'warn in options'() {
+			const callStack: any[][] = [];
+
+			function warn(...args: any[]): void {
+				callStack.push(args);
+			}
+
+			const advice = deprecatedAdvice({ warn });
+
+			const args: any[] = [ 'foo' ];
+			const result = advice.apply(null, args);
+			assert.deepEqual(args, result);
+			assert.isTrue(consoleWarnSpy.notCalled);
+			assert.strictEqual(callStack.length, 1);
+			assert.strictEqual(callStack[0].length, 1);
+			assert.strictEqual(callStack[0][0], 'DEPRECATED: This function will be removed in future versions.');
+		}
+	},
+
+	'deprecatedDecorator()': {
+		'no options'() {
+			const callStack: any[][] = [];
+
+			class Foo {
+				@deprecatedDecorator()
+				method(...args: any[]) {
+					callStack.push(args);
+				}
+			}
+
+			const foo = new Foo();
+			assert.isTrue(consoleWarnSpy.notCalled);
+			foo.method('foo');
+			assert.isTrue(consoleWarnSpy.calledOnce);
+			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+			assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: Foo#method: This function will be removed in future versions.');
+			assert.strictEqual(callStack[0].length, 1);
+			assert.strictEqual(callStack[0][0], 'foo');
+		},
+
+		'warn in options'() {
+			const callStack: any[][] = [];
+
+			function warn(...args: any[]): void {
+				callStack.push(args);
+			}
+
+			class Foo {
+				@deprecatedDecorator({ warn })
+				method() { }
+			}
+
+			const foo = new Foo();
+			foo.method();
+			assert.isTrue(consoleWarnSpy.notCalled);
+			assert.strictEqual(callStack.length, 1);
+			assert.strictEqual(callStack[0].length, 1);
+			assert.strictEqual(callStack[0][0], 'DEPRECATED: Foo#method: This function will be removed in future versions.');
+		}
+	}
+});

--- a/tests/unit/instrument.ts
+++ b/tests/unit/instrument.ts
@@ -5,8 +5,7 @@ import { spy, SinonSpy } from 'sinon';
 import {
 	deprecated,
 	deprecatedAdvice,
-	deprecatedDecorator,
-	setConsoleWarn
+	deprecatedDecorator
 } from '../../src/instrument';
 
 let consoleWarnSpy: SinonSpy;
@@ -16,12 +15,10 @@ registerSuite({
 
 	beforeEach() {
 		consoleWarnSpy = spy(console, 'warn');
-		setConsoleWarn(console.warn);
 	},
 
 	afterEach() {
 		(<any> console.warn).restore && (<any> console.warn).restore();
-		setConsoleWarn(console.warn);
 	},
 
 	'deprecated()': {

--- a/tests/unit/instrument.ts
+++ b/tests/unit/instrument.ts
@@ -5,7 +5,8 @@ import { spy, SinonSpy } from 'sinon';
 import {
 	deprecated,
 	deprecatedAdvice,
-	deprecatedDecorator
+	deprecatedDecorator,
+	setWarn
 } from '../../src/instrument';
 
 let consoleWarnSpy: SinonSpy;
@@ -150,5 +151,27 @@ registerSuite({
 				assert.strictEqual(callStack[0][0], 'DEPRECATED: method: This function will be removed in future versions.');
 			}
 		}
+	},
+
+	'setWarn()'() {
+		const callStack: any[][] = [];
+
+		function warn(...args: any[]): void {
+			callStack.push(args);
+		}
+
+		setWarn(warn);
+		deprecated();
+		assert.isTrue(consoleWarnSpy.notCalled);
+		assert.strictEqual(callStack.length, 1);
+		assert.strictEqual(callStack[0].length, 1);
+		assert.strictEqual(callStack[0][0], 'DEPRECATED: This function will be removed in future versions.');
+
+		setWarn();
+		deprecated();
+		assert.isTrue(consoleWarnSpy.calledOnce);
+		assert.strictEqual(callStack.length, 1);
+		assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
+		assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
 	}
 });


### PR DESCRIPTION
This PR provides a new module named `instrument` which exports 3 functions:
- `deprecated`
- `deprecatedAdvice`
- `deprecatedDecorator`

`deprecated` allows you to log to `console.warn` when running in debug mode (which is the default for `dojo-has`) to signals that something is deprecated.  It takes an options bag which allows the specification of a different message, the name of the function being deprecated, a URL for additional information and an alternative _warn_ function.

The `deprecatedAdvice` generates an before advising function which will call `deprecated`.

The `deprecatedDecorator` is a method decorator which will call `deprecated`.  It also will automatically determine the `name` for the options based on the class and method names.

Resolves #220
