### PR TITLE
Fix for binary data getting corrupted in node request provider

### DIFF
--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -468,7 +468,7 @@ export default function node(url: string, options: NodeRequestOptions = {}): Tas
 							if (contentEncodings.length) {
 								const encoding = contentEncodings.pop()!.trim();
 
-								if (encoding === '' || encoding === 'identity') {
+								if (encoding === '' || encoding.toLowerCase() === 'none' || encoding === 'identity') {
 									// do nothing, response stream is as-is
 									handleEncoding();
 								}

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -88,7 +88,7 @@ interface HttpsOptions extends Options {
 interface RequestData {
 	task: Task<http.IncomingMessage>;
 	buffer: any[];
-	data: string;
+	data: Buffer | string;
 	size: number;
 	used: boolean;
 	nativeResponse: http.IncomingMessage;
@@ -172,12 +172,7 @@ export class NodeResponse extends Response {
 	arrayBuffer(): Task<ArrayBuffer> {
 		return <any> getDataTask(this).then(data => {
 			if (data) {
-				if (<any> data.data instanceof Buffer) {
-					return data.data;
-				}
-				else {
-					return Buffer.from(data.data, 'utf8');
-				}
+				return data.data;
 			}
 
 			return new Buffer([]);
@@ -502,7 +497,7 @@ export default function node(url: string, options: NodeRequestOptions = {}): Tas
 								}
 							}
 							else {
-								data.data = String(dataAsBuffer);
+								data.data = dataAsBuffer;
 
 								response.emit({
 									type: 'end',

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -88,7 +88,7 @@ interface HttpsOptions extends Options {
 interface RequestData {
 	task: Task<http.IncomingMessage>;
 	buffer: any[];
-	data: Buffer | string;
+	data: Buffer;
 	size: number;
 	used: boolean;
 	nativeResponse: http.IncomingMessage;
@@ -466,9 +466,9 @@ export default function node(url: string, options: NodeRequestOptions = {}): Tas
 							 content, so do undo the encoding we have to start at the end and work backwards.
 							 */
 							if (contentEncodings.length) {
-								const encoding = contentEncodings.pop()!.trim();
+								const encoding = contentEncodings.pop()!.trim().toLowerCase();
 
-								if (encoding === '' || encoding.toLowerCase() === 'none' || encoding === 'identity') {
+								if (encoding === '' || encoding === 'none' || encoding === 'identity') {
 									// do nothing, response stream is as-is
 									handleEncoding();
 								}
@@ -518,7 +518,7 @@ export default function node(url: string, options: NodeRequestOptions = {}): Tas
 			const data: RequestData = {
 				task,
 				buffer: [],
-				data: '',
+				data: Buffer.alloc(0),
 				size: 0,
 				used: false,
 				url: url,


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Binary data (a zip file in this case) was being corrupted in the node request provider because it would convert everything to a string and that was causing some issues.

Also explicitly ignoring the `None` content encoding.