### PR TITLE
Resolving unhandled promise rejection errors, #229

### DIFF
--- a/src/request/node.ts
+++ b/src/request/node.ts
@@ -282,7 +282,8 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 						},
 						function (error: RequestError<T>) {
 							if (options.streamTarget) {
-								options.streamTarget.abort(error);
+								options.streamTarget.abort(error).catch(() => {
+								});
 							}
 							request.abort();
 							error.response = response;
@@ -318,7 +319,8 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 					resolve(response);
 				}
 				else {
-					options.streamTarget.close();
+					options.streamTarget.close().catch(() => {
+					});
 				}
 			});
 		});
@@ -332,7 +334,8 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 				options.data.pipeTo(writableRequest)
 					.catch(function (error: RequestError<T>) {
 						error.response = response;
-						writableRequest.abort(error);
+						writableRequest.abort(error).catch(() => {
+						});
 						reject(error);
 					});
 			}

--- a/src/request/node.ts
+++ b/src/request/node.ts
@@ -282,6 +282,8 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 						},
 						function (error: RequestError<T>) {
 							if (options.streamTarget) {
+								// abort the stream, swallowing any errors,
+								// (because we've already got an error, and we can't catch this one)
 								options.streamTarget.abort(error).catch(() => {
 								});
 							}

--- a/src/streams/ReadableStreamReader.ts
+++ b/src/streams/ReadableStreamReader.ts
@@ -59,6 +59,9 @@ export default class ReadableStreamReader<T> {
 			this._resolveClosedPromise = resolve;
 			this._rejectClosedPromise = reject;
 		});
