### PR TITLE
Adding v4 UUID generation, issue 214

### DIFF
--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,0 +1,13 @@
+// implementation of v4 UUID from https://github.com/kitsonk/hokan/blob/master/util/main.js
+
+/**
+ * Returns a v4 compliant UUID.
+ *
+ * @returns {string}
+ */
+export default function uuid(): string {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+		const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+		return v.toString(16);
+	});
+}

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,5 +1,3 @@
-// implementation of v4 UUID from https://github.com/kitsonk/hokan/blob/master/util/main.js
-
 /**
  * Returns a v4 compliant UUID.
  *

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -23,4 +23,5 @@ import './stringExtras';
 import './text';
 import './UrlSearchParams';
 import './DateObject';
+import './uuid';
 import './util';

--- a/tests/unit/uuid.ts
+++ b/tests/unit/uuid.ts
@@ -1,0 +1,19 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import uuid from '../../src/uuid';
+
+registerSuite({
+	name: 'uuid functions',
+
+	'v4 uuid'() {
+		const firstId = uuid();
+
+		assert.isDefined(firstId);
+		assert.match(firstId, new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig'));
+
+		const secondId = uuid();
+
+		assert.match(secondId, new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig'));
+		assert.notEqual(firstId, secondId);
+	}
+});


### PR DESCRIPTION
I decided to not go with using `node-uuid`.. My thinking was that this is a pretty small bit of code that will probably never change, so it seems like a lot less overhead to just add it here and forget about it.

I made this a separate module (instead of putting it in `utils`) because I thought perhaps in the future we would want to offer more robust UUID generation (which could then maybe just use `node-uuid`).