### PR TITLE
Fix `blob` has sniff

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -16,8 +16,8 @@ add('blob', function () {
 		return false;
 	}
 
-	const request = new XMLHttpRequest();
-	request.open('GET', '/foo', true);
+	const request = new global.XMLHttpRequest();
+	request.open('GET', 'http://www.google.com', true);
 	request.responseType = 'blob';
 	request.abort();
 	return request.responseType === 'blob';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Fixes the sniff for `blob` and the usage of `XMLHttpRequest` - An issue will be open to create a test for the has check.

Related to #320
