### PR TITLE
Re-Export @dojo/shim/global and change imports

### DIFF
--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,4 +1,4 @@
-import global from './global';
+import global from '@dojo/shim/global';
 import has, { add as hasAdd } from '@dojo/has/has';
 
 hasAdd('btoa', 'btoa' in global);

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,2 +1,10 @@
 import globalObject from '@dojo/shim/global';
+import { deprecated } from './instrument';
+
+deprecated({
+	message: 'has been replaced with @dojo/shim/global',
+	name: '@dojo/core/global',
+	url: 'https://github.com/dojo/core/issues/302'
+});
+
 export default globalObject;

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,17 +1,2 @@
-const globalObject: any = (function (): any {
-	if (typeof window !== 'undefined') {
-		// Browsers
-		return window;
-	}
-	else if (typeof global !== 'undefined') {
-		// Node
-		return global;
-	}
-	else if (typeof self !== 'undefined') {
-		// Web workers
-		return self;
-	}
-	return {};
-})();
-
+import globalObject from '@dojo/shim/global';
 export default globalObject;

--- a/src/has.ts
+++ b/src/has.ts
@@ -1,4 +1,4 @@
-import global from './global';
+import global from '@dojo/shim/global';
 import has, { add } from '@dojo/shim/support/has';
 
 export * from '@dojo/shim/support/has';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import * as aspect from './aspect';
 import DateObject from './DateObject';
 import Evented from './Evented';
-import global from './global';
 import IdentityRegistry from './IdentityRegistry';
 import * as lang from './lang';
 import * as base64 from './base64';
@@ -33,7 +32,6 @@ export {
 	DateObject,
 	emit,
 	Evented,
-	global,
 	IdentityRegistry,
 	lang,
 	load,

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -1,8 +1,8 @@
 import { Handle } from '@dojo/interfaces/core';
+import global from '@dojo/shim/global';
 import { forOf } from '@dojo/shim/iterator';
 import WeakMap from '@dojo/shim/WeakMap';
 import Task, { State } from '../../async/Task';
-import global from '../../global';
 import has from '../../has';
 import { createTimer } from '../../util';
 import Headers from '../Headers';

--- a/tests/unit/global.ts
+++ b/tests/unit/global.ts
@@ -1,11 +1,12 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import global from '../../src/global';
+import shimGlobal from '@dojo/shim/global';
 
 registerSuite({
 	name: 'global',
 
-	'global references the global object for the target environment'() {
-		assert.strictEqual(global, Function('return this')());
+	'global is a re-export of @dojo/shim/global'() {
+		assert.strictEqual(global, shimGlobal, 'globals should match');
 	}
 });

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -1,4 +1,5 @@
 import { RootRequire } from '@dojo/interfaces/loader';
+import global from '@dojo/shim/global';
 import Promise from '@dojo/shim/Promise';
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
@@ -7,7 +8,6 @@ import has from '../../src/has';
 import load, { isPlugin, useDefault } from '../../src/load';
 import { isPlugin as utilIsPlugin, useDefault as utilUseDefault } from '../../src/load/util';
 import mockPlugin from '../support/load/plugin-default';
-import global from '../../src/global';
 
 declare const require: RootRequire;
 

--- a/tests/unit/load/webpack.ts
+++ b/tests/unit/load/webpack.ts
@@ -1,7 +1,7 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import * as sinon from 'sinon';
-import global from '../../../src/global';
+import global from '@dojo/shim/global';
 import { isPlugin as utilIsPlugin, useDefault as utilUseDefault } from '../../../src/load/util';
 import load, { isPlugin, useDefault } from '../../../src/load/webpack';
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR changes the `global` module to re-export `@dojo/shim/global` module, adds a deprecation warning when the module is loaded, and changes other modules which import it to point directly to `@dojo/shim/global`.

Resolves #302 
