### PR TITLE
Hotfix: move common load methods into load/util.

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -1,6 +1,6 @@
-import { forOf, isIterable, isArrayLike } from '@dojo/shim/iterator';
 import Promise from '@dojo/shim/Promise';
 import { Require } from '@dojo/interfaces/loader';
+import { isPlugin } from './load/util';
 
 declare const require: Require;
 
@@ -18,55 +18,6 @@ export type Require = Require | NodeRequire;
 export interface Load {
 	(require: Require, ...moduleIds: string[]): Promise<any[]>;
 	(...moduleIds: string[]): Promise<any[]>;
-}
-
-export interface LoadPlugin<T> {
-	/**
-	 * An optional method that normmalizes a resource id.
-	 *
-	 * @param resourceId
-	 * The raw resource id.
-	 *
-	 * @param resolver
-	 * A method that can resolve an id to an absolute path. Depending on the environment, this will
-	 * usually be either `require.toUrl` or `require.resolve`.
-	 */
-	normalize?: (resourceId: string, resolver: (resourceId: string) => string) => string;
-
-	/**
-	 * A method that loads the specified resource.
-	 *
-	 * @param resourceId
-	 * The id of the resource to load.
-	 *
-	 * @param load
-	 * The `load` method that was used to load and execute the plugin.
-	 *
-	 * @return
-	 * A promise that resolves to the loaded resource.
-	 */
-	load(resourceId: string, load: Load): Promise<T>;
-}
-
-export function isPlugin(value: any): value is LoadPlugin<any> {
-	return Boolean(value) && typeof value.load === 'function';
-}
-
-export function useDefault(modules: any[]): any[];
-export function useDefault(module: any): any;
-export function useDefault(modules: any | any[]): any[] | any {
-	if (isIterable(modules) || isArrayLike(modules)) {
-		let processedModules: any[] = [];
-
-		forOf(modules, (module) => {
-			processedModules.push((module.__esModule && module.default) ? module.default : module);
-		});
-
-		return processedModules;
-	}
-	else {
-		return (modules.__esModule && modules.default) ? modules.default : modules;
-	}
 }
 
 const load: Load = (function (): Load {

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,6 +1,6 @@
 import Promise from '@dojo/shim/Promise';
 import { Require } from '@dojo/interfaces/loader';
-import { isPlugin } from './load/util';
+import { isPlugin, useDefault } from './load/util';
 
 declare const require: Require;
 
@@ -105,3 +105,8 @@ const load: Load = (function (): Load {
 	}
 })();
 export default load;
+
+export {
+	isPlugin,
+	useDefault
+}

--- a/src/load/util.ts
+++ b/src/load/util.ts
@@ -1,0 +1,51 @@
+import { forOf, isIterable, isArrayLike } from '@dojo/shim/iterator';
+import { Load } from '../load';
+
+export interface LoadPlugin<T> {
+	/**
+	 * An optional method that normmalizes a resource id.
+	 *
+	 * @param resourceId
+	 * The raw resource id.
+	 *
+	 * @param resolver
+	 * A method that can resolve an id to an absolute path. Depending on the environment, this will
+	 * usually be either `require.toUrl` or `require.resolve`.
+	 */
+	normalize?: (resourceId: string, resolver: (resourceId: string) => string) => string;
+
+	/**
+	 * A method that loads the specified resource.
+	 *
+	 * @param resourceId
+	 * The id of the resource to load.
+	 *
+	 * @param load
+	 * The `load` method that was used to load and execute the plugin.
+	 *
+	 * @return
+	 * A promise that resolves to the loaded resource.
+	 */
+	load(resourceId: string, load: Load): Promise<T>;
+}
+
+export function isPlugin(value: any): value is LoadPlugin<any> {
+	return Boolean(value) && typeof value.load === 'function';
+}
+
+export function useDefault(modules: any[]): any[];
+export function useDefault(module: any): any;
+export function useDefault(modules: any | any[]): any[] | any {
+	if (isIterable(modules) || isArrayLike(modules)) {
+		let processedModules: any[] = [];
+
+		forOf(modules, (module) => {
+			processedModules.push((module.__esModule && module.default) ? module.default : module);
+		});
+
+		return processedModules;
+	}
+	else {
+		return (modules.__esModule && modules.default) ? modules.default : modules;
+	}
+}

--- a/src/load/webpack.ts
+++ b/src/load/webpack.ts
@@ -1,5 +1,5 @@
 import Promise from '@dojo/shim/Promise';
-import { isPlugin, useDefault } from '../load';
+import { isPlugin, useDefault } from './util';
 
 interface ModuleIdMap {
 	[path: string]: { id: number; lazy: boolean };

--- a/tests/support/load/node.ts
+++ b/tests/support/load/node.ts
@@ -1,4 +1,5 @@
-import load, { useDefault } from '../../../src/load';
+import load from '../../../src/load';
+import { useDefault } from '../../../src/load/util';
 import { Require } from '@dojo/interfaces/loader';
 
 declare const require: Require;

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -12,6 +12,7 @@ import './instrument';
 import './lang';
 import './List';
 import './load';
+import './load/util';
 import './load/webpack';
 import './main';
 import './Observable';

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -4,8 +4,8 @@ import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import * as sinon from 'sinon';
 import has from '../../src/has';
-import load from '../../src/load';
-import { useDefault } from '../../src/load/util';
+import load, { isPlugin, useDefault } from '../../src/load';
+import { isPlugin as utilIsPlugin, useDefault as utilUseDefault } from '../../src/load/util';
 import mockPlugin from '../support/load/plugin-default';
 import global from '../../src/global';
 
@@ -16,6 +16,11 @@ const suite: any = {
 
 	before() {
 		return load('tests/support/load/a', 'tests/support/load/b', 'tests/support/load/c');
+	},
+
+	api() {
+		assert.strictEqual(isPlugin, utilIsPlugin, 'isPlugin should be re-exported');
+		assert.strictEqual(useDefault, utilUseDefault, 'useDefault should be re-exported');
 	},
 
 	'global load'(this: any) {

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -4,7 +4,8 @@ import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import * as sinon from 'sinon';
 import has from '../../src/has';
-import load, { isPlugin, useDefault } from '../../src/load';
+import load from '../../src/load';
+import { useDefault } from '../../src/load/util';
 import mockPlugin from '../support/load/plugin-default';
 import global from '../../src/global';
 
@@ -15,46 +16,6 @@ const suite: any = {
 
 	before() {
 		return load('tests/support/load/a', 'tests/support/load/b', 'tests/support/load/c');
-	},
-
-	isPlugin() {
-		assert.isFalse(isPlugin(null));
-		assert.isFalse(isPlugin(2));
-		assert.isFalse(isPlugin([]));
-		assert.isFalse(isPlugin(/\s/));
-		assert.isFalse(isPlugin({}));
-		assert.isTrue(isPlugin({
-			load() {}
-		}));
-	},
-
-	useDefault: {
-		'single es6 module'() {
-			assert.strictEqual(useDefault({
-				'__esModule': true,
-				'default': 42
-			}), 42, 'The default export should be returned.');
-		},
-
-		'single non-es6 module'() {
-			const module = { value: 42 };
-			assert.deepEqual(useDefault(module), module, 'The module itself should be returned.');
-		},
-
-		'all es6 modules'() {
-			const modules = [ 42, 43 ].map((value: number) => {
-				return { '__esModule': true, 'default': value };
-			});
-			assert.sameMembers(useDefault(modules), [ 42, 43 ], 'The default export should be returned for all modules.');
-		},
-
-		'mixed module types'() {
-			const modules: any[] = [ 42, 43 ].map((value: number) => {
-				return { '__esModule': true, 'default': value };
-			});
-			modules.push({ value: 44 });
-			assert.sameDeepMembers(useDefault(modules), [ 42, 43, { value: 44 } ]);
-		}
 	},
 
 	'global load'(this: any) {
@@ -198,16 +159,6 @@ if (has('host-node')) {
 			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
 				assert.deepEqual(a, { 'default': 'A', one: 1, two: 2 });
 				assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
-			}));
-		},
-
-		'useDefault resolves es modules'(this: any) {
-			const def = this.async(5000);
-
-			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedDefault;
-			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
-				assert.deepEqual(a, 'A');
-				assert.deepEqual(b, 'B');
 			}));
 		},
 

