### PR TITLE
Adding extended observable to implement some RxJs methods, shim #59

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,0 +1,179 @@
+import ObservableShim, { ObservableObject, Subscribable, SubscriptionObserver } from 'dojo-shim/Observable';
+import Promise from 'dojo-shim/Promise';
+import { Iterable } from 'dojo-shim/iterator';
+
+function isSubscribable(object: any): object is Subscribable<any> {
+	return object && object.subscribe !== undefined;
+}
+
+export default class Observable<T> extends ObservableShim<T> {
+
+	static of<T>(...items: T[]): Observable<T> {
+		return <Observable<T>> super.of(...items);
+	}
+
+	static from<T>(item: Iterable<T> | ArrayLike<T> | ObservableObject): Observable<T> {
+		return <Observable<T>> super.from(item);
+	}
+
+	static defer<T>(deferFunction: () => Subscribable<T>): Observable<T> {
+		return new Observable<T>(observer => {
+				const trueObservable = deferFunction();
+
+				return trueObservable.subscribe({
+					next(value: T) {
+						return observer.next(value);
+					},
+					error(errorValue ?: any) {
+						return observer.error(errorValue);
+					},
+					complete(completeValue ?: any) {
+						observer.complete(completeValue);
+					}
+				});
+			}
+		);
+	}
+
+	toPromise(): Promise<T> {
+		return new Promise<T>((resolve, reject) => {
+			this.subscribe({
+				next(value: T) {
+					resolve(value);
+				},
+				error(error: any) {
+					reject(error);
+				}
+			});
+		});
+	}
+
+	map<U>(mapFunction: (x: T) => U): Observable<U> {
+		const self = this;
+
+		if (typeof mapFunction !== 'function') {
+			throw new TypeError('Map parameter must be a function');
+		}
+
+		return new Observable<U>((observer: SubscriptionObserver<U>) => {
+			self.subscribe({
+				next(value: T) {
+					try {
+						let result: U = mapFunction(value);
+						return observer.next(result);
+					} catch (e) {
+						return observer.error(e);
+					}
+				},
+				error(errorValue?: any) {
+					return observer.error(errorValue);
+				},
+				complete(completeValue?: any) {
+					return observer.complete(completeValue);
+				}
+			});
+		});
+	}
+
+	filter(filterFunction: (x: T) => boolean): Observable<T> {
+		const self = this;
+
+		if (typeof filterFunction !== 'function') {
+			throw new TypeError('Filter argument must be a function');
+		}
+
+		return new Observable<T>((observer: SubscriptionObserver<T>) => {
+			self.subscribe({
+				next(value: T) {
+					try {
+						if (filterFunction(value)) {
+							return observer.next(value);
+						}
+					}
+					catch (e) {
+						return observer.error(e);
+					}
+				},
+				error(errorValue?: any) {
+					return observer.error(errorValue);
+				},
+				complete(completeValue?: any) {
+					return observer.complete(completeValue);
+				}
+			});
+		});
+	}
+
+	toArray(): Observable<T[]> {
+		const self = this;
+
+		return new Observable<T[]>(observer => {
+			let values: T[] = [];
+
+			self.subscribe({
+				next(value: T) {
+					values.push(value);
+				},
+				error(errorValue?: any) {
+					return observer.error(errorValue);
+				},
+				complete(completeValue?: any) {
+					observer.next(values);
+					observer.complete(completeValue);
+				}
+			});
+		});
+	}
+
+	mergeAll(concurrent: number): Observable<any> {
+		const self = this;
+
+		return new Observable<Observable<any>>((observer) => {
+			let active: any[] = [];
+			let queue: any[] = [];
+
+			function checkForComplete() {
+				if (active.length === 0 && queue.length === 0) {
+					observer.complete();
+				}
+				else if (queue.length > 0 && active.length < concurrent) {
+					const item = queue.shift();
+
+					if (isSubscribable(item)) {
+						const itemIndex = active.length;
+						active.push(item);
+
+						item.subscribe({
+							next(value: any) {
+								observer.next(value);
+							},
+							complete() {
+								active.splice(itemIndex, 1);
+								checkForComplete();
+							}
+						});
+					} else {
+						observer.next(item);
+						checkForComplete();
+					}
+				}
+			}
+
+			self.subscribe({
+				next(value: T) {
+					queue.push(value);
+				},
+				complete() {
+					checkForComplete();
+				}
+			});
+		});
+	}
+}
+
+// for convienence, re-export some interfaces from shim
+export {
+	Observable,
+	Subscribable,
+	SubscriptionObserver as Observer
+}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -59,9 +59,10 @@ export default class Observable<T> extends ObservableShim<T> {
 			self.subscribe({
 				next(value: T) {
 					try {
-						let result: U = mapFunction(value);
+						const result: U = mapFunction(value);
 						return observer.next(result);
-					} catch (e) {
+					}
+					catch (e) {
 						return observer.error(e);
 					}
 				},
@@ -108,7 +109,7 @@ export default class Observable<T> extends ObservableShim<T> {
 		const self = this;
 
 		return new Observable<T[]>(observer => {
-			let values: T[] = [];
+			const values: T[] = [];
 
 			self.subscribe({
 				next(value: T) {
@@ -152,7 +153,8 @@ export default class Observable<T> extends ObservableShim<T> {
 								checkForComplete();
 							}
 						});
-					} else {
+					}
+					else {
 						observer.next(item);
 						checkForComplete();
 					}

--- a/tests/unit/Observable.ts
+++ b/tests/unit/Observable.ts
@@ -1,0 +1,424 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import Observable from '../../src/Observable';
+
+function asyncRange(start: number, end: number) {
+	return new Observable(observer => {
+		let i = start;
+
+		function handler() {
+			observer.next(i++);
+			if (i > end) {
+				observer.complete();
+			} else {
+				setTimeout(handler, 0);
+
+			}
+		}
+
+		setTimeout(handler, 0);
+	});
+}
+
+registerSuite({
+	name: 'Observable',
+
+	'toPromise': {
+		'resolution with single'() {
+			return Observable.of(42).toPromise().then((value: number) => {
+				assert.strictEqual(value, 42);
+			});
+		},
+		'resolution with multiple'() {
+			return Observable.from([ 1, 2, 3 ]).toPromise().then((value: number) => {
+				assert.strictEqual(value, 1);
+			});
+		},
+		'reject'(this: any) {
+			let dfd = this.async();
+
+			new Observable(() => {
+				throw new Error('error');
+			}).toPromise().then(dfd.rejectOnError(() => {
+				assert.fail('should not have succeeded');
+			}), dfd.callback((error: Error) => {
+				assert.strictEqual(error.message, 'error');
+			}));
+		}
+	},
+	'map': {
+		'transforms values'() {
+			let values: any[] = [],
+				returns: any[] = [];
+
+			new Observable<number>(observer => {
+				returns.push(observer.next(1));
+				returns.push(observer.next(2));
+				observer.complete();
+			}).map(x => x * 2).subscribe({
+				next(v) {
+					values.push(v);
+					return -v;
+				}
+			});
+
+			assert.deepEqual(values, [ 2, 4 ], 'Mapped values are sent to the observer');
+			assert.deepEqual(returns, [ -2, -4 ], 'Return values from the observer are returned to the caller');
+		},
+		'errors during callback get sent to the observer'() {
+			let error = new Error(),
+				thrown = null,
+				returned = null,
+				token = {};
+
+			new Observable<number>(observer => {
+				returned = observer.next(1);
+			}).map(() => {
+				throw error;
+			}).subscribe({
+				error(e) {
+					thrown = e;
+					return token;
+				}
+			});
+
+			assert.equal(thrown, error, 'Exceptions from callback are sent to the observer');
+			assert.equal(returned, token, 'The result of calling error is returned to the caller');
+		},
+		'errors are sent to the observer'() {
+			let error = new Error(),
+				thrown = null,
+				returned = null,
+				token = {};
+
+			new Observable(observer => {
+				returned = observer.error(error);
+			}).map(x => x).subscribe({
+				error(e) {
+					thrown = e;
+					return token;
+				}
+			});
+
+			assert.equal(thrown, error, 'Error values are forwarded');
+			assert.equal(returned, token, 'The return value of the error method is returned to the caller');
+		},
+		'invalid argument errors'() {
+			const observable = new Observable(() => {
+			});
+
+			assert.throws(() => observable.map(<any> undefined), TypeError);
+			assert.throws(() => observable.map(<any> null), TypeError);
+			assert.throws(() => observable.map(<any> {}), TypeError);
+			assert.throws(() => observable.map(<any> 42), TypeError);
+		},
+		'complete is forwarded to the observer'() {
+			let arg = {},
+				passed = null;
+
+			new Observable(observer => {
+				observer.complete(arg);
+			}).map(x => x).subscribe({
+				complete(v) {
+					passed = v;
+				}
+			});
+
+			assert.equal(passed, arg, 'Complete values are forwarded');
+		}
+	},
+
+	'filter': {
+		'allowed argument'() {
+
+			let observable = new Observable(() => undefined);
+
+			assert.throws(() => observable.filter(<any> undefined), TypeError);
+			assert.throws(() => observable.filter(<any> null), TypeError);
+			assert.throws(() => observable.filter(<any> {}), TypeError);
+		},
+		'even numbers'() {
+			const source = Observable.of(1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10).filter((x) => {
+				return x % 2 ? false : true;
+			});
+
+			let values: any[] = [];
+			let finished = false;
+
+			source.subscribe({
+				next(value: number) {
+					values.push(value);
+				},
+				complete() {
+					finished = true;
+				}
+			});
+
+			assert.isTrue(finished);
+			assert.deepEqual(values, [ 2, 4, 6, 8, 10 ]);
+		},
+
+		'errors thrown from callback are returned to observer'() {
+			let error = new Error(),
+				thrown = null,
+				returned = null,
+				token = {};
+
+			new Observable(observer => {
+				returned = observer.next(1);
+			}).filter(x => {
+				throw error;
+			}).subscribe({
+				error(e) {
+					thrown = e;
+					return token;
+				}
+			});
+
+			assert.equal(thrown, error, 'The result of calling error is returned to the caller');
+			assert.equal(returned, token);
+		},
+
+		'errors propagate'() {
+			let error = new Error(),
+				thrown = null,
+				returned = null,
+				token = {};
+
+			new Observable(observer => {
+				returned = observer.error(error);
+			}).filter(x => true).subscribe({
+				error(e) {
+					thrown = e;
+					return token;
+				}
+			});
+
+			assert.equal(thrown, error, 'Error values are forwarded');
+			assert.equal(returned, token, 'The return value of the error method is returned to the caller');
+		},
+
+		'complete is called on the observer'() {
+			let arg = {},
+				passed = null,
+				token = {};
+
+			new Observable(observer => {
+				observer.complete(arg);
+			}).filter(x => true).subscribe({
+				complete(v) {
+					passed = v;
+					return token;
+				}
+			});
+
+			assert.equal(passed, arg, 'Complete values are forwarded');
+		}
+	},
+	'defer': {
+		'execution is deferred until subscribe'() {
+			let called = false;
+			let values: number[] = [];
+
+			const source = Observable.defer(() => {
+				return new Observable<number>(observer => {
+					called = true;
+
+					observer.next(1);
+					observer.next(2);
+				});
+			});
+
+			assert.isFalse(called);
+
+			source.subscribe({
+				next(value) {
+					values.push(value);
+				}
+			});
+
+			assert.isTrue(called);
+			assert.deepEqual(values, [ 1, 2 ]);
+		},
+
+		'errors thrown during factory call are sent to subscriber'() {
+			let error: any = undefined;
+
+			const source = Observable.defer(() => {
+				throw new Error('error');
+			});
+
+			source.subscribe({
+				error(e) {
+					error = e;
+				}
+			});
+
+			assert.equal(error.message, 'error');
+		},
+
+		'errors created in factory observable get propagated to the observer'() {
+			const source = Observable.defer(() => {
+				return new Observable(observer => {
+					observer.error(new Error('error'));
+				});
+			});
+
+			source.subscribe({
+				error(error) {
+					assert.equal(error.message, 'error');
+				}
+			});
+		}
+	},
+
+	'toArray': {
+		'complete list'() {
+			let called = false;
+
+			Observable.from([ 1, 2, 3 ]).toArray().subscribe((values) => {
+				called = true;
+				assert.deepEqual(values, [ 1, 2, 3 ]);
+			});
+
+			assert.isTrue(called);
+		},
+		'errors thrown during subscription are sent to observer'() {
+			new Observable(() => {
+				throw new Error('test');
+			}).toArray().subscribe(() => {
+				assert.fail('should not have succeeded');
+			}, error => {
+				assert.equal(error.message, 'test');
+			});
+		},
+		'errors called are sent to observer'() {
+			new Observable(observer => {
+				observer.error(new Error('test'));
+			}).toArray().subscribe(() => {
+				assert.fail('should not have succeeded');
+			}, error => {
+				assert.equal(error.message, 'test');
+			});
+		},
+		'complete calls are sent to observer'() {
+			let completeValue = 0;
+
+			new Observable(observer => {
+				observer.complete(4);
+			}).toArray().subscribe({
+				complete(value) {
+					completeValue = value;
+				}
+			});
+
+			assert.equal(completeValue, 4);
+		}
+	},
+
+	'mergeAll': {
+		'synchronous concat'() {
+			let values: any[] = [];
+
+			const source = Observable.of(Observable.defer(() => Observable.of(1, 2, 3)), Observable.defer(() => Observable.of(4, 5, 6)));
+
+			source.mergeAll(1).subscribe({
+				next(value) {
+					values.push(value);
+				}
+			});
+
+			assert.deepEqual(values, [ 1, 2, 3, 4, 5, 6 ]);
+		},
+
+		'asynchronous concat'(this: any) {
+			const dfd = this.async();
+			let values: any[] = [];
+
+			const source = Observable.of(
+				Observable.defer(() => asyncRange(1, 2)),
+				Observable.defer(() => asyncRange(3, 4))
+			);
+
+			source.mergeAll(1).subscribe({
+				next(value) {
+					values.push(value);
+				},
+				complete: dfd.callback(() => {
+					assert.deepEqual(values, [ 1, 2, 3, 4 ]);
+				})
+			});
+		},
+
+		'non observable values'() {
+			let values: any[] = [];
+
+			Observable.of(1, 2, 3).mergeAll(1).subscribe(value => {
+				values.push(value);
+			});
+
+			assert.deepEqual(values, [ 1, 2, 3 ]);
+		},
+
+		'concurrency'(this: any) {
+			const dfd = this.async();
+			let values: any[] = [];
+
+			let observables: Observable<any>[] = [];
+
+			observables.push(Observable.defer(() => asyncRange(1, 2)));
+			observables.push(Observable.defer(() => asyncRange(3, 4)));
+			observables.push(Observable.defer(() => asyncRange(5, 6)));
+			observables.push(Observable.defer(() => asyncRange(7, 8)));
+			observables.push(Observable.defer(() => asyncRange(9, 10)));
+			observables.push(Observable.defer(() => asyncRange(11, 12)));
+
+			const source = Observable.from(observables);
+
+			source.mergeAll(2).subscribe({
+				next(value) {
+					values.push(value);
+				},
+				complete: dfd.callback(() => {
+					assert.sameMembers(values, [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]);
+				})
+			});
+		},
+
+		'underused concurrency'(this: any) {
+			const dfd = this.async();
+			let values: any[] = [];
+
+			const source = Observable.of(Observable.defer(() => asyncRange(1, 2)));
+
+			source.mergeAll(2).subscribe({
+				next(value) {
+					values.push(value);
+				},
+				complete: dfd.callback(() => {
+					assert.deepEqual(values, [ 1, 2 ]);
+				})
+			});
+		},
+
+		'thrown errors during merge call observer'() {
+			Observable.of(new Observable(() => {
+				throw new Error('error');
+			})).subscribe({
+				error(error) {
+					assert.equal(error.message, 'error');
+				}
+			});
+		},
+
+		'called errors during merge call observer'() {
+			Observable.of(new Observable(observer => {
+				observer.error(new Error('error'));
+			})).subscribe({
+				error(error) {
+					assert.equal(error.message, 'error');
+				}
+			});
+		}
+	}
+});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -12,6 +12,7 @@ import './lang';
 import './List';
 import './load';
 import './main';
+import './Observable';
 import './on/all';
 import './MatchRegistry';
 import './queue';

--- a/typings.json
+++ b/typings.json
@@ -7,6 +7,6 @@
 		"http-proxy": "github:dojo/typings/custom/http-proxy/http-proxy.d.ts#208e87898cd7a7d65a6f63db4a45846cd7220476",
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
 	}
 }


### PR DESCRIPTION
Adding a more usable version of the `Observable` we added in dojo/shim.  Imports and naming conventions should be similar to RxJs, so most usages can just be replaced with the new import `dojo-core/Observable`.

Added `toPromise`, `defer`, `map`, `filter`, `toArray`, and `mergeAll`.