### PR TITLE
Enhance `assign()` typings to allow different types of sources.

### DIFF
--- a/src/lang.ts
+++ b/src/lang.ts
@@ -87,7 +87,10 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 }
 
 interface ObjectAssignConstructor extends ObjectConstructor {
-	assign<T extends {}, U extends {}>(target: T, ...sources: (U | null | undefined)[]): T&U;
+	assign<T, U>(target: T, source: U): T & U;
+	assign<T, U1, U2>(target: T, source1: U1, source2: U2): T & U1 & U2;
+	assign<T, U1, U2, U3>(target: T, source1: U1, source2: U2, source3: U3): T & U1 & U2 & U3;
+	assign(target: any, ...sources: any[]): any;
 }
 
 /**
@@ -99,7 +102,7 @@ interface ObjectAssignConstructor extends ObjectConstructor {
  */
 export const assign = has('object-assign') ?
 	(<ObjectAssignConstructor> Object).assign :
-	function<T extends {}, U extends {}> (target: T, ...sources: (U | null | undefined)[]): T&U {
+	function (target: any, ...sources: any[]): any {
 		return _mixin({
 			deep: false,
 			inherited: false,

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -57,7 +57,7 @@ registerSuite({
 			property2: 'value2'
 		};
 
-		lang.assign<typeof object, typeof source1 | typeof source3>(object, source1, <any> null, source3);
+		lang.assign(object, source1, <any> null, source3);
 
 		assert.deepEqual(object, {
 			property1: 'value1',
@@ -97,6 +97,32 @@ registerSuite({
 		const alsoAssigned: {} & ({ a: number, b: number } | { c: number, d: number }) = lang.assign(object, source1, source2, source3);
 
 		assert(alsoAssigned);
+	},
+
+	'.assign() with different types of sources'() {
+		const baseObject = {
+			foo: 'foo'
+		};
+
+		const assignedObject = lang.assign({}, baseObject, { bar: 'bar' });
+		assert.strictEqual(assignedObject.bar, 'bar');
+		assert.strictEqual(assignedObject.foo, 'foo');
+	},
+	'.assign() with a source whose type is a subset of another'() {
+		type FooBar = {
+			foo: string;
+			bar: string;
+		};
+		const foobar = {
+			foo: 'foo',
+			bar: 'bar'
+		};
+		const bar = {
+			bar: 'baz'
+		};
+		const assignedObject = lang.assign({}, foobar, bar);
+		assert.strictEqual(assignedObject.foo, 'foo');
+		assert.strictEqual(assignedObject.bar, 'baz');
 	},
 
 	'.deepAssign()'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The updated typings for `assign()` is the same as in [Typescript](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es6.d.ts#L4461-L4480).

I looked at `Partial` but so far I haven't found a way to solve the problem with it. 

Although this solution should resolve #291 , it is still based on the same intersection types we've been using, so due to the limitation of intersection types, there's still other typings issues. For example:
```ts
const result  = lang.assign({foo: 1}, {foo: 'foo'}); // result.foo becomes `string & number`
result.foo = 'bar'; // won't compile
```
And a workaround:
```ts
// workaround
type Foo = { foo: string };
const result: Foo  = lang.assign({foo: 1}, {foo: 'foo'}); // result.foo becomes `string`
result.foo = 'bar'; // works
```

Resolves #291 
