### PR TITLE
Merging compose/aspect with core/aspect

### DIFF
--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,4 +1,5 @@
 import { Handle } from '@dojo/interfaces/core';
+import WeakMap from '@dojo/shim/WeakMap';
 import { createHandle } from './lang';
 
 /**
@@ -27,7 +28,7 @@ export interface Indexable {
  */
 export type Targetable = MapLike<string, any> | Indexable;
 
-type AdviceType = 'before' | 'after';
+type AdviceType = 'before' | 'after' | 'around';
 
 /**
  * A meta data structure when applying advice
@@ -52,6 +53,54 @@ interface Dispatcher {
 	around?: Advised;
 	after?: Advised;
 }
+
+export interface JoinPointDispatchAdvice<T> {
+	before?: JoinPointBeforeAdvice[];
+	after?: JoinPointAfterAdvice<T>[];
+	readonly joinPoint: Function;
+}
+
+export interface JoinPointAfterAdvice<T> {
+	/**
+	 * Advice which is applied *after*, receiving the result and arguments from the join point.
+	 *
+	 * @param result The result from the function being advised
+	 * @param args The arguments that were supplied to the advised function
+	 * @returns The value returned from the advice is then the result of calling the method
+	 */
+	(result: T, ...args: any[]): T;
+}
+
+export interface JoinPointAroundAdvice<T> {
+	/**
+	 * Advice which is applied *around*.  The advising function receives the original function and
+	 * needs to return a new function which will then invoke the original function.
+	 *
+	 * @param origFn The original function
+	 * @returns A new function which will invoke the original function.
+	 */
+	(origFn: GenericFunction<T>): (...args: any[]) => T;
+}
+
+export interface JoinPointBeforeAdvice {
+	/**
+	 * Advice which is applied *before*, receiving the original arguments, if the advising
+	 * function returns a value, it is passed further along taking the place of the original
+	 * arguments.
+	 *
+	 * @param args The arguments the method was called with
+	 */
+	(...args: any[]): any[] | void;
+}
+
+export interface GenericFunction<T> {
+	(...args: any[]): T;
+}
+
+/**
+ * A weak map of dispatchers used to apply the advice
+ */
+const dispatchAdviceMap = new WeakMap<Function, JoinPointDispatchAdvice<any>>();
 
 /**
  * A UID for tracking advice ordering
@@ -129,6 +178,31 @@ function advise(
 }
 
 /**
+ * Advise a join point (function) with supplied advice
+ *
+ * @param joinPoint The function to be advised
+ * @param type The type of advice to be applied
+ * @param advice The advice to apply
+ */
+function adviseJoinPoint<F extends GenericFunction<T>, T>(this: any, joinPoint: F, type: AdviceType, advice: JoinPointBeforeAdvice | JoinPointAfterAdvice<T> | JoinPointAroundAdvice<T>): F {
+	let dispatcher: F;
+	if (type === 'around') {
+		dispatcher = getJoinPointDispatcher(advice.apply(this, [ joinPoint ]));
+	}
+	else {
+		dispatcher = getJoinPointDispatcher(joinPoint);
+		const adviceMap = dispatchAdviceMap.get(dispatcher);
+		if (type === 'before') {
+			(adviceMap.before || (adviceMap.before = [])).unshift(<JoinPointBeforeAdvice> advice);
+		}
+		else {
+			(adviceMap.after || (adviceMap.after = [])).push(advice);
+		}
+	}
+	return dispatcher;
+}
+
+/**
  * An internal function that resolves or creates the dispatcher for a given join point
  *
  * @param target The target object or map
@@ -200,6 +274,55 @@ function getDispatcher(target: Targetable, methodName: string): Dispatcher {
 }
 
 /**
+ * Returns the dispatcher function for a given joinPoint (method/function)
+ *
+ * @param joinPoint The function that is to be advised
+ */
+function getJoinPointDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): F {
+
+	function dispatcher(this: Function, ...args: any[]): T {
+		const { before, after, joinPoint } = dispatchAdviceMap.get(dispatcher);
+		if (before) {
+			args = before.reduce((previousArgs, advice) => {
+				const currentArgs = advice.apply(this, previousArgs);
+				return currentArgs || previousArgs;
+			}, args);
+		}
+		let result = joinPoint.apply(this, args);
+		if (after) {
+			result = after.reduce((previousResult, advice) => {
+				return advice.apply(this, [ previousResult ].concat(args));
+			}, result);
+		}
+		return result;
+	}
+
+	/* We want to "clone" the advice that has been applied already, if this
+	 * joinPoint is already advised */
+	if (dispatchAdviceMap.has(joinPoint)) {
+		const adviceMap = dispatchAdviceMap.get(joinPoint);
+		let { before, after } = adviceMap;
+		if (before) {
+			before = before.slice(0);
+		}
+		if (after) {
+			after = after.slice(0);
+		}
+		dispatchAdviceMap.set(dispatcher, {
+			joinPoint: adviceMap.joinPoint,
+			before,
+			after
+		});
+	}
+	/* Otherwise, this is a new joinPoint, so we will create the advice map afresh */
+	else {
+		dispatchAdviceMap.set(dispatcher, { joinPoint });
+	}
+
+	return dispatcher as F;
+}
+
+/**
  * Attaches "after" advice to be executed after the original method.
  * The advising function will receive the original method's return value and arguments object.
  * The value it returns will be returned from the method when it is called (even if the return value is undefined).
@@ -211,6 +334,16 @@ function getDispatcher(target: Targetable, methodName: string): Dispatcher {
  */
 export function after(target: Targetable, methodName: string, advice: (originalReturn: any, originalArgs: IArguments) => any): Handle {
 	return advise(getDispatcher(target, methodName), 'after', advice);
+}
+
+/**
+ * Apply advice *after* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The after advice
+ */
+export function afterJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAfterAdvice<T>): F {
+	return adviseJoinPoint(joinPoint, 'after', advice);
 }
 
 /**
@@ -245,6 +378,16 @@ export function around(target: Targetable, methodName: string, advice: ((previou
 }
 
 /**
+ * Apply advice *around* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The around advice
+ */
+export function aroundJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAroundAdvice<T>): F {
+	return adviseJoinPoint<F, T>(joinPoint, 'around', advice);
+}
+
+/**
  * Attaches "before" advice to be executed before the original method.
  *
  * @param target Object whose method will be aspected
@@ -254,6 +397,16 @@ export function around(target: Targetable, methodName: string, advice: ((previou
  */
 export function before(target: Targetable, methodName: string, advice: (...originalArgs: any[]) => any[] | void): Handle {
 	return advise(getDispatcher(target, methodName), 'before', advice);
+}
+
+/**
+ * Apply advice *before* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The before advice
+ */
+export function beforeJoinPoint<F extends GenericFunction<any>>(joinPoint: F, advice: JoinPointBeforeAdvice): F {
+	return adviseJoinPoint(joinPoint, 'before', advice);
 }
 
 /**

--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -323,6 +323,16 @@ function getJoinPointDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): 
 }
 
 /**
+ * Apply advice *after* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The after advice
+ */
+function afterJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAfterAdvice<T>): F {
+	return adviseJoinPoint(joinPoint, 'after', advice);
+}
+
+/**
  * Attaches "after" advice to be executed after the original method.
  * The advising function will receive the original method's return value and arguments object.
  * The value it returns will be returned from the method when it is called (even if the return value is undefined).
@@ -334,16 +344,6 @@ function getJoinPointDispatcher<F extends GenericFunction<T>, T>(joinPoint: F): 
  */
 function afterObject(target: Targetable, methodName: string, advice: (originalReturn: any, originalArgs: IArguments) => any): Handle {
 	return adviseObject(getDispatcherObject(target, methodName), 'after', advice);
-}
-
-/**
- * Apply advice *after* the supplied joinPoint (function)
- *
- * @param joinPoint A function that should have advice applied to
- * @param advice The after advice
- */
-function afterJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAfterAdvice<T>): F {
-	return adviseJoinPoint(joinPoint, 'after', advice);
 }
 
 /**
@@ -371,6 +371,16 @@ export function after<F extends GenericFunction<T>, T>(joinPointOrTarget: F | Ta
 	else {
 		return afterObject(joinPointOrTarget, <string> methodNameOrAdvice, objectAdvice!);
 	}
+}
+
+/**
+ * Apply advice *around* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The around advice
+ */
+export function aroundJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAroundAdvice<T>): F {
+	return adviseJoinPoint<F, T>(joinPoint, 'around', advice);
 }
 
 /**
@@ -405,16 +415,20 @@ export function aroundObject(target: Targetable, methodName: string, advice: ((p
 }
 
 /**
+ * Attaches "around" advice around the original method.
+ *
+ * @param target Object whose method will be aspected
+ * @param methodName Name of method to aspect
+ * @param advice Advising function which will receive the original function
+ * @return A handle which will remove the aspect when destroy is called
+ */
+export function around(target: Targetable, methodName: string, advice: ((previous: Function) => Function)): Handle;
+/**
  * Apply advice *around* the supplied joinPoint (function)
  *
  * @param joinPoint A function that should have advice applied to
  * @param advice The around advice
  */
