### PR TITLE
Type updates for ExtensiblePromise and Task

### DIFF
--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -139,6 +139,7 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
+	then<U, V>(onFulfilled: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected: (reason: Error) => (V | Thenable<V>)): ExtensiblePromise<U | V>;
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): ExtensiblePromise<U>;
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): ExtensiblePromise<U> {
 		const e: Executor<U> = (resolve, reject) => {

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -126,8 +126,8 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): ExtensiblePromise<U>;
-	catch<U>(onRejected: (reason: Error) => void): ExtensiblePromise<U> {
+	catch(onRejected: (reason: Error) => T | Thenable<T> | void): ExtensiblePromise<T>;
+	catch<U>(onRejected: (reason: Error) => U | Thenable<U>): ExtensiblePromise<U> {
 		return this.then<U>(undefined, onRejected);
 	}
 

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -18,7 +18,7 @@ function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 }
 
 export type DictionaryOfPromises<T> = { [_: string]: T | Promise<T> | Thenable<T> };
-export type ListOfPromises<T> = Iterable<(T | Thenable<T>)> | (T | Thenable<T>);
+export type ListOfPromises<T> = Iterable<(T | Thenable<T>)>;
 
 /**
  * An extensible base to allow Promises to be extended in ES5. This class basically wraps a native Promise object,
@@ -42,10 +42,10 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	static resolve(): any;
-	static resolve<T>(value: (T | Thenable<T>)): any;
-	static resolve<T>(value?: any): any {
-		return new this<T>((resolve, reject) => resolve(value));
+	static resolve<F extends ExtensiblePromise<void>>(): F;
+	static resolve<T, F extends ExtensiblePromise<T>>(value: (T | Thenable<T>)): F;
+	static resolve<T, F extends ExtensiblePromise<T>>(value?: any): F {
+		return <F> new this<T>((resolve, reject) => resolve(value));
 	}
 
 	/**
@@ -60,6 +60,8 @@ export default class ExtensiblePromise<T> {
 	 * @returns {ExtensiblePromise}
 	 */
 	static all<F extends ExtensiblePromise<{ [key: string]: T }>, T>(iterable: DictionaryOfPromises<T>): F;
+	static all<F extends ExtensiblePromise<T[]>, T>(iterable: (T | Thenable<T>)[]): F;
+	static all<F extends ExtensiblePromise<T[]>, T>(iterable: T | Thenable<T>): F;
 	static all<F extends ExtensiblePromise<T[]>, T>(iterable: ListOfPromises<T>): F;
 	static all<F extends ExtensiblePromise<any>, T>(iterable: DictionaryOfPromises<T> | ListOfPromises<T>): F {
 		if (!isArrayLike(iterable) && !isIterable(iterable)) {
@@ -124,8 +126,8 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): this;
-	catch<U>(onRejected: (reason: Error) => void): this {
+	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): ExtensiblePromise<U>;
+	catch<U>(onRejected: (reason: Error) => void): ExtensiblePromise<U> {
 		return this.then<U>(undefined, onRejected);
 	}
 
@@ -137,8 +139,8 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): this;
-	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): this {
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): ExtensiblePromise<U>;
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): ExtensiblePromise<U> {
 		const e: Executor<U> = (resolve, reject) => {
 			function handler(rejected: boolean, valueOrError: T | U | Error) {
 				const callback: ((value: T | U | Error) => (U | Thenable<U> | void)) | undefined = rejected ? onRejected : onFulfilled;

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -229,6 +229,7 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
+	then<U, V>(onFulfilled: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected: (reason: Error) => (V | Thenable<V>)): Task<U | V>;
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): Task<U>;
 	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): Task<U>;
 	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error: Error) => U | Thenable<U>): Task<U> {

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -195,9 +195,9 @@ export default class Task<T> extends ExtensiblePromise<T> {
 		}
 	}
 
