### PR TITLE
Adding iterator-like support to IdentityRegistry, issue #200

### DIFF
--- a/src/IdentityRegistry.ts
+++ b/src/IdentityRegistry.ts
@@ -1,8 +1,11 @@
 import Map from 'dojo-shim/Map';
 import WeakMap from 'dojo-shim/WeakMap';
+import { Iterable, IterableIterator } from 'dojo-shim/iterator';
 import { Handle } from 'dojo-interfaces/core';
+import 'dojo-shim/Symbol';
+import List from './List';
 
-const noop = () => {};
+const noop = () => { };
 
 interface Entry<V> {
 	handle: Handle;
@@ -28,7 +31,7 @@ export type Identity = string | symbol;
 /**
  * A registry of values, mapped by identities.
  */
-export default class IdentityRegistry<V extends Object> {
+export default class IdentityRegistry<V extends Object> implements Iterable<[Identity, V]> {
 	constructor() {
 		privateStateMap.set(this, {
 			entryMap: new Map<Identity, Entry<V>>(),
@@ -143,5 +146,33 @@ export default class IdentityRegistry<V extends Object> {
 		getState<V>(this).idMap.set(value, id);
 
 		return handle;
+	}
+
+	entries(): IterableIterator<[Identity, V]> {
+		const values = new List<[Identity, V]>();
+
+		getState<V>(this).entryMap.forEach((value: Entry<V>, key: Identity) => {
+			values.add([key, value.value]);
+		});
+
+		return values.values();
+	}
+
+	values(): IterableIterator<V> {
+		const values = new List<V>();
+
+		getState<V>(this).entryMap.forEach((value: Entry<V>, key: Identity) => {
+			values.add(value.value);
+		});
+
+		return values.values();
+	}
+
+	ids(): IterableIterator<Identity> {
+		return getState<V>(this).entryMap.keys();
+	}
+
+	[Symbol.iterator](): IterableIterator<[Identity, V]> {
+		return this.entries();
 	}
 };

--- a/tests/unit/IdentityRegistry.ts
+++ b/tests/unit/IdentityRegistry.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Symbol from 'dojo-shim/Symbol';
+import { from as arrayFrom } from 'dojo-shim/array';
 
 import IdentityRegistry from '../../src/IdentityRegistry';
 
@@ -169,5 +170,57 @@ registerSuite({
 			handle.destroy();
 			assert.isFalse(registry.has('id'));
 		}
+	},
+
+	'#values'() {
+		const value1 = new Value();
+		const value2 = new Value();
+		const value3 = new Value();
+
+		const registry = new IdentityRegistry<Value>();
+		registry.register('id1', value1);
+		registry.register('id2', value2);
+		registry.register('id3', value3);
+
+		assert.deepEqual(arrayFrom(registry.values()), [ value1, value2, value3 ]);
+	},
+
+	'#ids'() {
+		const value1 = new Value();
+		const value2 = new Value();
+		const value3 = new Value();
+
+		const registry = new IdentityRegistry<Value>();
+		registry.register('id1', value1);
+		registry.register('id2', value2);
+		registry.register('id3', value3);
+
+		assert.deepEqual(arrayFrom(registry.ids()), [ 'id1', 'id2', 'id3' ]);
+	},
+
+	'#entries'() {
+		const value1 = new Value();
+		const value2 = new Value();
+		const value3 = new Value();
+
+		const registry = new IdentityRegistry<Value>();
+		registry.register('id1', value1);
+		registry.register('id2', value2);
+		registry.register('id3', value3);
+
+		assert.deepEqual(arrayFrom(registry.entries()), [ [ 'id1', value1 ], [ 'id2', value2 ], [ 'id3', value3 ] ]);
+	},
+
+	'iterator'() {
+		const value1 = new Value();
+		const value2 = new Value();
+		const value3 = new Value();
+
+		const registry = new IdentityRegistry<Value>();
+		registry.register('id1', value1);
+		registry.register('id2', value2);
+		registry.register('id3', value3);
+
+		assert.deepEqual(arrayFrom(registry), [ [ 'id1', value1 ], [ 'id2', value2 ], [ 'id3', value3 ] ]);
 	}
 });


### PR DESCRIPTION
Adding iterator-like methods to `IdentityRegistry`. Now with 100% more `values`, `entries`, `ids`, and `Symbol.iterator`!