### PR TITLE
Has test for `blob` should use a valid URI

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -17,7 +17,7 @@ add('blob', function () {
 	}
 
 	const request = new XMLHttpRequest();
-	request.open('GET', '/', true);
+	request.open('GET', '/foo', true);
 	request.responseType = 'blob';
 	request.abort();
 	return request.responseType === 'blob';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Update `has` check for `blob` to a valid URI.

Resolves #318