### PR TITLE
Adding readonly modifier where appropriate, issue #180

### DIFF
--- a/src/DateObject.ts
+++ b/src/DateObject.ts
@@ -25,10 +25,10 @@ export interface OperationKwArgs {
  */
 export interface DateProperties {
 	dayOfMonth: number;
-	dayOfWeek: number;
-	daysInMonth: number;
+	readonly dayOfWeek: number;
+	readonly daysInMonth: number;
 	hours: number;
-	isLeapYear: boolean;
+	readonly isLeapYear: boolean;
 	milliseconds: number;
 	minutes: number;
 	month: number;
@@ -67,8 +67,8 @@ export default class DateObject implements DateProperties {
 		return new DateObject(Date.now());
 	}
 
-	private _date: Date;
-	utc: DateProperties;
+	private readonly _date: Date;
+	readonly utc: DateProperties;
 
 	constructor(value: number);
 	constructor(value: string);

--- a/src/IdentityRegistry.ts
+++ b/src/IdentityRegistry.ts
@@ -5,13 +5,13 @@ import { Handle } from 'dojo-interfaces/core';
 const noop = () => {};
 
 interface Entry<V> {
-	handle: Handle;
-	value: V;
+	readonly handle: Handle;
+	readonly value: V;
 }
 
 interface State<V> {
-	entryMap: Map<Identity, Entry<V>>;
-	idMap: WeakMap<V, Identity>;
+	readonly entryMap: Map<Identity, Entry<V>>;
+	readonly idMap: WeakMap<V, Identity>;
 }
 
 const privateStateMap = new WeakMap<IdentityRegistry<any>, State<any>>();

--- a/src/MatchRegistry.ts
+++ b/src/MatchRegistry.ts
@@ -5,8 +5,8 @@ import { Handle } from 'dojo-interfaces/core';
  * the entry.
  */
 interface Entry<T> {
-	test: Test | null;
-	value: T | null;
+	readonly test: Test | null;
+	readonly value: T | null;
 }
 
 /**
@@ -14,7 +14,7 @@ interface Entry<T> {
  */
 export default class MatchRegistry<T> {
 	protected _defaultValue: T | undefined;
-	private _entries: Entry<T>[] | null;
+	private readonly _entries: Entry<T>[] | null;
 
 	/**
 	 * Construct a new MatchRegistry, optionally containing a given default value.

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -17,10 +17,10 @@ export interface KwArgs {
 }
 
 export default class Scheduler {
-	protected _boundDispatch: () => void;
+	protected readonly _boundDispatch: () => void;
 	protected _deferred: QueueItem[] | null;
 	protected _isProcessing: boolean;
-	protected _queue: QueueItem[];
+	protected readonly _queue: QueueItem[];
 	protected _task: Handle | null;
 
 	/**

--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -83,7 +83,7 @@ export default class UrlSearchParams {
 	 * Maps property keys to arrays of values. The value for any property that has been set will be an array containing
 	 * at least one item. Properties that have been deleted will have a value of 'undefined'.
 	 */
-	protected _list: Hash<string[] | undefined>;
+	protected readonly _list: Hash<string[] | undefined>;
 
 	/**
 	 * Appends a new value to the set of values for a key.

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -33,11 +33,11 @@ type AdviceType = 'before' | 'after';
  * A meta data structure when applying advice
  */
 interface Advised {
-	id?: number;
+	readonly id?: number;
 	advice?: Function;
 	previous?: Advised;
 	next?: Advised;
-	receiveArguments?: boolean;
+	readonly receiveArguments?: boolean;
 }
 
 /**

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -73,7 +73,7 @@ export default class ExtensiblePromise<T> {
 	 * @type {Promise}
 	 * The wrapped promise
 	 */
-	_promise: Promise<T>;
+	readonly _promise: Promise<T>;
 
 	/**
 	 * Creates a new extended Promise.

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -54,7 +54,7 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	/**
 	 * Children of this Task (i.e., Tasks that were created from this Task with `then` or `catch`).
 	 */
-	private children: Task<any>[];
+	private readonly children: Task<any>[];
 
 	/**
 	 * The finally callback for this Task (if it was created by a call to `finally`).

--- a/src/request/errors/RequestTimeoutError.ts
+++ b/src/request/errors/RequestTimeoutError.ts
@@ -1,7 +1,7 @@
 import { RequestError, Response } from '../../request';
 
 export default class RequestTimeoutError<T> implements RequestError<T> {
-	message: string;
+	readonly message: string;
 	get name(): string {
 		return 'RequestTimeoutError';
 	}

--- a/src/streams/ReadableStream.ts
+++ b/src/streams/ReadableStream.ts
@@ -143,14 +143,14 @@ export default class ReadableStream<T> {
 
 	protected _pullingPromise: Promise<void> | undefined;
 	protected _started: boolean;
-	protected _startedPromise: Promise<void>;
-	protected _strategy: Strategy<T>;
+	protected readonly _startedPromise: Promise<void>;
+	protected readonly _strategy: Strategy<T>;
 	protected _underlyingSource: Source<T>;
 
 	closeRequested: boolean = false;
 	controller: ReadableStreamController<T>;
 	pullScheduled: boolean;
-	queue: SizeQueue<T>;
+	readonly queue: SizeQueue<T>;
 	reader: ReadableStreamReader<T> | undefined;
 	state: State;
 	storedError: Error;

--- a/src/streams/ReadableStreamController.ts
+++ b/src/streams/ReadableStreamController.ts
@@ -6,7 +6,7 @@ export function isReadableStreamController(x: any): boolean {
 }
 
 export default class ReadableStreamController<T> {
-	private _controlledReadableStream: ReadableStream<T>;
+	private readonly _controlledReadableStream: ReadableStream<T>;
 
 	/**
 	 * Returns a number indicating how much additional data can be pushed by the source to the stream's queue before it

--- a/src/streams/ReadableStreamReader.ts
+++ b/src/streams/ReadableStreamReader.ts
@@ -12,8 +12,8 @@ interface ReadRequest<T> {
  * If the `done` property is true, the stream has no more data to provide.
  */
 export interface ReadResult<T> {
-	value: T | undefined;
-	done: boolean;
+	readonly value: T | undefined;
+	readonly done: boolean;
 }
 
 function isReadableStreamReader<T>(readableStreamReader: ReadableStreamReader<T>): boolean {
@@ -31,7 +31,7 @@ export default class ReadableStreamReader<T> {
 		return this._closedPromise;
 	}
 
-	private _closedPromise: Promise<void>;
+	private readonly _closedPromise: Promise<void>;
 	private _storedError: Error | undefined;
 	private _readRequests: ReadRequest<T>[];
 	private _resolveClosedPromise: () => void;

--- a/src/streams/SizeQueue.ts
+++ b/src/streams/SizeQueue.ts
@@ -1,6 +1,6 @@
 interface Pair<T> {
-	value: T;
-	size: number;
+	readonly value: T;
+	readonly size: number;
 }
 
 /**

--- a/src/streams/TransformStream.ts
+++ b/src/streams/TransformStream.ts
@@ -52,8 +52,8 @@ export interface Transform<R, W> {
  * is a {@link WritableStream}.
  */
 export default class TransformStream<R, W> {
-	readable: ReadableStream<R>;
-	writable: WritableStream<W>;
+	readonly readable: ReadableStream<R>;
+	readonly writable: WritableStream<W>;
 
 	constructor(transformer: Transform<R, W>) {
 		let writeChunk: W | undefined;

--- a/src/streams/WritableStream.ts
+++ b/src/streams/WritableStream.ts
@@ -7,10 +7,10 @@ import * as util from './util';
 // additional metadata used internally.
 export interface Record<T> {
 	// This flag indicates that this record is the end of the stream and the stream should close when processing it
-	close?: boolean;
-	chunk?: T;
-	reject?: (error: Error) => void;
-	resolve?: () => void;
+	readonly close?: boolean;
+	readonly chunk?: T;
+	readonly reject?: (error: Error) => void;
+	readonly resolve?: () => void;
 }
 
 /**
@@ -107,9 +107,9 @@ export default class WritableStream<T> {
 	protected _startedPromise: Promise<any> | undefined;
 	protected _state: State;
 	protected _storedError: Error;
-	protected _strategy: Strategy<T>;
+	protected readonly _strategy: Strategy<T>;
 	protected _underlyingSink: Sink<T> | undefined;
-	protected _queue: SizeQueue<Record<T>>;
+	protected readonly _queue: SizeQueue<Record<T>>;
 	protected _writing: boolean;
 
 	constructor(underlyingSink: Sink<T> = {}, strategy: Strategy<T> = {}) {

--- a/src/streams/interfaces.d.ts
+++ b/src/streams/interfaces.d.ts
@@ -2,7 +2,7 @@ export interface Strategy<T> {
 	/**
 	 * Computes the number of items in a chunk.
 	 */
-	size?: (chunk: T | undefined | null) => number;
+	readonly size?: (chunk: T | undefined | null) => number;
 
 	/**
 	 * The number of chunks allowed in the queue before backpressure is applied.


### PR DESCRIPTION
Added `readonly` modifier where I felt it was appropriate. (issue #180)

At first I was adding it to all interfaces where the declared properties where not being written to, but I decided not to do that, so people could still modify objects that they created.

```ts
let options: KwArgs {
	year: 2016,
	month: 10
};

if(useLastMonth) {
	options.month = 9;
}

const date = new DateObject(options);
```

instead of,

```ts
let month = 10;
if(useLastMonth) { 
	month = 9;
}

let options: KwArgs {
	year: 2016,
	month
};

const date = new DateObject(options);
```

Granted, this is a terrible, contrived, example, but you get the idea.