### PR TITLE
remove android due to saucelabs issues and IE10 as not supported

### DIFF
--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -7,12 +7,12 @@ export const capabilities = {
 };
 
 export const environments = [
-	{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
+	{ browserName: 'internet explorer', version: [ '11.0' ], platform: 'Windows 7' },
 	// { browserName: 'microsoftedge', platform: 'Windows 10' },
 	{ browserName: 'firefox', version: '43', platform: 'Windows 10' },
-	{ browserName: 'chrome', platform: 'Windows 10' },
+	{ browserName: 'chrome', platform: 'Windows 10' }
 	// { browserName: 'safari', version: '9', platform: 'OS X 10.11' },
-	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }// ,
+	// { browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }// ,
 	// { browserName: 'iphone', version: '9.1', deviceName: 'iPhone 6' }
 ];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Remove android from testing platforms as causes issues on travis/saucelabs and removing IE10 as not supported.