### PR TITLE
Case insensitivity when checking for user-agent header, fixes #168

### DIFF
--- a/src/request/node.ts
+++ b/src/request/node.ts
@@ -126,7 +126,7 @@ export default function node<T>(url: string, options: NodeRequestOptions<T> = {}
 
 	requestOptions.headers = options.headers || {};
 
-	if (!('user-agent' in requestOptions.headers)) {
+	if (!Object.keys(requestOptions.headers).map(headerName => headerName.toLowerCase()).some(headerName => headerName === 'user-agent')) {
 		requestOptions.headers['user-agent'] = 'dojo/' + version + ' Node.js/' + process.version.replace(/^v/, '');
 	}
 

--- a/src/request/xhr.ts
+++ b/src/request/xhr.ts
@@ -127,16 +127,19 @@ export default function xhr<T>(url: string, options: XhrRequestOptions = {}): Re
 
 		const headers = options.headers;
 		let hasContentTypeHeader = false;
+		let hasRequestedWithHeader = false;
 		if (headers) {
 			for (let header in headers) {
 				if (header.toLowerCase() === 'content-type') {
 					hasContentTypeHeader = true;
+				} else if (header.toLowerCase() === 'x-requested-with') {
+					hasRequestedWithHeader = true;
 				}
 				request.setRequestHeader(header, headers[header]);
 			}
 		}
 
-		if (!headers || !('X-Requested-With' in headers)) {
+		if (!hasRequestedWithHeader) {
 			request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 		}
 

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -496,6 +496,34 @@ registerSuite({
 			);
 		},
 
+		'user agent should be added if its not there'(this: any): any {
+			return nodeRequest(getRequestUrl('foo.json'), {}).then((response: any) => {
+				const header: any = response.nativeResponse.req._header;
+
+				assert.include(header, 'user-agent:');
+
+				return nodeRequest(getRequestUrl('food.json'), {
+					headers: {
+						'user-agent': 'already exists'
+					}
+				});
+			}).then((response: any) => {
+				const header: any = response.nativeResponse.req._header;
+
+				assert.include(header, 'user-agent: already exists');
+
+				return nodeRequest(getRequestUrl('food.json'), {
+					headers: {
+						'uSeR-AgEnT': 'mIxEd CaSe'
+					}
+				});
+			}).then((response: any) => {
+				const header: any = response.nativeResponse.req._header;
+
+				assert.include(header, 'uSeR-AgEnT: mIxEd CaSe');
+			});
+		},
+
 		'response headers': {
 			'before response'(this: any): void {
 				const dfd = this.async();

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -346,12 +346,16 @@ registerSuite({
 				}
 				return xhrRequest('/__echo/normalize', {
 					headers: {
-						'CONTENT-TYPE': 'arbitrary-value'
+						'CONTENT-TYPE': 'arbitrary-value',
+						'X-REQUESTED-WITH': 'test'
 					}
 				}).then(function (response: any) {
 					const data = JSON.parse(response.data);
 					assert.isUndefined(data.headers['CONTENT-TYPE']);
 					assert.propertyVal(data.headers, 'content-type', 'arbitrary-value');
+
+					assert.isUndefined(data.headers[ 'X-REQUESTED-WITH' ]);
+					assert.propertyVal(data.headers, 'x-requested-with', 'test');
 				});
 			},
 
@@ -366,6 +370,15 @@ registerSuite({
 				}).then(function (response: any) {
 					const data = JSON.parse(response.data);
 					assert.propertyVal(data.headers, 'content-type', 'application/arbitrary-value');
+
+					return xhrRequest('/__echo/custom', {
+						headers: {
+							'Range': 'bytes=0-1024'
+						}
+					});
+				}).then((response: any) => {
+					const data = JSON.parse(response.data);
+					assert.isDefined(data.headers, 'range');
 				});
 			},
 


### PR DESCRIPTION
> `user-agent` checking was once case sensitive,
> sending it mixed case caused behavior preventative.
> now they are normalized,
> so send them all capitalized,
> and no longer will `USER-AGENT` be decorative.

Note that I although I changed some case sensitivity header checking in `request/xhr`, I did not do anything with setting the user agent.

See, 

https://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-setrequestheader