### PR TITLE
Migrating Evented and Destroyable from widget-core, issue #286

### DIFF
--- a/src/Destroyable.ts
+++ b/src/Destroyable.ts
@@ -1,0 +1,65 @@
+import { Handle } from '@dojo/interfaces/core';
+import Promise from '@dojo/shim/Promise';
+
+/**
+ * No operation function to replace own once instance is destoryed
+ */
+function noop(): Promise<boolean> {
+	return Promise.resolve(false);
+};
+
+/**
+ * No op function used to replace own, once instance has been destoryed
+ */
+function destroyed(): never {
+	throw new Error('Call made to destroyed method');
+};
+
+export class Destroyable {
+	/**
+	 * register handles for the instance
+	 */
+	private handles: Handle[];
+
+	/**
+	 * @constructor
+	 */
+	constructor() {
+		this.handles = [];
+	}
+
+	/**
+	 * Register handles for the instance that will be destroyed when `this.destroy` is called
+	 *
+	 * @param {Handle} handle The handle to add for the instance
+	 * @returns {Handle} a handle for the handle, removes the handle for the instance and calls destroy
+	 */
+	own(handle: Handle): Handle {
+		const { handles } = this;
+		handles.push(handle);
+		return {
+			destroy() {
+				handles.splice(handles.indexOf(handle));
+				handle.destroy();
+			}
+		};
+	}
+
+	/**
+	 * Destrpys all handers registered for the instance
+	 *
+	 * @returns {Promise<any} a promise that resolves once all handles have been destroyed
+	 */
+	destroy(): Promise<any> {
+		return new Promise((resolve) => {
+			this.handles.forEach((handle) => {
+				handle && handle.destroy && handle.destroy();
+			});
+			this.destroy = noop;
+			this.own = destroyed;
+			resolve(true);
+		});
+	}
+}
+
+export default Destroyable;

--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -1,35 +1,151 @@
-import { Handle, EventObject } from '@dojo/interfaces/core';
+import { EventObject, EventTargettedObject, EventErrorObject, Handle } from '@dojo/interfaces/core';
+import { EventedListener, EventedListenerOrArray, EventedListenersMap, EventedCallback } from '@dojo/interfaces/bases';
+import { Actionable } from '@dojo/interfaces/abilities';
 import { on } from './aspect';
+import Map from '@dojo/shim/Map';
+import { Destroyable } from './Destroyable';
 
