### PR TITLE
Moving symbol shim out of dev dependencies

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,12 +1,14 @@
 {
 	"name": "dojo-core",
+	"globalDependencies": {
+		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
+	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
 		"http-proxy": "github:dojo/typings/custom/http-proxy/http-proxy.d.ts#208e87898cd7a7d65a6f63db4a45846cd7220476",
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
+		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377"
 	}
 }


### PR DESCRIPTION
We'll need this to release!  Apparently some changes to `grunt-dojo2` made this needed.