-export function aroundJoinPoint<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAroundAdvice<T>): F {
-	return adviseJoinPoint<F, T>(joinPoint, 'around', advice);
-}
-
-export function around(target: Targetable, methodName: string, advice: ((previous: Function) => Function)): Handle;
 export function around<F extends GenericFunction<T>, T>(joinPoint: F, advice: JoinPointAroundAdvice<T>): F;
 export function around<F extends GenericFunction<T>, T>(joinPointOrTarget: F | Targetable, methodNameOrAdvice: string | JoinPointAroundAdvice<T>, objectAdvice?: ((previous: Function) => Function)): Handle | F {
 	if (typeof joinPointOrTarget === 'function') {
@@ -423,6 +437,16 @@ export function around<F extends GenericFunction<T>, T>(joinPointOrTarget: F | T
 	else {
 		return aroundObject(joinPointOrTarget, <string> methodNameOrAdvice, objectAdvice!);
 	}
+}
+
+/**
+ * Apply advice *before* the supplied joinPoint (function)
+ *
+ * @param joinPoint A function that should have advice applied to
+ * @param advice The before advice
+ */
+export function beforeJoinPoint<F extends GenericFunction<any>>(joinPoint: F, advice: JoinPointBeforeAdvice): F {
+	return adviseJoinPoint(joinPoint, 'before', advice);
 }
 
 /**
@@ -438,16 +462,20 @@ export function beforeObject(target: Targetable, methodName: string, advice: (..
 }
 
 /**
+ * Attaches "before" advice to be executed before the original method.
+ *
+ * @param target Object whose method will be aspected
+ * @param methodName Name of method to aspect
+ * @param advice Advising function which will receive the same arguments as the original, and may return new arguments
+ * @return A handle which will remove the aspect when destroy is called
+ */
+export function before(target: Targetable, methodName: string, advice: (...originalArgs: any[]) => any[] | void): Handle;
+/**
  * Apply advice *before* the supplied joinPoint (function)
  *
  * @param joinPoint A function that should have advice applied to
  * @param advice The before advice
  */
-export function beforeJoinPoint<F extends GenericFunction<any>>(joinPoint: F, advice: JoinPointBeforeAdvice): F {
-	return adviseJoinPoint(joinPoint, 'before', advice);
-}
-
-export function before(target: Targetable, methodName: string, advice: (...originalArgs: any[]) => any[] | void): Handle;
 export function before<F extends GenericFunction<any>>(joinPoint: F, advice: JoinPointBeforeAdvice): F;
 export function before<F extends GenericFunction<T>, T>(joinPointOrTarget: F | Targetable, methodNameOrAdvice: string | JoinPointBeforeAdvice, objectAdvice?: ((...originalArgs: any[]) => any[] | void)): Handle | F {
 	if (typeof joinPointOrTarget === 'function') {

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -561,5 +561,216 @@ registerSuite({
 				assert.isFalse(aroundFunction.called);
 			}
 		}
+	},
+	'join points': {
+		'before advice': {
+			'adjust arguments': function () {
+				let result = 0;
+				function foo(a: number) {
+					result = a;
+				}
+
+				function advice(a: number) {
+					return [ a * a ];
+				}
+
+				const fn = aspect.beforeJoinPoint(foo, advice);
+
+				fn(2);
+
+				assert.strictEqual(result, 4, '"result" should equal 4');
+			},
+			'passes this': function () {
+				let result = 0;
+				function foo(this: any) {
+					result = this.a;
+				}
+
+				function advice(this: any) {
+					this.a = 2;
+				}
+
+				const fn = aspect.beforeJoinPoint(foo, advice);
+				const context = { a: 0 };
+				fn.call(context);
+				assert.strictEqual(context.a, 2, 'context.a should equal 2');
+				assert.strictEqual(result, 2, 'result should equal 2');
+			},
+			'multiple before advice': function () {
+				let result = 0;
+				const calls: string[] = [];
+				function foo(a: number) {
+					result = a;
+				}
+
+				function advice1(...args: any[]) {
+					calls.push('1');
+					args[0] = args[0] + args[0];
+					return args;
+				}
+
+				function advice2(a: number) {
+					calls.push('2');
+					return [ ++a ];
+				}
+
+				const fn = aspect.beforeJoinPoint(aspect.beforeJoinPoint(foo, advice1), advice2);
+				fn(2);
+				assert.strictEqual(result, 6, '"result" should equal 5');
+				assert.deepEqual(calls, [ '2', '1' ], 'advice should be called in order');
+			}
+		},
+		'after advice': {
+			'adjust return value': function () {
+				function foo(a: number) {
+					return a;
+				}
+
+				function advice(prevResult: number, ...args: any[]) {
+					return prevResult * args[0];
+				}
+
+				const fn = aspect.afterJoinPoint(foo, advice);
+
+				const result = fn(2);
+
+				assert.strictEqual(result, 4, '"result" should equal 4');
+			},
+			'passes this': function () {
+				function foo(this: any) {
+					return this.a;
+				}
+
+				function advice(this: any, prevResult: number) {
+					this.c = prevResult + this.b;
+					return this.c;
+				}
+
+				const fn = aspect.afterJoinPoint(foo, advice);
+				const context = { a: 2, b: 2, c: 0 };
+				const result = fn.call(context);
+				assert.strictEqual(result, 4, '"result" should equal 4');
+				assert.strictEqual(context.c, 4, '"context.c" should equal 4');
+			},
+			'multiple after advice': function () {
+				const calls: string[] = [];
+				function foo(a: number): number {
+					return a;
+				}
+
+				function advice1(prevResult: number, ...args: any[]) {
+					calls.push('1');
+					return prevResult + args[0];
+				}
+
+				function advice2(prevResult: number, ...args: any[]) {
+					calls.push('2');
+					return prevResult + args[0] + 1;
+				}
+
+				let fn = aspect.afterJoinPoint(foo, advice1);
+				fn = aspect.afterJoinPoint(fn, advice2);
+				const result = fn(2);
+				assert.strictEqual(result, 7, '"result" should equal 7');
+				assert.deepEqual(calls, [ '1', '2' ], 'call should have been made in order');
+			}
+		},
+		'around advice': {
+			'basic function': function () {
+				function foo(a: number): number {
+					return a;
+				}
+
+				function advice(origFn: Function): (...args: any[]) => number {
+					return function(this: any, ...args: any[]): number {
+						args[0] = args[0] + args[0];
+						let result = origFn.apply(this, args);
+						return ++result;
+					};
+				}
+
+				const fn = aspect.aroundJoinPoint(foo, advice);
+				const result = fn(2);
+				assert.strictEqual(result, 5, '"result" should equal 5');
+			},
+			'preserves this': function () {
+				function foo(this: any, a: number): number {
+					return this.a;
+				}
+
+				function advice(origFn: Function): (...args: any[]) => number {
+					return function(this: any, ...args: any[]): number {
+						this.a = 2;
+						return origFn.apply(this, args);
+					};
+				}
+
+				const context = { a: 2 };
+				const fn = aspect.aroundJoinPoint(foo, advice);
+				const result = fn.apply(context);
+				assert.strictEqual(result, 2, '"result" should equal 2');
+			},
+			'multiple around advice': function () {
+				const calls: string[] = [];
+				function foo(a: number): number {
+					return a;
+				}
+
+				function advice1(origFn: Function): (...args: any[]) => number {
+					return function (this: any, ...args: any[]): number {
+						calls.push('1');
+						args[0]++;
+						return origFn.apply(this, args) + 1;
+					};
+				}
+
+				function advice2(origFn: Function): (...args: any[]) => number {
+					return function (this: any, ...args: any[]): number {
+						calls.push('2');
+						args[0] += args[0];
+						return origFn.apply(this, args) + 1;
+					};
+				}
+
+				const fn = aspect.aroundJoinPoint(aspect.aroundJoinPoint(foo, advice1), advice2);
+				const result = fn(2);
+				assert.strictEqual(result, 7, '"result" should equal 7');
+				assert.deepEqual(calls, [ '2', '1' ]);
+			}
+		},
+		'combined advice': {
+			'before and after': function () {
+				function foo(a: number): number {
+					return a + a;
+				}
+
+				function adviceBefore(...args: any[]): any[] {
+					args[0] = args[0] + args[0];
+					return args;
+				}
+
+				function adviceAfter(origResult: number, ...args: any[]): number {
+					return origResult + args[0] + 1;
+				}
+
+				let fn = aspect.afterJoinPoint(foo, adviceAfter);
+				fn = aspect.beforeJoinPoint(fn, adviceBefore);
+				const result = fn(2);
+				assert.strictEqual(result, 13, '"result" should equal 13');
+			}
+		},
+		'chained advice'() {
+			function foo(a: string): string {
+				return a;
+			}
+
+			function adviceAfter(origResult: string): string {
+				return origResult + 'foo';
+			}
+
+			const fn = aspect.afterJoinPoint(aspect.afterJoinPoint(foo, adviceAfter), adviceAfter);
+			aspect.afterJoinPoint(fn, adviceAfter);
+			assert.strictEqual(fn('bar'), 'barfoofoo', 'should only apply advice twice');
+		}
 	}
 });

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -574,7 +574,7 @@ registerSuite({
 					return [ a * a ];
 				}
 
-				const fn = aspect.beforeJoinPoint(foo, advice);
+				const fn = aspect.before(foo, advice);
 
 				fn(2);
 
@@ -590,7 +590,7 @@ registerSuite({
 					this.a = 2;
 				}
 
-				const fn = aspect.beforeJoinPoint(foo, advice);
+				const fn = aspect.before(foo, advice);
 				const context = { a: 0 };
 				fn.call(context);
 				assert.strictEqual(context.a, 2, 'context.a should equal 2');
@@ -614,7 +614,7 @@ registerSuite({
 					return [ ++a ];
 				}
 
-				const fn = aspect.beforeJoinPoint(aspect.beforeJoinPoint(foo, advice1), advice2);
+				const fn = aspect.before(aspect.before(foo, advice1), advice2);
 				fn(2);
 				assert.strictEqual(result, 6, '"result" should equal 5');
 				assert.deepEqual(calls, [ '2', '1' ], 'advice should be called in order');
@@ -630,7 +630,7 @@ registerSuite({
 					return prevResult * args[0];
 				}
 
-				const fn = aspect.afterJoinPoint(foo, advice);
+				const fn = aspect.after(foo, advice);
 
 				const result = fn(2);
 
@@ -646,7 +646,7 @@ registerSuite({
 					return this.c;
 				}
 
-				const fn = aspect.afterJoinPoint(foo, advice);
+				const fn = aspect.after(foo, advice);
 				const context = { a: 2, b: 2, c: 0 };
 				const result = fn.call(context);
 				assert.strictEqual(result, 4, '"result" should equal 4');
@@ -668,8 +668,8 @@ registerSuite({
 					return prevResult + args[0] + 1;
 				}
 
-				let fn = aspect.afterJoinPoint(foo, advice1);
-				fn = aspect.afterJoinPoint(fn, advice2);
+				let fn = aspect.after(foo, advice1);
+				fn = aspect.after(fn, advice2);
 				const result = fn(2);
 				assert.strictEqual(result, 7, '"result" should equal 7');
 				assert.deepEqual(calls, [ '1', '2' ], 'call should have been made in order');
@@ -689,7 +689,7 @@ registerSuite({
 					};
 				}
 
-				const fn = aspect.aroundJoinPoint(foo, advice);
+				const fn = aspect.around(foo, advice);
 				const result = fn(2);
 				assert.strictEqual(result, 5, '"result" should equal 5');
 			},
@@ -706,7 +706,7 @@ registerSuite({
 				}
 
 				const context = { a: 2 };
-				const fn = aspect.aroundJoinPoint(foo, advice);
+				const fn = aspect.around(foo, advice);
 				const result = fn.apply(context);
 				assert.strictEqual(result, 2, '"result" should equal 2');
 			},
@@ -732,7 +732,7 @@ registerSuite({
 					};
 				}
 
-				const fn = aspect.aroundJoinPoint(aspect.aroundJoinPoint(foo, advice1), advice2);
+				const fn = aspect.around(aspect.around(foo, advice1), advice2);
 				const result = fn(2);
 				assert.strictEqual(result, 7, '"result" should equal 7');
 				assert.deepEqual(calls, [ '2', '1' ]);
@@ -753,8 +753,8 @@ registerSuite({
 					return origResult + args[0] + 1;
 				}
 
-				let fn = aspect.afterJoinPoint(foo, adviceAfter);
-				fn = aspect.beforeJoinPoint(fn, adviceBefore);
+				let fn = aspect.after(foo, adviceAfter);
+				fn = aspect.before(fn, adviceBefore);
 				const result = fn(2);
 				assert.strictEqual(result, 13, '"result" should equal 13');
 			}
@@ -768,8 +768,8 @@ registerSuite({
 				return origResult + 'foo';
 			}
 
-			const fn = aspect.afterJoinPoint(aspect.afterJoinPoint(foo, adviceAfter), adviceAfter);
-			aspect.afterJoinPoint(fn, adviceAfter);
+			const fn = aspect.after(aspect.after(foo, adviceAfter), adviceAfter);
+			aspect.after(fn, adviceAfter);
 			assert.strictEqual(fn('bar'), 'barfoofoo', 'should only apply advice twice');
 		}
 	}


### PR DESCRIPTION
Issue #144 

This should be backwards compatible with the original `after`, `before`, and `around` methods provided by `core/aspect`, as well as be able to accept functions with no objects (from `compose/aspect`).