-export default class Evented {
-	/**
-	 * Emits an event, firing listeners registered for it.
-	 * @param event The event object to emit
-	 */
-	emit<T extends EventObject>(data: T): void {
-		const type = '__on' + data.type;
-		const method: Function = (<any> this)[type];
-		if (method) {
-			method.call(this, data);
-		}
-	}
+/**
+ * Determines is the value is Actionable (has a `.do` function)
+ *
+ * @param value the value to check
+ * @returns boolean indicating is the value is Actionable
+ */
+function isActionable(value: any): value is Actionable<any, any> {
+	return Boolean(value && typeof value.do === 'function');
+}
 
-	/**
-	 * Listens for an event, calling the listener whenever the event fires.
-	 * @param type Event type to listen for
-	 * @param listener Callback to handle the event when it fires
-	 * @return A handle which will remove the listener when destroy is called
-	 */
-	on(type: string, listener: (event: EventObject) => void): Handle {
-		const name = '__on' + type;
-		if (!(<any> this)[name]) {
-			// define a non-enumerable property (see #77)
-			Object.defineProperty(this, name, {
-				configurable: true,
-				value: undefined,
-				writable: true
-			});
+/**
+ * Resolve listeners.
+ */
+function resolveListener<T, E extends EventTargettedObject<T>>(listener: EventedListener<T, E>): EventedCallback<E> {
+	return isActionable(listener) ? (event: E) => listener.do({ event }) : listener;
+}
+
+/**
+ * Handles an array of handles
+ *
+ * @param handles an array of handles
+ * @returns a single Handle for handles passed
+ */
+function handlesArraytoHandle(handles: Handle[]): Handle {
+	return {
+		destroy() {
+			handles.forEach((handle) => handle.destroy());
 		}
-		return on(this, name, listener);
+	};
+}
+
+/**
+ * Interface for Evented constructor options
+ */
+export interface EventedOptions {
+	/**
+	 * Optional listeners to add
+	 */
+	listeners?: EventedListenersMap<any>;
+}
+
+/**
+ * Map of computed regular expressions, keyed by string
+ */
+const regexMap = new Map<string, RegExp>();
+
+/**
+ * Determines is the event type glob has been matched
+ *
+ * @returns boolean that indicates if the glob is matched
+ */
+export function isGlobMatch(globString: string, targetString: string): boolean {
+	if (globString.indexOf('*') !== -1) {
+		let regex: RegExp;
+		if (regexMap.has(globString)) {
+			regex = regexMap.get(globString)!;
+		}
+		else {
+			regex = new RegExp(`^${ globString.replace(/\*/g, '.*') }$`);
+			regexMap.set(globString, regex);
+		}
+		return regex.test(targetString);
+
+	} else {
+		return globString === targetString;
 	}
 }
+
+/**
+ * Event Class
+ */
+export class Evented extends Destroyable {
+
+	/**
+	 * map of listeners keyed by event type
+	 */
+	protected listenersMap: Map<string, EventedCallback<EventObject>> = new Map<string, EventedCallback<EventObject>>();
+
+	/**
+	 * @constructor
+	 * @param options The constructor argurments
+	 */
+	constructor(options: EventedOptions = {}) {
+		super();
+		const { listeners } = options;
+		if (listeners) {
+			this.own(this.on(listeners));
+		}
+	}
+
+	/**
+	 * Emits the event objet for the specified type
+	 *
+	 * @param event the event to emit
+	 */
+	emit<E extends EventObject>(event: E): void {
+		this.listenersMap.forEach((method, type) => {
+			if (isGlobMatch(type, event.type)) {
+				method.call(this, event);
+			}
+		});
+	}
+
+	/**
+	 * Regsister a callback for a specific event type
+	 *
+	 * @param listeners map of listeners
+	 */
+	on(listeners: EventedListenersMap<Evented>): Handle;
+
+	/**
+	 * @param type the type of the event
+	 * @param listener the listener to attach
+	 */
+	on(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
+
+	/**
+	 * @param type the type for `error`
+	 * @param listener the listener to attach
+	 */
+	on(type: 'error', listener: EventedListenerOrArray<Evented, EventErrorObject<Evented>>): Handle;
+	on(...args: any[]): Handle {
+		if (args.length === 2) {
+			const [ type, listeners ] = <[ string, EventedListenerOrArray<any, EventTargettedObject<any>>]> args;
+			if (Array.isArray(listeners)) {
+				const handles = listeners.map((listener) => on(this.listenersMap, type, resolveListener(listener)));
+				return handlesArraytoHandle(handles);
+			}
+			else {
+				return on(this.listenersMap, type, resolveListener(listeners));
+			}
+		}
+		else if (args.length === 1) {
+			const [ listenerMapArg ] = <[EventedListenersMap<any>]> args;
+			const handles = Object.keys(listenerMapArg).map((type) => this.on(type, listenerMapArg[type]));
+			return handlesArraytoHandle(handles);
+		}
+		else {
+			throw new TypeError('Invalid arguments');
+		}
+	}
+}
+
+export default Evented;

--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -46,6 +46,31 @@ export interface EventedOptions {
 	listeners?: EventedListenersMap<any>;
 }
 
+export interface BaseEventedEvents {
+	/**
+	 * Regsister a callback for a specific event type
+	 *
+	 * @param listeners map of listeners
+	 */
+	(listeners: EventedListenersMap<Evented>): Handle;
+
+	/**
+	 * @param type the type of the event
+	 * @param listener the listener to attach
+	 */
+	(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
+
+	/**
+	 * @param type the type for `error`
+	 * @param listener the listener to attach
+	 */
+	(type: 'error', listener: EventedListenerOrArray<Evented, EventErrorObject<Evented>>): Handle;
+}
+
+interface EventedOnInterface {
+	on: BaseEventedEvents;
+}
+
 /**
  * Map of computed regular expressions, keyed by string
  */
@@ -76,7 +101,7 @@ export function isGlobMatch(globString: string, targetString: string): boolean {
 /**
  * Event Class
  */
-export class Evented extends Destroyable {
+export class Evented extends Destroyable implements EventedOnInterface {
 
 	/**
 	 * map of listeners keyed by event type
@@ -108,25 +133,7 @@ export class Evented extends Destroyable {
 		});
 	}
 
-	/**
-	 * Regsister a callback for a specific event type
-	 *
-	 * @param listeners map of listeners
-	 */
-	on(listeners: EventedListenersMap<Evented>): Handle;
-
-	/**
-	 * @param type the type of the event
-	 * @param listener the listener to attach
-	 */
-	on(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
-
-	/**
-	 * @param type the type for `error`
-	 * @param listener the listener to attach
-	 */
-	on(type: 'error', listener: EventedListenerOrArray<Evented, EventErrorObject<Evented>>): Handle;
-	on(...args: any[]): Handle {
+	on: BaseEventedEvents = function (this: Evented, ...args: any[]) {
 		if (args.length === 2) {
 			const [ type, listeners ] = <[ string, EventedListenerOrArray<any, EventTargettedObject<any>>]> args;
 			if (Array.isArray(listeners)) {
@@ -145,7 +152,7 @@ export class Evented extends Destroyable {
 		else {
 			throw new TypeError('Invalid arguments');
 		}
-	}
+	};
 }
 
 export default Evented;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,27 +2,6 @@
  * They are only provided here to make the transistion to @dojo/interfaces easier */
 
 /**
- * The base event object, which provides a `type` property
- */
-export interface EventObject {
-	/**
-	 * The type of the event
-	 */
-	readonly type: string;
-}
-
-/**
- * Used through the toolkit as a consistent API to manage how callers can "cleanup"
- * when doing a function.
- */
-export interface Handle {
-	/**
-	 * Perform the destruction/cleanup logic associated with this handle
-	 */
-	destroy(): void;
-}
-
-/**
  * A general interface that can be used to renference a general index map of values of a particular type
  */
 export interface Hash<T> {

--- a/src/request/Response.ts
+++ b/src/request/Response.ts
@@ -1,18 +1,8 @@
-import { Handle, EventTargettedObject } from '@dojo/interfaces/core';
 import Promise from '@dojo/shim/Promise';
 import Task from '../async/Task';
 import QueuingEvented from '../QueuingEvented';
 import Headers from './Headers';
-import {
-	Response as ResponseInterface,
-	RequestOptions,
-	DataEvent,
-	EndEvent,
-	StartEvent,
-	ProgressEvent
-} from './interfaces';
-import { EventedListenersMap, EventedListenerOrArray } from '@dojo/interfaces/bases';
-import { Evented } from '../Evented';
+import { Response as ResponseInterface, RequestOptions } from './interfaces';
 
 export interface ResponseData {
 	task: Task<any>;
@@ -30,16 +20,6 @@ abstract class Response extends QueuingEvented implements ResponseInterface {
 
 	json<T>(): Task<T> {
 		return <any> this.text().then(JSON.parse);
-	}
-
-	on(type: 'progress', fn: (event: ProgressEvent) => void): Handle;
-	on(type: 'data', fn: (event: DataEvent) => void): Handle;
-	on(type: 'end', fn: (event: EndEvent) => void): Handle;
-	on(type: 'start', fn: (event: StartEvent) => void): Handle;
-	on(listeners: EventedListenersMap<Evented>): Handle;
-	on(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
-	on(...args: any[]): Handle {
-		return (<any> super.on)(...args);
 	}
 
 	abstract arrayBuffer(): Task<ArrayBuffer>;

--- a/src/request/Response.ts
+++ b/src/request/Response.ts
@@ -1,3 +1,8 @@
+import { Handle, EventTargettedObject } from '@dojo/interfaces/core';
+import Promise from '@dojo/shim/Promise';
+import Task from '../async/Task';
+import QueuingEvented from '../QueuingEvented';
+import Headers from './Headers';
 import {
 	Response as ResponseInterface,
 	RequestOptions,
@@ -6,11 +11,8 @@ import {
 	StartEvent,
 	ProgressEvent
 } from './interfaces';
-import Headers from './Headers';
-import Task from '../async/Task';
-import QueuingEvented from '../QueuingEvented';
-import { EventObject, Handle } from '@dojo/interfaces/core';
-import Promise from '@dojo/shim/Promise';
+import { EventedListenersMap, EventedListenerOrArray } from '@dojo/interfaces/bases';
+import { Evented } from '../Evented';
 
 export interface ResponseData {
 	task: Task<any>;
@@ -26,10 +28,6 @@ abstract class Response extends QueuingEvented implements ResponseInterface {
 	abstract readonly bodyUsed: boolean;
 	readonly requestOptions: RequestOptions;
 
-	emit(event: ProgressEvent | DataEvent | EndEvent | StartEvent) {
-		super.emit(event);
-	}
-
 	json<T>(): Task<T> {
 		return <any> this.text().then(JSON.parse);
 	}
@@ -38,8 +36,10 @@ abstract class Response extends QueuingEvented implements ResponseInterface {
 	on(type: 'data', fn: (event: DataEvent) => void): Handle;
 	on(type: 'end', fn: (event: EndEvent) => void): Handle;
 	on(type: 'start', fn: (event: StartEvent) => void): Handle;
-	on(type: string, fn: (event: EventObject) => void): Handle {
-		return super.on(type, fn);
+	on(listeners: EventedListenersMap<Evented>): Handle;
+	on(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
+	on(...args: any[]): Handle {
+		return (<any> super.on)(...args);
 	}
 
 	abstract arrayBuffer(): Task<ArrayBuffer>;

--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -29,6 +29,7 @@ export interface Headers {
 
 interface ResponseEvent {
 	response: Response;
+	target: any;
 }
 
 export interface DataEvent extends ResponseEvent {

--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -1,8 +1,9 @@
-import Task from '../async/Task';
-import UrlSearchParams from '../UrlSearchParams';
-import { ParamList } from '../UrlSearchParams';
+import { EventedListenerOrArray } from '@dojo/interfaces/bases';
 import { Handle } from '@dojo/interfaces/core';
 import { IterableIterator } from '@dojo/shim/iterator';
+import Task from '../async/Task';
+import { BaseEventedEvents, Evented } from '../Evented';
+import UrlSearchParams, { ParamList } from '../UrlSearchParams';
 
 export interface Body {
 	readonly bodyUsed: boolean;
@@ -66,6 +67,13 @@ export interface RequestOptions {
 	query?: string | ParamList;
 }
 
+export interface ResponseEvents extends BaseEventedEvents {
+	(type: 'data', handler: EventedListenerOrArray<Evented, DataEvent>): Handle;
+	(type: 'end', handler: EventedListenerOrArray<Evented, EndEvent>): Handle;
+	(type: 'progress', handler: EventedListenerOrArray<Evented, ProgressEvent>): Handle;
+	(type: 'start', handler: EventedListenerOrArray<Evented, StartEvent>): Handle;
+}
+
 export interface Response extends Body {
 	readonly headers: Headers;
 	readonly ok: boolean;
@@ -73,8 +81,5 @@ export interface Response extends Body {
 	readonly statusText: string;
 	readonly url: string;
 
-	on(type: 'data', fn: (event?: DataEvent) => void): Handle;
-	on(type: 'end', fn: (event?: EndEvent) => void): Handle;
-	on(type: 'progress', fn: (event?: ProgressEvent) => void): Handle;
-	on(type: 'start', fn: (event?: StartEvent) => void): Handle;
+	on: ResponseEvents;
 }

--- a/tests/unit/Destroyable.ts
+++ b/tests/unit/Destroyable.ts
@@ -1,0 +1,52 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { Destroyable } from '../../src/Destroyable';
+
+registerSuite({
+	name: 'bases/Destroyable',
+	'own/destroy handle'() {
+		let count = 0;
+
+		const destroyable = new Destroyable();
+		destroyable.own({
+			destroy() {
+				count++;
+			}
+		});
+
+		assert.strictEqual(count, 0, 'handle should not be called yet');
+		return destroyable.destroy().then(() => {
+			assert.strictEqual(count, 1, 'handle should have been called');
+			return destroyable.destroy().then(() => {
+				assert.strictEqual(count, 1, 'handle should not have been called again');
+			});
+		});
+	},
+	'own after destruction throws'() {
+		const destroyable = new Destroyable();
+		destroyable.own({
+			destroy() {}
+		});
+		return destroyable.destroy().then(() => {
+			assert.throws(() => {
+				destroyable.own({
+					destroy() {}
+				});
+			}, Error);
+		});
+	},
+	'own handle destruction'() {
+		let count = 0;
+		const destroyable = new Destroyable();
+		const handle = destroyable.own({
+			destroy() {
+				count++;
+			}
+		});
+		assert.strictEqual(count, 0, 'destroy not called yet');
+		handle.destroy();
+		assert.strictEqual(count, 1, 'handle was destroyed');
+		destroyable.destroy();
+		assert.strictEqual(count, 1, 'destroy was not called again');
+	}
+});

--- a/tests/unit/Evented.ts
+++ b/tests/unit/Evented.ts
@@ -1,81 +1,284 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import Evented from '../../src/Evented';
-
-interface CustomEvent {
-	type: string;
-	value?: string;
-	cancelable?: boolean;
-	preventDefault?: () => void;
-}
+import { Evented } from '../../src/Evented';
 
 registerSuite({
-		name: 'Evented',
+	name: 'bases/Evented',
+	creation() {
+		const evented = new Evented({});
+		assert(evented);
+		assert.isFunction(evented.on);
+		assert.isFunction(evented.emit);
+	},
+	'listeners at creation'() {
+		const eventStack: string[] = [];
+		const evented = new Evented({
+			listeners: {
+				'foo'(event) {
+					eventStack.push(event.type);
+				},
+				'bar'(event) {
+					eventStack.push(event.type);
+				}
+			}
+		});
 
-		'.on and .emit': function () {
-			const evented = new Evented();
-			let emittedEvent: CustomEvent;
-			let listenerCallCount = 0;
+		evented.emit({ type: 'foo' });
+		evented.emit({ type: 'bar' });
+		evented.emit({ type: 'baz' });
 
-			evented.on('test', function (actualEvent: CustomEvent) {
-				listenerCallCount++;
-				assert.strictEqual(actualEvent.value, emittedEvent.value);
+		evented.destroy();
+
+		evented.emit({ type: 'foo' });
+		evented.emit({ type: 'bar' });
+		evented.emit({ type: 'baz' });
+
+		assert.deepEqual(eventStack, [ 'foo', 'bar' ]);
+	},
+	'listener array at creation'() {
+		const eventStack: string[] = [];
+		const evented = new Evented({
+			listeners: {
+				foo: [
+					function (event) {
+						eventStack.push('foo1-' + event.type);
+					},
+					function (event) {
+						eventStack.push('foo2-' + event.type);
+					}
+				],
+				bar(event) {
+					eventStack.push(event.type);
+				}
+			}
+		});
+
+		evented.emit({ type: 'foo' });
+		evented.emit({ type: 'bar' });
+
+		evented.destroy();
+
+		evented.emit({ type: 'foo' });
+		evented.emit({ type: 'bar' });
+
+		assert.deepEqual(eventStack, [ 'foo1-foo', 'foo2-foo', 'bar' ]);
+	},
+	'on': {
+		'on()'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			const handle = evented.on('foo', (event) => {
+				eventStack.push(event.type);
 			});
 
-			emittedEvent = { value: 'foo', type: 'test' };
-			evented.emit(emittedEvent);
-			assert.strictEqual(listenerCallCount, 1);
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
 
-			emittedEvent = { value: 'bar', type: 'test' };
-			evented.emit(emittedEvent);
-			assert.strictEqual(listenerCallCount, 2);
-		},
-
-		'__on<eventname> methods': function () {
-			const evented = new Evented();
-			let expectedEvent: CustomEvent;
-			let actualEvent: CustomEvent | undefined;
-
-			assert.notProperty(evented, 'ontestevent');
-			evented.on('testevent', function (event) {
-				actualEvent = event;
-			});
-			assert.property(evented, '__ontestevent');
-
-			expectedEvent = { value: 'test', type: 'testevent' };
-			(<any> evented).__ontestevent(expectedEvent);
-			assert.deepEqual(actualEvent, expectedEvent);
-		},
-
-		'removing a listener': function () {
-			const evented = new Evented();
-			let listenerCalled = false;
-
-			const handle = evented.on('test', function () {
-				listenerCalled = true;
-			});
 			handle.destroy();
 
-			evented.emit({ value: 'foo', type: 'test' });
-			assert.isFalse(listenerCalled);
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+
+			assert.deepEqual(eventStack, [ 'foo' ]);
 		},
+		'listener on creation, plus on'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({
+				listeners: {
+					foo(event) {
+						eventStack.push('listener:' + event.type);
+					}
+				}
+			});
 
-		'listener order': function () {
-			const evented = new Evented();
-			const order: number[] = [];
+			const handle = evented.on('foo', (event) => {
+				eventStack.push('on:' + event.type);
+			});
 
-			(<any> evented).__ontestevent = function () {
-				order.push(1);
+			evented.emit({ type: 'foo' });
+			handle.destroy();
+			evented.emit({ type: 'foo' });
+			evented.destroy();
+			evented.emit({ type: 'foo' });
+
+			assert.deepEqual(eventStack, [ 'listener:foo', 'on:foo', 'listener:foo' ]);
+		},
+		'multiple listeners, same event'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+
+			const handle1 = evented.on('foo', () => {
+				eventStack.push('one');
+			});
+			const handle2 = evented.on('foo', () => {
+				eventStack.push('two');
+			});
+
+			evented.emit({ type: 'foo' });
+			handle1.destroy();
+			evented.emit({ type: 'foo' });
+			handle2.destroy();
+			evented.emit({ type: 'foo' });
+
+			assert.deepEqual(eventStack, [ 'one', 'two', 'two' ]);
+		},
+		'on(map)'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+
+			const handle = evented.on({
+				foo(event) {
+					eventStack.push(event.type);
+				},
+				bar(event) {
+					eventStack.push(event.type);
+				}
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			handle.destroy();
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'bar' ]);
+		},
+		'on(type, listener[])'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+
+			const handle = evented.on({
+				foo: [
+					function (event) {
+						eventStack.push('foo1');
+					},
+					function (event) {
+						eventStack.push('foo2');
+					}
+				]
+			});
+
+			evented.emit({ type: 'foo' });
+			handle.destroy();
+			evented.emit({ type: 'foo' });
+
+			assert.deepEqual(eventStack, [ 'foo1', 'foo2' ]);
+		},
+		'on throws'() {
+			const evented = new Evented({});
+			assert.throws(() => {
+				(<any> evented).on();
+			}, TypeError);
+			assert.throws(() => {
+				(<any> evented).on('type', () => {}, () => {});
+			}, TypeError);
+		}
+	},
+	'wildcards in event type name': {
+		'all event types'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			evented.on('*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'bar', 'foo:bar' ]);
+		},
+		'event types starting with a pattern'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			evented.on('foo:*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foo:' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ 'foo:', 'foo:bar' ]);
+		},
+		'event types ending with a pattern'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			evented.on('*:bar', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: ':bar' });
+			evented.emit({ type: 'foo:bar' });
+
+			assert.deepEqual(eventStack, [ ':bar', 'foo:bar' ]);
+		},
+		'event types contains a pattern'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			evented.on('*foo*', (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foobar' });
+			evented.emit({ type: 'barfoo' });
+			evented.emit({ type: 'barfoobiz' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'foobar', 'barfoo', 'barfoobiz' ]);
+		},
+		'multiple matches'() {
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			evented.on('foo', (event) => {
+				eventStack.push(`foo->${event.type}`);
+			});
+			evented.on('*foo', (event) => {
+				eventStack.push(`*foo->${event.type}`);
+			});
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'foobar' });
+			evented.emit({ type: 'barfoo' });
+
+			assert.deepEqual(eventStack, [ 'foo->foo', '*foo->foo', '*foo->barfoo' ]);
+		}
+	},
+	'actions': {
+		'listener'() {
+			const eventStack: string[] = [];
+			const action = {
+				do(options: { event: { type: string; target: any; } }): void {
+					eventStack.push(options.event.type);
+				}
 			};
-			evented.on('testevent', function () {
-				order.push(2);
-			});
-			evented.on('testevent', function () {
-				order.push(3);
+
+			const evented = new Evented({
+				listeners: {
+					foo: action
+				}
 			});
 
-			evented.emit({type: 'testevent'});
-			assert.deepEqual(order, [ 1, 2, 3 ]);
+			const handle = evented.on('bar', action);
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: 'baz' });
+
+			evented.destroy();
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: 'baz' });
+
+			handle.destroy();
+
+			evented.emit({ type: 'foo' });
+			evented.emit({ type: 'bar' });
+			evented.emit({ type: 'baz' });
+
+			assert.deepEqual(eventStack, [ 'foo', 'bar', 'bar' ]);
 		}
 	}
-);
+});

--- a/tests/unit/QueuingEvented.ts
+++ b/tests/unit/QueuingEvented.ts
@@ -3,7 +3,8 @@ import * as assert from 'intern/chai!assert';
 import QueuingEvented from '../../src/QueuingEvented';
 
 interface CustomEvent {
-	type: string;
+	type: 'test';
+	target: any;
 	value: number;
 }
 
@@ -15,10 +16,11 @@ registerSuite({
 			let listenerCallCount = 0;
 
 			evented.emit({
-				type: 'test'
+				type: 'test',
+				value: 1
 			});
 
-			evented.on('test', function (actualEvent: CustomEvent) {
+			evented.on('test', function () {
 				listenerCallCount++;
 			});
 
@@ -37,8 +39,8 @@ registerSuite({
 				});
 			}
 
-			evented.on('test', function (actualEvent: CustomEvent) {
-				expectedValues.push(actualEvent.value);
+			evented.on('test', function (event: CustomEvent) {
+				expectedValues.push(event.value);
 			});
 
 			assert.deepEqual(expectedValues, [ 6, 7, 8, 9, 10 ]);

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -3,6 +3,7 @@ import './async/iteration';
 import './async/ExtensiblePromise';
 import './async/Task';
 import './async/timing';
+import './Destroyable';
 import './Evented';
 import './encoding';
 import './global';


### PR DESCRIPTION
Migrating `Evented` and `Destroyable` from widget-core so other packages can use it.