--- a/tests/unit/load/util.ts
+++ b/tests/unit/load/util.ts
@@ -1,0 +1,70 @@
+import Promise from '@dojo/shim/Promise';
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import has from '../../../src/has';
+import { isPlugin, useDefault } from '../../../src/load/util';
+import global from '../../../src/global';
+
+const suite: any = {
+	name: 'load/util',
+
+	isPlugin() {
+		assert.isFalse(isPlugin(null));
+		assert.isFalse(isPlugin(2));
+		assert.isFalse(isPlugin([]));
+		assert.isFalse(isPlugin(/\s/));
+		assert.isFalse(isPlugin({}));
+		assert.isTrue(isPlugin({
+			load() {}
+		}));
+	},
+
+	useDefault: {
+		'single es6 module'() {
+			assert.strictEqual(useDefault({
+				'__esModule': true,
+				'default': 42
+			}), 42, 'The default export should be returned.');
+		},
+
+		'single non-es6 module'() {
+			const module = { value: 42 };
+			assert.deepEqual(useDefault(module), module, 'The module itself should be returned.');
+		},
+
+		'all es6 modules'() {
+			const modules = [ 42, 43 ].map((value: number) => {
+				return { '__esModule': true, 'default': value };
+			});
+			assert.sameMembers(useDefault(modules), [ 42, 43 ], 'The default export should be returned for all modules.');
+		},
+
+		'mixed module types'() {
+			const modules: any[] = [ 42, 43 ].map((value: number) => {
+				return { '__esModule': true, 'default': value };
+			});
+			modules.push({ value: 44 });
+			assert.sameDeepMembers(useDefault(modules), [ 42, 43, { value: 44 } ]);
+		}
+	}
+};
+
+if (has('host-node')) {
+	const nodeRequire: any = global.require.nodeRequire;
+	const path: any = nodeRequire('path');
+	const buildDir: string = path.join(process.cwd(), '_build');
+
+	suite.node = {
+		'useDefault resolves es modules'(this: any) {
+			const def = this.async(5000);
+
+			const result: Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedDefault;
+			result.then(def.callback(function ([ a, b ]: [ any, any ]) {
+				assert.deepEqual(a, 'A');
+				assert.deepEqual(b, 'B');
+			}));
+		}
+	};
+}
+
+registerSuite(suite);

--- a/tests/unit/load/webpack.ts
+++ b/tests/unit/load/webpack.ts
@@ -2,6 +2,7 @@ import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import * as sinon from 'sinon';
 import global from '../../../src/global';
+import { isPlugin as utilIsPlugin, useDefault as utilUseDefault } from '../../../src/load/util';
 import load, { isPlugin, useDefault } from '../../../src/load/webpack';
 
 interface WebpackModules {
@@ -78,8 +79,8 @@ registerSuite({
 	},
 
 	api() {
-		assert.isFunction(isPlugin, '`isPlugin` should be re-exported.');
-		assert.isFunction(useDefault, '`useDefault` should be re-exported.');
+		assert.strictEqual(isPlugin, utilIsPlugin, '`isPlugin` should be re-exported.');
+		assert.strictEqual(useDefault, utilUseDefault, '`useDefault` should be re-exported.');
 	},
 
 	'without __modules__'() {


### PR DESCRIPTION

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`src/load/webpack` is no longer including the values imported from `src/load` in webpack builds. Separating the common methods between the two into a shared module circumvents this issue.

Resolves #304 