### PR TITLE
Add error handling to AMD require in `load`

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -62,9 +62,18 @@ const load: Load = (function (): Load {
 				moduleIds.unshift(contextualRequire);
 				contextualRequire = require;
 			}
-			return new Promise(function (resolve) {
-				// TODO: Error path once https://github.com/dojo/loader/issues/14 is figured out
+			return new Promise(function (resolve, reject) {
+				let errorHandle: { remove: () => void };
+
+				if (typeof contextualRequire.on === 'function') {
+					errorHandle = contextualRequire.on('error', (error: Error) => {
+						errorHandle.remove();
+						reject(error);
+					});
+				}
+
 				contextualRequire(moduleIds, function (...modules: any[]) {
+					errorHandle && errorHandle.remove();
 					resolve(modules);
 				});
 			});

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -53,7 +53,7 @@ const suite: any = {
 		}, (error: Error) => {
 			assert(error);
 			assert.isTrue(error.message.indexOf('some/bogus/nonexistent/thing') > -1,
-				'The error message contains the module ID.');
+				'The error message contains the module id.');
 		});
 	}
 };

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -45,9 +45,17 @@ const suite: any = {
 			assert.deepEqual(a, 'A');
 			assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
 		});
-	}
+	},
 
-	// TODO: once AMD error handling is figured out, add tests for the failure case
+	'error handling'() {
+		return load('some/bogus/nonexistent/thing').then(() => {
+			throw new Error('Should not resolve.');
+		}, (error: Error) => {
+			assert(error);
+			assert.isTrue(error.message.indexOf('some/bogus/nonexistent/thing') > -1,
+				'The error message contains the module ID.');
+		});
+	}
 };
 
 if (has('host-node')) {


### PR DESCRIPTION
Resolves #272, so that the `core/load` promise rejects when the AMD loader reports an error for the module id(s) being loaded.