### PR TITLE
Adding loader helper to load ES modules, issue #210

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -1,6 +1,6 @@
+import { forOf, isIterable, isArrayLike } from '@dojo/shim/iterator';
 import Promise from '@dojo/shim/Promise';
 import { Require } from '@dojo/interfaces/loader';
-import { isArray } from 'util';
 
 declare const require: Require;
 
@@ -23,10 +23,14 @@ export interface Load {
 export function useDefault(modules: any[]): any[];
 export function useDefault(module: any): any;
 export function useDefault(modules: any | any[]): any[] | any {
-	if (isArray(modules)) {
-		return modules.map((module: any) => {
-			return (module.__esModule && module.default) ? module.default : module;
+	if (isIterable(modules) || isArrayLike(modules)) {
+		let processedModules: any[] = [];
+
+		forOf(modules, (module) => {
+			processedModules.push((module.__esModule && module.default) ? module.default : module);
 		});
+
+		return processedModules;
 	}
 	else {
 		return (modules.__esModule && modules.default) ? modules.default : modules;

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,5 +1,6 @@
 import Promise from '@dojo/shim/Promise';
 import { Require } from '@dojo/interfaces/loader';
+import { isArray } from 'util';
 
 declare const require: Require;
 
@@ -17,6 +18,19 @@ export type Require = Require | NodeRequire;
 export interface Load {
 	(require: Require, ...moduleIds: string[]): Promise<any[]>;
 	(...moduleIds: string[]): Promise<any[]>;
+}
+
+export function useDefault(modules: any[]): any[];
+export function useDefault(module: any): any;
+export function useDefault(modules: any | any[]): any[] | any {
+	if (isArray(modules)) {
+		return modules.map((module: any) => {
+			return (module.__esModule && module.default) ? module.default : module;
+		});
+	}
+	else {
+		return (modules.__esModule && modules.default) ? modules.default : modules;
+	}
 }
 
 const load: Load = (function (): Load {

--- a/tests/support/load/a.ts
+++ b/tests/support/load/a.ts
@@ -1,2 +1,5 @@
 export const one = 1;
 export const two = 2;
+
+const a = 'A';
+export default a;

--- a/tests/support/load/b.ts
+++ b/tests/support/load/b.ts
@@ -1,2 +1,5 @@
 export const three = 3;
 export const four = 4;
+
+const b = 'B';
+export default b;

--- a/tests/support/load/node.ts
+++ b/tests/support/load/node.ts
@@ -1,9 +1,10 @@
-import load from '../../../src/load';
+import load, { useDefault } from '../../../src/load';
 import { Require } from '@dojo/interfaces/loader';
 
 declare const require: Require;
 
 export const succeed = load(require, './a', './b');
+export const succeedDefault = load(require, './a', './b').then(useDefault);
 export const fail = load(require, './a', './c');
 
 export const globalSucceed = load('fs', 'path');

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -1,7 +1,7 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import has from '../../src/has';
-import load from '../../src/load';
+import load, { useDefault } from '../../src/load';
 import Promise from '@dojo/shim/Promise';
 import { RootRequire } from '@dojo/interfaces/loader';
 import global from '../../src/global';
@@ -28,9 +28,23 @@ const suite: any = {
 		const def = this.async(5000);
 
 		load(require, '../support/load/a', '../support/load/b').then(def.callback(function ([ a, b ]: [ any, any ]) {
-			assert.deepEqual(a, { one: 1, two: 2 });
-			assert.deepEqual(b, { three: 3, four: 4 });
+			assert.deepEqual(a, { 'default': 'A', one: 1, two: 2 });
+			assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
 		}));
+	},
+
+	'contextual load - all es 6 modules'() {
+		return load(require, '../support/load/a', '../support/load/b').then(useDefault).then(([ a, b ]: any[]) => {
+			assert.deepEqual(a, 'A');
+			assert.deepEqual(b, 'B');
+		});
+	},
+
+	'contextual load - single es 6 module'() {
+		return load(require, '../support/load/a', '../support/load/b').then(([ a, b ]) => [ useDefault(a), b ]).then(([ a, b ]: any[]) => {
+			assert.deepEqual(a, 'A');
+			assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
+		});
 	}
 
 	// TODO: once AMD error handling is figured out, add tests for the failure case
@@ -73,8 +87,18 @@ if (has('host-node')) {
 
 			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeed;
 			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
-				assert.deepEqual(a, { one: 1, two: 2 });
-				assert.deepEqual(b, { three: 3, four: 4 });
+				assert.deepEqual(a, { 'default': 'A', one: 1, two: 2 });
+				assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
+			}));
+		},
+
+		'useDefault resolves es modules'(this: any) {
+			const def = this.async(5000);
+
+			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedDefault;
+			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
+				assert.deepEqual(a, 'A');
+				assert.deepEqual(b, 'B');
 			}));
 		},
 


### PR DESCRIPTION
Adding a helper to make loading ES modules easier. This is based on @matt-gadd 's suggestion in https://github.com/dojo/core/pull/262

```ts
import load, { useDefault } from '@dojo/core/load';

load('es-module').then(useDefault).then([module] => { /* do something */ });
```

`useDefault` will check if a module has the `__esModule` meta data and if so, return the module's `default` value.

Can also be used on an individual module,

```ts
load('a', 'b').then([a, b] => [useDefault(a), b]).then([moduleA, moduleB] => { /* do something */ });
```

Resolves #210 