-	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): Task<U>;
-	catch<U>(onRejected: (reason: Error) => void): Task<U> {
-		return <Task<U>> super.catch(onRejected);
+	catch(onRejected: (reason: Error) => T | Thenable<T> | void): Task<T>;
+	catch<U>(onRejected: (reason: Error) => U | Thenable<U>): Task<U> {
+		return this.then(undefined, onRejected);
 	}
 
 	/**

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -166,6 +166,11 @@ export default class Task<T> extends ExtensiblePromise<T> {
 		}
 	}
 
+	catch<U>(onRejected: (reason: Error) => (U | Thenable<U>)): Task<U>;
+	catch<U>(onRejected: (reason: Error) => void): Task<U> {
+		return <Task<U>> super.catch(onRejected);
+	}
+
 	/**
 	 * Allows for cleanup actions to be performed after resolution of a Promise.
 	 */
@@ -195,10 +200,12 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error: Error) => U | Thenable<U>): this {
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => void): Task<U>;
+	then<U>(onFulfilled?: ((value: T) => (U | Thenable<U> | undefined)) | undefined, onRejected?: (reason: Error) => (U | Thenable<U>)): Task<U>;
+	then<U>(onFulfilled?: (value?: T) => U | Thenable<U>, onRejected?: (error: Error) => U | Thenable<U>): Task<U> {
 		// FIXME
 		// tslint:disable-next-line:no-var-keyword
-		var task = super.then<U>(
+		var task = <Task<U>> super.then<U>(
 			// Don't call the onFulfilled or onRejected handlers if this Task is canceled
 			function (value) {
 				if (task._state === State.Canceled) {

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -1,6 +1,7 @@
 import { Thenable } from 'dojo-shim/interfaces';
 import { Executor } from 'dojo-shim/Promise';
-import ExtensiblePromise from './ExtensiblePromise';
+import ExtensiblePromise, { ListOfPromises, DictionaryOfPromises } from './ExtensiblePromise';
+import { Iterable } from 'dojo-shim/iterator';
 
 /**
  * Describe the internal state of a task.
@@ -34,6 +35,26 @@ export function isThenable<T>(value: any): value is Thenable<T> {
  */
 export default class Task<T> extends ExtensiblePromise<T> {
 	/**
+	 * Return a Task that resolves when one of the passed in objects have resolved
+	 *
+	 * @param iterable    An iterable of values to resolve. These can be Promises, ExtensiblePromises, or other objects
+	 * @returns {Task}
+	 */
+	static race<F extends ExtensiblePromise<T>, T>(iterable: Iterable<(T | Thenable<T>)> | (T | Thenable<T>)[]): Task<T> {
+		return <Task<T>> super.race(iterable);
+	}
+
+	/**
+	 * Return a rejected promise wrapped in a Task
+	 *
+	 * @param {Error?} reason    The reason for the rejection
+	 * @returns {Task}
+	 */
+	static reject<T>(reason?: Error): Task<T> {
+		return new this<T>((resolve, reject) => reject(reason));
+	}
+
+	/**
 	 * Return a resolved task.
 	 *
 	 * @param value The value to resolve with
@@ -44,6 +65,14 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	public static resolve<T>(value: (T | Thenable<T>)): Task<T>;
 	public static resolve<T>(value?: any): Task<T> {
 		return new this<T>((resolve, reject) => resolve(value));
+	}
+
+	static all<T>(iterable: DictionaryOfPromises<T>): Task<{ [key: string]: T }>;
+	static all<T>(iterable: (T | Thenable<T>)[]): Task<T[]>;
+	static all<T>(iterable: T | Thenable<T>): Task<T[]>;
+	static all<T>(iterable: ListOfPromises<T>): Task<T[]>;
+	static all<T>(iterable: DictionaryOfPromises<T> | ListOfPromises<T>): Task<any> {
+		return <Task<T>> super.all(iterable);
 	}
 
 	/**

--- a/src/async/timing.ts
+++ b/src/async/timing.ts
@@ -34,7 +34,7 @@ export function timeout<T>(milliseconds: number, reason: Error): Identity<T> {
 		if (Date.now() - milliseconds > start) {
 			return Promise.reject<T>(reason);
 		}
-		return Promise.resolve<T>(value);
+		return Promise.resolve(value);
 	};
 }
 


### PR DESCRIPTION
There were some issues with `ExtensiblePromise` and `Task` not returning the right types from `then`, `resolve`, and `all`.  

This hopefully fixes those problems :)