### PR TITLE
Adding default provider for node

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -43,7 +43,7 @@ Object.defineProperty(request, 'setDefaultProvider', {
 
 providerRegistry.setDefaultProvider(xhr);
 
-if (!has('host-node')) {
+if (has('host-node')) {
 	let nodeProvider = require('./request/providers/node').default;
 	providerRegistry.setDefaultProvider(nodeProvider);
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,6 +1,7 @@
+import has from '@dojo/has/has';
 import Task from './async/Task';
-import ProviderRegistry from './request/ProviderRegistry';
 import { RequestOptions, Response, Provider } from './request/interfaces';
+import ProviderRegistry from './request/ProviderRegistry';
 import xhr from './request/providers/xhr';
 
 export const providerRegistry = new ProviderRegistry();
@@ -41,6 +42,11 @@ Object.defineProperty(request, 'setDefaultProvider', {
 });
 
 providerRegistry.setDefaultProvider(xhr);
+
+if (!has('host-browser')) {
+	let nodeProvider = require('./request/providers/node').default;
+	providerRegistry.setDefaultProvider(nodeProvider);
+}
 
 export default request;
 export * from './request/interfaces';

--- a/src/request.ts
+++ b/src/request.ts
@@ -43,7 +43,7 @@ Object.defineProperty(request, 'setDefaultProvider', {
 
 providerRegistry.setDefaultProvider(xhr);
 
-if (!has('host-browser')) {
+if (!has('host-node')) {
 	let nodeProvider = require('./request/providers/node').default;
 	providerRegistry.setDefaultProvider(nodeProvider);
 }


### PR DESCRIPTION
Updating the request library so that it uses the node provider when running in node. This will mean we don't have to manually set the provider every time we want to use the request library.