### PR TITLE
Task: prevent finally w/canceled from resolving

### DIFF
--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -88,7 +88,7 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	/**
 	 * The finally callback for this Task (if it was created by a call to `finally`).
 	 */
-	private _finally: () => any;
+	private _finally: () => void;
 
 	/**
 	 * The state of the task

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -88,7 +88,7 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	/**
 	 * The finally callback for this Task (if it was created by a call to `finally`).
 	 */
-	private _finally: () => void | Thenable<any>;
+	private _finally: () => any;
 
 	/**
 	 * The state of the task
@@ -203,10 +203,11 @@ export default class Task<T> extends ExtensiblePromise<T> {
 	/**
 	 * Allows for cleanup actions to be performed after resolution of a Promise.
 	 */
-	finally(callback: () => void | Thenable<any>): Task<T> {
+	finally(callback: () => void): Task<T> {
 		// if this task is already canceled, call the task
 		if (this._state === State.Canceled) {
-			return Task.resolve(callback());
+			callback();
+			return this;
 		}
 
 		const task = this.then<any>(

--- a/tests/unit/async/Task.ts
+++ b/tests/unit/async/Task.ts
@@ -242,6 +242,17 @@ let suite = {
 			setTimeout(dfd.callback(() => {
 				assert.equal(callCount, 1);
 			}), 100);
+		},
+
+		'finally does not change the resolve value'(this: any) {
+			const dfd = this.async();
+			let task = new Task((resolve) => {
+				setTimeout(resolve.bind(null, 'test'), 10);
+			});
+			task = task.finally(() => 'changed');
+			task.then(dfd.callback((value: string) => {
+				assert.strictEqual(value, 'test');
+			}));
 		}
 	},
 


### PR DESCRIPTION
Prevent scenario where finally call after cancel results in a resolved Task.

Currently, `Task#finally` will return a new resolved Task when the task has already been cancelled. This leads to some inconsistencies where the Task returned by Finally will either be resolved or will not be resolvable, all depending on when `cancel` is called. 

```typescript
// This will return a new Task that is resolved to the return 
// value of the callback, allowing for further chaining of then calls
let task = new Task((resolve) => {
	setTimeout(resolve.bind(null, 'test'), 10);
});
task.cancel();
task = task.finally(() => 'changed');
task.then((value: string) => {
       // This callback will be called, resolving to the return value
       // of the finally call
	console.log(value); // changed
});

// However, when cancel is called after the finally callback is setup,
// the subsequent then call is never run.

let task2 = new Task((resolve) => {
	setTimeout(resolve.bind(null, 'test'), 10);
});
task2 = task2.finally(() => 'changed');
task2.then((value: string) => {
       // This is never resolved
	console.log(value);
});
task2.cancel();
```

This fixes the inconsistency by instead calling the callback passed to `finally` and then returning the same Task instance, which won't resolve if the Task has been cancelled. 