### PR TITLE
Calling finally task for canceled tasks, fixes #205

### DIFF
--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -157,6 +157,11 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	 * Allows for cleanup actions to be performed after resolution of a Promise.
 	 */
 	finally(callback: () => void | Thenable<any>): Task<T> {
+		// if this task is already canceled, call the task
+		if (this._state === State.Canceled) {
+			return Task.resolve(callback());
+		}
+
 		const task = this.then<any>(
 			value => Task.resolve(callback()).then(() => value),
 			reason => Task.resolve(callback()).then(() => {

--- a/tests/unit/async/Task.ts
+++ b/tests/unit/async/Task.ts
@@ -200,6 +200,48 @@ let suite = {
 			.finally(dfd.callback(function () {}));
 
 			resolver();
+		},
+
+		'invoked if already canceled'(this: any) {
+			const dfd = this.async();
+			const task = new Task(() => {
+			});
+			task.cancel();
+
+			task.finally(dfd.callback(() => {
+			}));
+		},
+
+		'finally is only called once when called after cancel'(this: any) {
+			let callCount = 0;
+			const dfd = this.async();
+			const task = new Task((resolve) => {
+				setTimeout(resolve, 10);
+			});
+			task.cancel();
+			task.finally(dfd.callback(() => {
+				callCount++;
+			}));
+
+			setTimeout(dfd.callback(() => {
+				assert.equal(callCount, 1);
+			}), 100);
+		},
+
+		'finally is only called once when called before cancel'(this: any) {
+			let callCount = 0;
+			const dfd = this.async();
+			const task = new Task((resolve) => {
+				setTimeout(resolve, 10);
+			});
+			task.finally(dfd.callback(() => {
+				callCount++;
+			}));
+			task.cancel();
+
+			setTimeout(dfd.callback(() => {
+				assert.equal(callCount, 1);
+			}), 100);
 		}
 	},
 


### PR DESCRIPTION
If you call `finally` on an already canceled task, the `finally` task now runs.