### PR TITLE
deep assign/mixin through nested object keys

### DIFF
--- a/src/lang.ts
+++ b/src/lang.ts
@@ -48,6 +48,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 	const inherited = kwArgs.inherited;
 	const target: any = kwArgs.target;
 	const copied = kwArgs.copied || [];
+	const copiedClone = [ ...copied ];
 
 	for (let source of kwArgs.sources) {
 		if (source === null || source === undefined) {
@@ -57,7 +58,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 			if (inherited || hasOwnProperty.call(source, key)) {
 				let value: any = source[key];
 
-				if (copied.indexOf(value) !== -1) {
+				if (copiedClone.indexOf(value) !== -1) {
 					continue;
 				}
 

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -40,12 +40,14 @@ interface MixinArgs<T extends {}, U extends {}> {
 	inherited: boolean;
 	sources: (U | null | undefined)[];
 	target: T;
+	copied?: any[];
 }
 
 function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 	const deep = kwArgs.deep;
 	const inherited = kwArgs.inherited;
-	const target = kwArgs.target;
+	const target: any = kwArgs.target;
+	const copied = kwArgs.copied || [];
 
 	for (let source of kwArgs.sources) {
 		if (source === null || source === undefined) {
@@ -53,23 +55,29 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 		}
 		for (let key in source) {
 			if (inherited || hasOwnProperty.call(source, key)) {
-				let value: any = (<any> source)[key];
+				let value: any = source[key];
+
+				if (copied.indexOf(value) !== -1) {
+					continue;
+				}
 
 				if (deep) {
 					if (Array.isArray(value)) {
 						value = copyArray(value, inherited);
 					}
 					else if (shouldDeepCopyObject(value)) {
+						const targetValue: any = target ? target[key] || {} : {};
+						copied.push(value);
 						value = _mixin({
 							deep: true,
 							inherited: inherited,
-							sources: <U[]> [ value ],
-							target: {}
+							sources: [ value ],
+							target: targetValue,
+							copied
 						});
 					}
 				}
-
-				(<any> target)[key] = value;
+				target[key] = value;
 			}
 		}
 	}

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -68,7 +68,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 					}
 					else if (shouldDeepCopyObject(value)) {
 						const targetValue: any = target ? target[key] || {} : {};
-						copied.push(value);
+						copied.push(source);
 						value = _mixin({
 							deep: true,
 							inherited: inherited,

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -67,7 +67,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 						value = copyArray(value, inherited);
 					}
 					else if (shouldDeepCopyObject(value)) {
-						const targetValue: any = target ? target[key] || {} : {};
+						const targetValue: any = target[key] || {};
 						copied.push(source);
 						value = _mixin({
 							deep: true,

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -200,12 +200,15 @@ registerSuite({
 			bar: foo,
 			baz: foo,
 			qux: {
-				foo
+				foo,
+				bar: {
+					foo
+				}
 			}
 		};
 
 		const assignedObject = lang.deepAssign(target, source);
-		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' }, qux: { foo: { foo: 'bar' } } });
+		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' }, qux: { foo: { foo: 'bar' }, bar: { foo: { foo: 'bar' } } } });
 	},
 
 	'.mixin()'() {

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -139,6 +139,56 @@ registerSuite({
 		assert.notStrictEqual(assignedObject.c.e, source.c.e, 'deepAssign should perform a deep copy');
 	},
 
+	'.deepAssign() merges nested object on to the target'() {
+		const target = {
+			apple: 0,
+			banana: {
+				weight: 52,
+				price: 100,
+				details: {
+					colour: 'brown', texture: 'soft'
+				}
+			},
+			cherry: 97
+		};
+
+		const source = {
+			banana: { price: 200, details: { colour: 'yellow' } },
+			durian: 100
+		};
+
+		const assignedObject = lang.deepAssign(target, source);
+		assert.deepEqual(assignedObject, {
+			apple: 0,
+			banana: { weight: 52, price: 200, details: { colour: 'yellow', texture: 'soft' } },
+			cherry: 97,
+			durian: 100
+		});
+	},
+
+	'.deepAssign() objects with circular references'() {
+		const target: any = {
+			nested: {
+				baz: 'foo',
+				qux: 'baz'
+			}
+		};
+
+		target.cyclical = target;
+
+		const source: any = {
+			nested: {
+				foo: 'bar',
+				bar: 'baz',
+				baz: 'qux'
+			}
+		};
+		source.cyclical = source;
+
+		const assignedObject = lang.deepAssign(target, source);
+		assert.deepEqual(assignedObject.nested, { foo: 'bar', bar: 'baz', baz: 'qux', qux: 'baz' });
+	},
+
 	'.mixin()'() {
 		const source: {
 			a: number,
@@ -239,6 +289,59 @@ registerSuite({
 		assert.notStrictEqual(mixedObject.nested.b, source.nested.b, 'deepMixin should perform a deep copy');
 		assert.notStrictEqual(mixedObject.nested.b[1], source.nested.b[1], 'deepMixin should perform a deep copy');
 		assert.notStrictEqual(mixedObject.nested.b[2], source.nested.b[2], 'deepMixin should perform a deep copy');
+	},
+
+	'.deepMixin() merges nested object on to the target'() {
+		const target = Object.create({
+			apple: 0,
+			banana: {
+				weight: 52,
+				price: 100,
+				details: {
+					colour: 'brown', texture: 'soft'
+				}
+			},
+			cherry: 97
+		});
+
+		const source = Object.create({
+			banana: { price: 200, details: { colour: 'yellow' } },
+			durian: 100
+		});
+
+		const assignedObject = lang.deepMixin(target, source);
+		assert.deepEqual(assignedObject, {
+			apple: 0,
+			banana: { weight: 52, price: 200, details: { colour: 'yellow', texture: 'soft' } },
+			cherry: 97,
+			durian: 100
+		});
+	},
+
+	'.deepMixin() objects with circular references'() {
+		let target: any = {
+			nested: {
+				baz: 'foo',
+				qux: 'baz'
+			}
+		};
+
+		target.cyclical = target;
+
+		target = Object.create(target);
+
+		let source: any = {
+			nested: {
+				foo: 'bar',
+				bar: 'baz',
+				baz: 'qux'
+			}
+		};
+		source.cyclical = source;
+		source = Object.create(source);
+
+		const assignedObject = lang.deepMixin(target, source);
+		assert.deepEqual(assignedObject.nested, { foo: 'bar', bar: 'baz', baz: 'qux', qux: 'baz' });
 	},
 
 	'.create()'() {

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -198,11 +198,14 @@ registerSuite({
 
 		const source: any = {
 			bar: foo,
-			baz: foo
+			baz: foo,
+			qux: {
+				foo
+			}
 		};
 
 		const assignedObject = lang.deepAssign(target, source);
-		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' } });
+		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' }, qux: { foo: { foo: 'bar' } } });
 	},
 
 	'.mixin()'() {

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -189,6 +189,22 @@ registerSuite({
 		assert.deepEqual(assignedObject.nested, { foo: 'bar', bar: 'baz', baz: 'qux', qux: 'baz' });
 	},
 
+	'.deepAssign with a source with two properties holding the same reference'() {
+		const target: any = {};
+
+		const foo = {
+			foo: 'bar'
+		};
+
+		const source: any = {
+			bar: foo,
+			baz: foo
+		};
+
+		const assignedObject = lang.deepAssign(target, source);
+		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' } });
+	},
+
 	'.mixin()'() {
 		const source: {
 			a: number,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Addresses an issue with deep assigning and deep mixing objects where nested objects where not merged with target but overrode the target.

Resolves #290 
