### PR TITLE
`after.id` can be zero so need to explicitly check for undefined.

### DIFF
--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -233,7 +233,7 @@ function getDispatcherObject(target: Targetable, methodName: string): Dispatcher
 			}
 
 			let after = dispatcher.after;
-			while (after && after.id && after.id < executionId) {
+			while (after && after.id !== undefined && after.id < executionId) {
 				if (after.advice) {
 					if (after.receiveArguments) {
 						let newResults = after.advice.apply(this, args);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Check `after.id` is explicitly not undefined.
