### PR TITLE
Adding object support to ExtensiblePromise.all, issue #211

### DIFF
--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -58,11 +58,11 @@ export default class ExtensiblePromise<T> {
 	 */
 	static all<F extends ExtensiblePromise<T>, T>(iterable: { [_: string]: T | Promise<T> | Thenable<T> } | Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): F {
 		if (!isArrayLike(iterable) && !isIterable(iterable)) {
-			let promiseKeys = Object.keys(iterable);
+			const promiseKeys = Object.keys(iterable);
 
 			return <F> new this((resolve, reject) => {
 				Promise.all(promiseKeys.map(key => iterable[ key ])).then((promiseResults: T[]) => {
-					let returnValue: {[_: string]: T} = {};
+					const returnValue: {[_: string]: T} = {};
 
 					promiseResults.forEach((value: T, index: number) => {
 						returnValue[ promiseKeys[ index ] ] = value;
@@ -134,7 +134,7 @@ export default class ExtensiblePromise<T> {
 	 */
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): this;
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): this {
-		let e: Executor<U> = (resolve, reject) => {
+		const e: Executor<U> = (resolve, reject) => {
 			function handler(rejected: boolean, valueOrError: T | U | Error) {
 				const callback: ((value: T | U | Error) => (U | Thenable<U> | void)) | undefined = rejected ? onRejected : onFulfilled;
 

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -1,4 +1,4 @@
-import { Iterable, forOf } from 'dojo-shim/iterator';
+import { Iterable, forOf, isIterable, isArrayLike } from 'dojo-shim/iterator';
 import Promise, { Executor } from 'dojo-shim/Promise';
 import { Thenable } from 'dojo-shim/interfaces';
 
@@ -46,12 +46,33 @@ export default class ExtensiblePromise<T> {
 	}
 
 	/**
-	 * Return a ExtensiblePromise that resolves when all of the passed in objects have resolved
+	 * Return a ExtensiblePromise that resolves when all of the passed in objects have resolved. When used with a key/value
+	 * pair, the returned promise's argument is a key/value pair of the original keys with their resolved values.
 	 *
-	 * @param iterable    An iterable of values to resolve. These can be Promises, ExtensiblePromises, or other objects
+	 * @example
+	 * ExtensiblePromise.all({ one: 1, two: 2 }).then(results => console.log(results));
+	 * // { one: 1, two: 2 }
+	 *
+	 * @param iterable    An iterable of values to resolve, or a key/value pair of values to resolve. These can be Promises, ExtensiblePromises, or other objects
 	 * @returns {ExtensiblePromise}
 	 */
-	static all<F extends ExtensiblePromise<T>, T>(iterable: Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): F {
+	static all<F extends ExtensiblePromise<T>, T>(iterable: { [_: string]: T | Promise<T> | Thenable<T> } | Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): F {
+		if (!isArrayLike(iterable) && !isIterable(iterable)) {
+			let promiseKeys = Object.keys(iterable);
+
+			return <F> new this((resolve, reject) => {
+				Promise.all(promiseKeys.map(key => iterable[ key ])).then((promiseResults: T[]) => {
+					let returnValue: {[_: string]: T} = {};
+
+					promiseResults.forEach((value: T, index: number) => {
+						returnValue[ promiseKeys[ index ] ] = value;
+					});
+
+					resolve(returnValue);
+				}, reject);
+			});
+		}
+
 		return <F> new this((resolve, reject) => {
 			Promise.all(unwrapPromises(iterable)).then(resolve, reject);
 		});

--- a/tests/unit/async/ExtensiblePromise.ts
+++ b/tests/unit/async/ExtensiblePromise.ts
@@ -47,5 +47,38 @@ registerSuite({
 			assert.isTrue(false, 'Should not have resolved');
 		}), undefined).catch(dfd.callback(() => {
 		}));
+	},
+
+	'.all': {
+		'with array'() {
+			return ExtensiblePromise.all([ 1, ExtensiblePromise.resolve(2), new ExtensiblePromise((resolve) => {
+				setTimeout(() => resolve(3), 100);
+			}) ]).then((results: any) => {
+				assert.deepEqual(results, [ 1, 2, 3 ]);
+			});
+		},
+
+		'with object'() {
+			return ExtensiblePromise.all({
+				one: 1, two: ExtensiblePromise.resolve(2), three: new ExtensiblePromise((resolve) => {
+					setTimeout(() => resolve(3), 100);
+				})
+			}).then((results: any) => {
+				assert.deepEqual(results, { one: 1, two: 2, three: 3 });
+			});
+		},
+
+		'errors with object'(this: any) {
+			let dfd = this.async();
+
+			ExtensiblePromise.all({
+				one: ExtensiblePromise.resolve(1),
+				two: ExtensiblePromise.reject(new Error('error message'))
+			}).then(dfd.rejectOnError(() => {
+				assert.fail('should have failed');
+			}), dfd.callback((error: Error) => {
+				assert.equal(error.message, 'error message');
+			}));
+		}
 	}
 });


### PR DESCRIPTION
Allowing object support in `ExtensiblePromise.all` and it's derivatives (`Task.all`) (issue #211 ).

```ts
return ExtensiblePromise.all({
    one: 1, two: Promise.resolve(2), three: new ExtensiblePromise((resolve) => {
        setTimeout(() => resolve(3), 100);
    })
}).then((results: any) => {
    // results = { one: 1, two: 2, three: 3 }
});
```

Note that for this to work in IE 10/11, we need this... 

https://github.com/dojo/shim/pull/53