+
+		this._closedPromise.catch(() => {
+		});
 	}
 
 	/**
@@ -131,16 +134,23 @@ export default class ReadableStreamReader<T> {
 			});
 		}
 		else {
-			// FIXME
-			// tslint:disable-next-line:no-var-keyword
-			var readPromise = new Promise<ReadResult<T>>((resolve, reject) => {
-				this._readRequests.push({
-					promise: readPromise,
-					resolve: resolve,
-					reject: reject
-				});
-				stream.pull();
+			let readResolve: (value: ReadResult<T>) => void = () => {
+			};
+			let readReject: (reason: any) => void = () => {
+			};
+
+			let readPromise = new Promise<ReadResult<T>>((resolve, reject) => {
+				readResolve = resolve;
+				readReject = reject;
 			});
+
+			this._readRequests.push({
+				promise: readPromise,
+				resolve: readResolve,
+				reject: readReject
+			});
+
+			stream.pull();
 
 			return readPromise;
 		}

--- a/src/streams/SizeQueue.ts
+++ b/src/streams/SizeQueue.ts
@@ -35,8 +35,8 @@ export default class SizeQueue<T> {
 		return pair ? pair.value : null;
 	}
 
-	peek(): T | undefined {
+	peek(): T | null | undefined {
 		const pair = this._queue[0];
-		return pair.value;
+		return pair ? pair.value : null;
 	}
 }

--- a/tests/unit/async/ExtensiblePromise.ts
+++ b/tests/unit/async/ExtensiblePromise.ts
@@ -42,10 +42,10 @@ registerSuite({
 
 	'then reject w/ no handler': function (this: any) {
 		let dfd = this.async();
+
 		ExtensiblePromise.reject().then(dfd.rejectOnError(() => {
 			assert.isTrue(false, 'Should not have resolved');
-		}), undefined);
-		setTimeout(dfd.callback(() => {
-		}), 100);
+		}), undefined).catch(dfd.callback(() => {
+		}));
 	}
 });

--- a/tests/unit/async/Task.ts
+++ b/tests/unit/async/Task.ts
@@ -188,7 +188,7 @@ let suite = {
 				task.cancel();
 				return new Promise(function (resolve, reject) {
 					setTimeout(reject);
-				});
+				}).catch(() => {});
 			})
 			.then(dfd.rejectOnError(function () {
 				assert(false, 'should not have run');

--- a/tests/unit/async/timing.ts
+++ b/tests/unit/async/timing.ts
@@ -32,7 +32,7 @@ registerSuite({
 			};
 			return timing.delay(251)( getNow ).then(function (finish: number) {
 				const diff: number = finish - now;
-				assert.approximately(diff, 251, 100);
+				assert.approximately(diff, 251, 150);
 			});
 		},
 		'delay should return undefined when the value is not passed in': function () {
@@ -44,15 +44,15 @@ registerSuite({
 			const start = Date.now();
 			const delay = timing.delay(251);
 			const p1 = delay().then(function() {
-				assert.approximately(Date.now() - start, 251, 100);
+				assert.approximately(Date.now() - start, 251, 150);
 			});
 			const p2 = delay('foo').then(function(value) {
 				assert.strictEqual(value, 'foo');
-				assert.approximately(Date.now() - start, 251, 100);
+				assert.approximately(Date.now() - start, 251, 150);
 			});
 			const p3 = delay(() => Promise.resolve('bar')).then(function(value) {
 				assert.strictEqual(value, 'bar');
-				assert.approximately(Date.now() - start, 251, 100);
+				assert.approximately(Date.now() - start, 251, 150);
 			});
 			return Promise.all([p1, p2, p3]);
 		}

--- a/tests/unit/async/timing.ts
+++ b/tests/unit/async/timing.ts
@@ -12,7 +12,7 @@ registerSuite({
 		'delay returning a value after the given timeout': function () {
 			return timing.delay(251)(Date.now()).then(function (start: number) {
 				const diff: number = Date.now() - start;
-				assert.isAbove(diff, 249);
+				assert.approximately(diff, 251, 100);
 			});
 		},
 		'delay executing a function that returns a value after the given timeout': function () {
@@ -22,7 +22,7 @@ registerSuite({
 			};
 			return timing.delay(251)( getNow ).then(function (finish: number) {
 				const diff: number = finish - now;
-				assert.isAbove(diff, 249);
+				assert.approximately(diff, 251, 100);
 			});
 		},
 		'delay executing a function that returns another promise after the given timeout': function () {
@@ -32,7 +32,7 @@ registerSuite({
 			};
 			return timing.delay(251)( getNow ).then(function (finish: number) {
 				const diff: number = finish - now;
-				assert.isAbove(diff, 249);
+				assert.approximately(diff, 251, 100);
 			});
 		},
 		'delay should return undefined when the value is not passed in': function () {
@@ -44,15 +44,15 @@ registerSuite({
 			const start = Date.now();
 			const delay = timing.delay(251);
 			const p1 = delay().then(function() {
-				assert.isAbove(Date.now() - start, 249);
+				assert.approximately(Date.now() - start, 251, 100);
 			});
 			const p2 = delay('foo').then(function(value) {
 				assert.strictEqual(value, 'foo');
-				assert.isAbove(Date.now() - start, 249);
+				assert.approximately(Date.now() - start, 251, 100);
 			});
 			const p3 = delay(() => Promise.resolve('bar')).then(function(value) {
 				assert.strictEqual(value, 'bar');
-				assert.isAbove(Date.now() - start, 249);
+				assert.approximately(Date.now() - start, 251, 100);
 			});
 			return Promise.all([p1, p2, p3]);
 		}

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -122,6 +122,12 @@ const responseData: { [url: string]: DummyResponse } = {
 	}
 };
 
+process.on('unhandledRejection', (reason: any, promise: any) => {
+	console.log('*** UNHANDLED PROMISE ***');
+	console.log(promise);
+	console.log(reason);
+});
+
 function buildRedirectTests(methods: RedirectTestData[]) {
 	let tests: { [key: string]: () => void } = {};
 

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -122,12 +122,6 @@ const responseData: { [url: string]: DummyResponse } = {
 	}
 };
 
-process.on('unhandledRejection', (reason: any, promise: any) => {
-	console.log('*** UNHANDLED PROMISE ***');
-	console.log(promise);
-	console.log(reason);
-});
-
 function buildRedirectTests(methods: RedirectTestData[]) {
 	let tests: { [key: string]: () => void } = {};
 

--- a/tests/unit/streams/ReadableStream.ts
+++ b/tests/unit/streams/ReadableStream.ts
@@ -292,14 +292,16 @@ registerSuite({
 		assert.strictEqual(stream.queueSize, 0);
 		assert.strictEqual(stream.state, State.Errored);
 
-		assert.throws(function () {
-			stream.error(error);
-		});
-
 		stream = new ReadableStream(new BaseStringSource(), strategy);
 		let reader = stream.getReader();
 		stream.error(error);
 		assert.strictEqual(reader.state, State.Errored);
+
+		assert.throws(() => {
+			stream = new ReadableStream(new BaseStringSource(), strategy);
+			stream.state = State.Closed;
+			stream.error(new Error('error'));
+		});
 	},
 
 	'getReader': {

--- a/tests/unit/streams/SizeQueue.ts
+++ b/tests/unit/streams/SizeQueue.ts
@@ -17,6 +17,7 @@ registerSuite({
 		assert.lengthOf(queue, 1);
 		assert.strictEqual(queue.dequeue(), str);
 		assert.lengthOf(queue, 0);
+		assert.strictEqual(queue.dequeue(), null);
 	},
 
 	'totalSize'() {
@@ -44,5 +45,7 @@ registerSuite({
 		assert.lengthOf(queue, 1);
 		assert.strictEqual(queue.peek(), str);
 		assert.lengthOf(queue, 1);
+		queue.dequeue();
+		assert.strictEqual(queue.peek(), null);
 	}
 });

--- a/tests/unit/streams/TransformStream.ts
+++ b/tests/unit/streams/TransformStream.ts
@@ -121,5 +121,21 @@ registerSuite({
 			assert.strictEqual(stream.readable.state, ReadableState.Errored);
 			assert.strictEqual(stream.writable.state, WritableState.Errored);
 		});
+	},
+
+	'sink.abort resolves'() {
+		return stream.writable.abort('reason').then(() => {
+			assert.strictEqual(stream.writable.state, WritableState.Errored);
+		}, () => {
+			assert.fail('should have succeeded');
+		});
+	},
+
+	'sink.cancel resolves'() {
+		return stream.readable.cancel('reason').then(() => {
+			assert.strictEqual(stream.readable.state, ReadableState.Closed);
+		}, () => {
+			assert.fail('should have succeeded');
+		});
 	}
 });

--- a/tests/unit/streams/WritableStream.ts
+++ b/tests/unit/streams/WritableStream.ts
@@ -344,6 +344,17 @@ registerSuite({
 			}, function (error: Error) {
 				assert.instanceOf(error, Error, 'Promise should reject with an Error');
 			});
+		},
+
+		'error if invalid record'(this: any) {
+			(<any> stream)._queue.enqueue({
+				close: true
+			});
+			(<any> stream)._started = true;
+
+			assert.throws(() => {
+				(<any> stream)._advanceQueue();
+			});
 		}
 	},
 

--- a/tests/unit/streams/util.ts
+++ b/tests/unit/streams/util.ts
@@ -96,6 +96,9 @@ registerSuite({
 			otherMethod: function () {
 				otherParameters = Array.prototype.slice.call(arguments);
 				otherCallCount += 1;
+			},
+			errorMethod: function () {
+				throw new Error('error');
 			}
 		};
 
@@ -119,6 +122,16 @@ registerSuite({
 			assert.strictEqual(callCount, 2);
 			assert.strictEqual(otherCallCount, 2);
 			assert.sameMembers(otherParameters, testParameters, 'obj.otherMethod should be called with test parameters');
+
+			return util.promiseInvokeOrFallbackOrNoop(undefined, 'METHOD', <any> undefined, 'otherMethod');
+		}).then(() => {
+			assert.fail('should not have succeeded');
+		}, () => {
+			return util.promiseInvokeOrFallbackOrNoop(obj, 'errorMethod', <any> undefined, 'otherMethod');
+		}).then(() => {
+			assert.fail('should not have succeeded');
+		}, (error: any) => {
+			assert.equal(error.message, 'error');
 		});
 	},
 
@@ -130,6 +143,9 @@ registerSuite({
 			testMethod: function () {
 				passedParameters = Array.prototype.slice.call(arguments);
 				callCount += 1;
+			},
+			errorMethod: function () {
+				throw new Error('test');
 			}
 		};
 
@@ -139,6 +155,12 @@ registerSuite({
 			return util.promiseInvokeOrNoop(obj, 'testMethod', testParameters);
 		}).then(function () {
 			assert.sameMembers(passedParameters, testParameters, 'obj.testMethod should be called with test parameters');
+
+			return util.promiseInvokeOrNoop(obj, 'errorMethod');
+		}).then(() => {
+			assert.fail('should not have succeeded');
+		}, (error: any) => {
+			assert.equal(error.message, 'test');
 		});
 	}
 });

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -93,7 +93,7 @@ registerSuite({
 		'debounces callback'(this: any) {
 			const dfd = this.async(TIMEOUT);
 			const debouncedFunction = util.debounce(dfd.callback(function () {
-				assert.isAbove(Date.now() - lastCallTick, 25, 'Function should not be called until period has elapsed without further calls');
+				assert.isAbove(Date.now() - lastCallTick, 10, 'Function should not be called until period has elapsed without further calls');
 
 				// Typically, we expect the 3rd invocation to be the one that is executed.
 				// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -93,8 +93,7 @@ registerSuite({
 		'debounces callback'(this: any) {
 			const dfd = this.async(TIMEOUT);
 			const debouncedFunction = util.debounce(dfd.callback(function () {
-				assert.isAbove(Date.now() - lastCallTick, 24,
-					'Function should not be called until period has elapsed without further calls');
+				assert.isAbove(Date.now() - lastCallTick, 25, 'Function should not be called until period has elapsed without further calls');
 
 				// Typically, we expect the 3rd invocation to be the one that is executed.
 				// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may


### PR DESCRIPTION
> The tests, they did throw uncaught promises a lot.
> Dispatching their promises, the results were forgot.
> Merge this PR,
> and then you will see,
> The test logs don't error, they're clean as can be.

Also, we'll probably want someone familiar with the streams to give this a quick glance to confirm that I'm not hiding any _important_ errors. There shouldn't be anything caught now that wasn't before, but, you never know!