### PR TITLE
Load enhancements

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -46,17 +46,26 @@ function processModules(modules: any, isDefault: boolean): Object | Object[] {
 }
 
 const load: Load = (function (): Load {
-	if (typeof module === 'object' && typeof module.exports === 'object') {
-		return function (contextualRequire: any, isDefault: any, ...moduleIds: string[]): Promise<any[]> {
-			if (typeof isDefault !== 'boolean') {
+	return function (contextualRequire: any, isDefault: any, ...moduleIds: string[]): Promise<any[]> {
+		if (typeof contextualRequire === 'boolean') {
+			if (typeof isDefault === 'string') {
 				moduleIds.unshift(isDefault);
-				isDefault = true;
 			}
-			if (typeof contextualRequire === 'string') {
-				moduleIds.unshift(contextualRequire);
-				contextualRequire = require;
+			isDefault = contextualRequire;
+			contextualRequire = require;
+		}
+		if (typeof isDefault !== 'boolean') {
+			if (typeof isDefault === 'string') {
+				moduleIds.unshift(isDefault);
 			}
-			return new Promise(function (resolve, reject) {
+			isDefault = true;
+		}
+		if (typeof contextualRequire === 'string') {
+			moduleIds.unshift(contextualRequire);
+			contextualRequire = require;
+		}
+		return new Promise(function (resolve, reject) {
+			if (typeof module === 'object' && typeof module.exports === 'object') {
 				try {
 					resolve(moduleIds.map(function (moduleId): any {
 						return processModules(contextualRequire(moduleId), isDefault);
@@ -65,31 +74,17 @@ const load: Load = (function (): Load {
 				catch (error) {
 					reject(error);
 				}
-			});
-		};
-	}
-	else if (typeof define === 'function' && define.amd) {
-		return function (contextualRequire: any, isDefault: any, ...moduleIds: string[]): Promise<any[]> {
-			if (typeof isDefault !== 'boolean') {
-				moduleIds.unshift(isDefault);
-				isDefault = true;
 			}
-			if (typeof contextualRequire === 'string') {
-				moduleIds.unshift(contextualRequire);
-				contextualRequire = require;
-			}
-			return new Promise(function (resolve) {
+			else if (typeof define === 'function' && define.amd) {
 				// TODO: Error path once https://github.com/dojo/loader/issues/14 is figured out
 				contextualRequire(moduleIds, function (...modules: any[]) {
 					resolve(processModules(modules, isDefault));
 				});
-			});
-		};
-	}
-	else {
-		return function () {
-			return Promise.reject(new Error('Unknown loader'));
-		};
-	}
+			}
+			else {
+				reject(new Error('Unknown loader'));
+			}
+		});
+	};
 })();
 export default load;

--- a/src/request.ts
+++ b/src/request.ts
@@ -69,9 +69,9 @@ export class ProviderRegistry extends MatchRegistry<RequestProvider> {
 		// provider. While that import is in-flight, subsequent requests will queue up while
 		// waiting for the provider to be fulfilled.
 		this._defaultValue = (url: string, options?: RequestOptions): ResponsePromise<any> => {
-			this._providerPromise = load(require, defaultProvider).then(([ providerModule ]: [ { default: RequestProvider } ]): RequestProvider => {
-				this._defaultValue = providerModule.default;
-				return providerModule.default;
+			this._providerPromise = load(require, defaultProvider).then(([ providerModule ]: [ RequestProvider ]): RequestProvider => {
+				this._defaultValue = providerModule;
+				return providerModule;
 			});
 			this._defaultValue = deferRequest;
 			return deferRequest(url, options);

--- a/tests/support/load/a.ts
+++ b/tests/support/load/a.ts
@@ -1,2 +1,4 @@
 export const one = 1;
 export const two = 2;
+const a = 'A';
+export default a;

--- a/tests/support/load/b.ts
+++ b/tests/support/load/b.ts
@@ -1,2 +1,4 @@
 export const three = 3;
 export const four = 4;
+const b = 'B';
+export default b;

--- a/tests/support/load/node.ts
+++ b/tests/support/load/node.ts
@@ -3,7 +3,8 @@ import { Require } from 'dojo-interfaces/loader';
 
 declare const require: Require;
 
-export const succeed = load(require, './a', './b');
+export const succeedDefault = load(require, './a', './b');
+export const succeedNonDefault = load(require, false, './a', './b');
 export const fail = load(require, './a', './c');
 
 export const globalSucceed = load('fs', 'path');

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -11,16 +11,12 @@ declare const require: RootRequire;
 const suite: any = {
 	name: 'load',
 
-	before() {
-		return load('tests/support/load/a', 'tests/support/load/b');
-	},
-
 	'global load'(this: any) {
 		const def = this.async(5000);
 
 		load('src/has', 'dojo-shim/Promise').then(def.callback(function ([ hasModule, promiseModule ]: [ any, any ]) {
-			assert.strictEqual(hasModule.default, has);
-			assert.strictEqual(promiseModule.default, Promise);
+			assert.strictEqual(hasModule, has);
+			assert.strictEqual(promiseModule, Promise);
 		}));
 	},
 

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -1,8 +1,10 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import has from '../../src/has';
+import * as _hasModule from '../../src/has';
 import load from '../../src/load';
 import Promise from 'dojo-shim/Promise';
+import * as _promiseModule from 'dojo-shim/Promise';
 import { RootRequire } from 'dojo-interfaces/loader';
 import global from '../../src/global';
 
@@ -11,24 +13,62 @@ declare const require: RootRequire;
 const suite: any = {
 	name: 'load',
 
-	'global load'(this: any) {
-		const def = this.async(5000);
+	'default load - load default export only': {
+		'load single module'(this: any) {
+			const def = this.async(5000);
 
-		load('src/has', 'dojo-shim/Promise').then(def.callback(function ([ hasModule, promiseModule ]: [ any, any ]) {
-			assert.strictEqual(hasModule, has);
-			assert.strictEqual(promiseModule, Promise);
-		}));
+			load('src/has').then(def.callback(function ([ hasModule ]: [ any ]) {
+				assert.strictEqual(hasModule, has);
+			}));
+		},
+		'load multiple modules'(this: any) {
+			const def = this.async(5000);
+
+			load('src/has', 'dojo-shim/Promise').then(def.callback(function ([ hasModule, promiseModule ]: [ any, any ]) {
+				assert.strictEqual(hasModule, has);
+				assert.strictEqual(promiseModule, Promise);
+			}));
+		},
+		'contextual load'(this: any) {
+			const def = this.async(5000);
+
+			load(require, '../support/load/a', '../support/load/b').then(def.callback(function ([ a, b ]: [ any, any ]) {
+				assert.deepEqual(a, 'A');
+				assert.deepEqual(b, 'B');
+			}));
+		}
 	},
+	'non-default load - load all exports but default one': {
+		'load single module'(this: any) {
+			const def = this.async(5000);
 
-	'contextual load'(this: any) {
-		const def = this.async(5000);
+			load(false, 'src/has').then(def.callback(function ([ hasModule ]: [ any ]) {
+				const hasModuleCopy: any = { ..._hasModule };
+				delete hasModuleCopy['default'];
+				assert.deepEqual(hasModule, hasModuleCopy);
+			}));
+		},
+		'load multiple modules'(this: any) {
+			const def = this.async(5000);
 
-		load(require, '../support/load/a', '../support/load/b').then(def.callback(function ([ a, b ]: [ any, any ]) {
-			assert.deepEqual(a, { one: 1, two: 2 });
-			assert.deepEqual(b, { three: 3, four: 4 });
-		}));
+			load(false, 'src/has', 'dojo-shim/Promise').then(def.callback(function ([ hasModule, promiseModule ]: [ any, any ]) {
+				const hasModuleCopy: any = { ..._hasModule };
+				const promiseModuleCopy: any = { ..._promiseModule };
+				delete hasModuleCopy['default'];
+				delete promiseModuleCopy['default'];
+				assert.deepEqual(hasModule, hasModuleCopy);
+				assert.deepEqual(promiseModule, promiseModuleCopy);
+			}));
+		},
+		'contextual load'(this: any) {
+			const def = this.async(5000);
+
+			load(require, false, '../support/load/a', '../support/load/b').then(def.callback(function ([ a, b ]: [ any, any ]) {
+				assert.deepEqual(a, { one: 1, two: 2 });
+				assert.deepEqual(b, { three: 3, four: 4 });
+			}));
+		}
 	}
-
 	// TODO: once AMD error handling is figured out, add tests for the failure case
 };
 
@@ -64,10 +104,19 @@ if (has('host-node')) {
 			}));
 		},
 
-		'contextual load succeeds'(this: any) {
+		'contextual load succeeds - default load'(this: any) {
 			const def = this.async(5000);
 
-			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeed;
+			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedDefault;
+			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
+				assert.deepEqual(a, 'A');
+				assert.deepEqual(b, 'B');
+			}));
+		},
+		'contextual load succeeds - non-default load'(this: any) {
+			const def = this.async(5000);
+
+			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedNonDefault;
 			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
 				assert.deepEqual(a, { one: 1, two: 2 });
 				assert.deepEqual(b, { three: 3, four: 4 });


### PR DESCRIPTION
Enhance `load()` with options to load based on `__esModule` metadata either: a) default export. b) all exports except default. The default behavior is a). Existing code spreading across all other packages that depends on `load()` will have to update as well.

Resolves: #210