### PR TITLE
Support symbols for event type

### DIFF
--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -1,6 +1,6 @@
 import { Actionable } from '@dojo/interfaces/abilities';
-import { EventedListener, EventedListenerOrArray, EventedListenersMap, EventedCallback } from '@dojo/interfaces/bases';
-import { EventObject, EventTargettedObject, EventErrorObject, Handle } from '@dojo/interfaces/core';
+import { EventedListener, EventedListenerOrArray, EventedListenersMap } from '@dojo/interfaces/bases';
+import { EventTargettedObject, EventErrorObject, Handle } from '@dojo/interfaces/core';
 import Map from '@dojo/shim/Map';
 import { on as aspectOn } from './aspect';
 import { Destroyable } from './Destroyable';
@@ -36,6 +36,22 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
 	};
 }
 
+export interface EventObject {
+	/**
+	 * The type of the event
+	 */
+	readonly type: string | symbol;
+}
+
+export interface EventedCallback<E extends EventObject> {
+	/**
+	 * A callback that takes an `event` argument
+	 *
+	 * @param event The event object
+	 */
+	(event: E): boolean | void;
+}
+
 /**
  * Interface for Evented constructor options
  */
@@ -60,6 +76,8 @@ export interface BaseEventedEvents {
 	 */
 	(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
 
+	(type: symbol, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
+
 	/**
 	 * @param type the type for `error`
 	 * @param listener the listener to attach
@@ -81,8 +99,8 @@ const regexMap = new Map<string, RegExp>();
  *
  * @returns boolean that indicates if the glob is matched
  */
-export function isGlobMatch(globString: string, targetString: string): boolean {
-	if (globString.indexOf('*') !== -1) {
+export function isGlobMatch(globString: string, targetString: string | symbol): boolean {
+	if (typeof targetString === 'string' && globString.indexOf('*') !== -1) {
 		let regex: RegExp;
 		if (regexMap.has(globString)) {
 			regex = regexMap.get(globString)!;

--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -36,6 +36,9 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
 	};
 }
 
+/**
+ * The base event object, which provides a `type` property
+ */
 export interface EventObject {
 	/**
 	 * The type of the event
@@ -76,6 +79,10 @@ export interface BaseEventedEvents {
 	 */
 	(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
 
+	/**
+	 * @param type the type of the event
+	 * @param listener the listener to attach
+	 */
 	(type: symbol, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
 
 	/**

--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -77,13 +77,7 @@ export interface BaseEventedEvents {
 	 * @param type the type of the event
 	 * @param listener the listener to attach
 	 */
-	(type: string, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
-
-	/**
-	 * @param type the type of the event
-	 * @param listener the listener to attach
-	 */
-	(type: symbol, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
+	(type: string | symbol, listener: EventedListenerOrArray<Evented, EventTargettedObject<Evented>>): Handle;
 
 	/**
 	 * @param type the type for `error`
@@ -106,8 +100,8 @@ const regexMap = new Map<string, RegExp>();
  *
  * @returns boolean that indicates if the glob is matched
  */
-export function isGlobMatch(globString: string, targetString: string | symbol): boolean {
-	if (typeof targetString === 'string' && globString.indexOf('*') !== -1) {
+export function isGlobMatch(globString: string | symbol, targetString: string | symbol): boolean {
+	if (typeof targetString === 'string' && typeof globString === 'string' && globString.indexOf('*') !== -1) {
 		let regex: RegExp;
 		if (regexMap.has(globString)) {
 			regex = regexMap.get(globString)!;

--- a/src/QueuingEvented.ts
+++ b/src/QueuingEvented.ts
@@ -1,6 +1,6 @@
-import { EventObject, Handle } from '@dojo/interfaces/core';
+import { Handle } from '@dojo/interfaces/core';
 import Map from '@dojo/shim/Map';
-import Evented, { isGlobMatch } from './Evented';
+import Evented, { isGlobMatch, EventObject } from './Evented';
 
 /**
  * An implementation of the Evented class that queues up events when no listeners are
@@ -10,7 +10,7 @@ import Evented, { isGlobMatch } from './Evented';
  * @property maxEvents  The number of events to queue before old events are discarded. If zero (default), an unlimited number of events is queued.
  */
 export default class QueuingEvented extends Evented {
-	private _queue: Map<string, EventObject[]>;
+	private _queue: Map<string | symbol, EventObject[]>;
 	private _originalOn: (...args: any[]) => Handle;
 
 	maxEvents = 0;

--- a/src/on.ts
+++ b/src/on.ts
@@ -1,6 +1,6 @@
-import { Handle, EventObject } from '@dojo/interfaces/core';
+import { Handle } from '@dojo/interfaces/core';
 import { createHandle, createCompositeHandle } from './lang';
-import Evented from './Evented';
+import Evented, { EventObject } from './Evented';
 
 export interface EventCallback {
 	(event: EventObject): void;

--- a/tests/unit/Evented.ts
+++ b/tests/unit/Evented.ts
@@ -92,11 +92,12 @@ registerSuite({
 
 			evented.emit({ type: foo });
 			evented.emit({ type: bar });
+			evented.emit({ type: 'bar' });
 
 			handle.destroy();
 
 			evented.emit({ type: foo });
-			evented.emit({ type: bar });
+			evented.emit({ type: 'bar' });
 
 			assert.deepEqual(eventStack, [ foo ]);
 		},

--- a/tests/unit/Evented.ts
+++ b/tests/unit/Evented.ts
@@ -81,6 +81,25 @@ registerSuite({
 
 			assert.deepEqual(eventStack, [ 'foo' ]);
 		},
+		'on() with Symbol type'() {
+			const foo = Symbol();
+			const bar = Symbol();
+			const eventStack: string[] = [];
+			const evented = new Evented({});
+			const handle = evented.on(foo, (event) => {
+				eventStack.push(event.type);
+			});
+
+			evented.emit({ type: foo });
+			evented.emit({ type: bar });
+
+			handle.destroy();
+
+			evented.emit({ type: foo });
+			evented.emit({ type: bar });
+
+			assert.deepEqual(eventStack, [ foo ]);
+		},
 		'listener on creation, plus on'() {
 			const eventStack: string[] = [];
 			const evented = new Evented({


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support to use symbols as an event type.

As part of this PR I have moved interfaces from `@dojo/interfaces` that have been affected into the `Evented` module; It feels cumbersome to need to make interface changes in `@dojo/interfaces` (that could be breaking, which is pretty much unmanageable) and then release `@dojo/interfaces` in order to get make fixes/enhancements downstream.

Resolves #329 
