### PR TITLE
Adding a flag to disable automatic inclusion of x-requested-with

### DIFF
--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -35,14 +35,39 @@ export type Provider = (url: string, options?: RequestOptions) => UploadObservab
 export type ProviderTest = (url: string, options?: RequestOptions) => boolean | null;
 
 export interface RequestOptions {
+	/**
+	 * Enable cache busting (default false). Cache busting will make a new URL by appending a parameter to the
+	 * requested URL
+	 */
 	cacheBust?: boolean;
 	credentials?: 'omit' | 'same-origin' | 'include';
+	/**
+	 * Body to send along with the http request
+	 */
 	body?: Blob | BufferSource | FormData | UrlSearchParams | string;
+	/**
+	 * Headers to send along with the http request
+	 */
 	headers?: Headers | { [key: string]: string; };
+	/**
+	 * HTTP method
+	 */
 	method?: string;
+	/**
+	 * Password for HTTP authentication
+	 */
 	password?: string;
+	/**
+	 * Number of milliseconds before the request times out and is canceled
+	 */
 	timeout?: number;
+	/**
+	 * User for HTTP authentication
+	 */
 	user?: string;
+	/**
+	 * Optional query parameter(s) for the URL. The requested url will have these query parameters appended.
+	 */
 	query?: string | ParamList;
 }
 

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -18,34 +18,105 @@ import Observable from '../../Observable';
 import SubscriptionPool from '../SubscriptionPool';
 
 /**
- * Request options specific to a node request
+ * Request options specific to a node request. For HTTPS options, see
+ * https://nodejs.org/api/tls.html#tls_tls_connect_options_callback for more details.
  */
 export interface NodeRequestOptions extends RequestOptions {
+	/**
+	 * User-agent header
+	 */
 	agent?: any;
+	/**
+	 * If specified, the request body is read from the stream specified here, rather than from the `body` field.
+	 */
 	bodyStream?: Readable;
+	/**
+	 * HTTPS optionally override the trusted CA certificates
+	 */
 	ca?: any;
+	/**
+	 * HTTPS optional cert chains in PEM format. One cert chain should be provided per private key.
+	 */
 	cert?: string;
+	/**
+	 * HTTPS optional cipher suite specification
+	 */
 	ciphers?: string;
 	dataEncoding?: string;
+	/**
+	 * Whether or not to automatically follow redirects (default true)
+	 */
 	followRedirects?: boolean;
+	/**
+	 * HTTPS optional private key in PEM format.
+	 */
 	key?: string;
+	/**
+	 * Local interface to bind for network connections.
+	 */
 	localAddress?: string;
+	/**
+	 * HTTPS optional shared passphrase used for a single private key and/or a PFX.
+	 */
 	passphrase?: string;
+	/**
+	 * HTTPS optional PFX or PKCS12 encoded private key and certificate chain.
+	 */
 	pfx?: any;
+	/**
+	 * Optional proxy address. If specified, requests will be sent through this url.
+	 */
 	proxy?: string;
+	/**
+	 * HTTPS If not false the server will reject any connection which is not authorized with the list of supplied CAs
+	 */
 	rejectUnauthorized?: boolean;
+	/**
+	 * HTTPS optional SSL method to use, default is "SSLv23_method"
+	 */
 	secureProtocol?: string;
+	/**
+	 * Unix Domain Socket (use one of host:port or socketPath)
+	 */
 	socketPath?: string;
+	/**
+	 * Whether or not to add the gzip and deflate accept headers (default true)
+	 */
 	acceptCompression?: boolean;
+	/**
+	 * A set of options to set on the HTTP request
+	 */
 	socketOptions?: {
+		/**
+		 * Enable/disable keep-alive functionality, and optionally set the initial delay before the first keepalive probe is sent on an idle socket.
+		 */
 		keepAlive?: number;
+		/**
+		 * Disables the Nagle algorithm. By default TCP connections use the Nagle algorithm, they buffer data before sending it off.
+		 */
 		noDelay?: boolean;
+		/**
+		 * Number of milliseconds before the HTTP request times out
+		 */
 		timeout?: number;
 	};
+	/**
+	 * Stream encoding on incoming HTTP response
+	 */
 	streamEncoding?: string;
+	/**
+	 * Options to control redirect follow logic
+	 */
 	redirectOptions?: {
+		/**
+		 * The limit to the number of redirects that will be followed (default 15). This is used to prevent infinite
+		 * redirect loops.
+		 */
 		limit?: number;
 		count?: number;
+		/**
+		 * Whether or not to keep the original HTTP method during 301 redirects (default false).
+		 */
 		keepOriginalMethod?: boolean;
 	};
 }

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -18,6 +18,7 @@ import SubscriptionPool from '../SubscriptionPool';
  */
 export interface XhrRequestOptions extends RequestOptions {
 	blockMainThread?: boolean;
+	includeRequestedWithHeader?: boolean;
 }
 
 interface RequestData {
@@ -270,6 +271,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 
 	let hasContentTypeHeader = false;
 	let hasRequestedWithHeader = false;
+	const { includeRequestedWithHeader = true } = options;
 
 	if (options.headers) {
 		const requestHeaders = new Headers(options.headers);
@@ -282,7 +284,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 		});
 	}
 
-	if (!hasRequestedWithHeader) {
+	if (!hasRequestedWithHeader && includeRequestedWithHeader) {
 		request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 	}
 

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -17,7 +17,14 @@ import SubscriptionPool from '../SubscriptionPool';
  * Request options specific to an XHR request
  */
 export interface XhrRequestOptions extends RequestOptions {
+	/**
+	 * Controls whether or not the request is synchronous (blocks the main thread) or asynchronous (default).
+	 */
 	blockMainThread?: boolean;
+	/**
+	 * Controls whether or not the X-Requested-With header is added to the request (default true). Set to false to not
+	 * include the header.
+	 */
 	includeRequestedWithHeader?: boolean;
 }
 

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -403,6 +403,18 @@ registerSuite({
 						}
 					});
 				});
+			},
+
+			'X-Requested-With headers can be disabled'(this: any) {
+				if (!echoServerAvailable) {
+					this.skip('No echo server available');
+				}
+				const options = {includeRequestedWithHeader: false};
+				return xhrRequest('/__echo/default', options).then(function (response: any) {
+					return response.json().then((data: any) => {
+						assert.isUndefined(data.headers['x-requested-with']);
+					});
+				});
 			}
 		}
 	},

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -410,7 +410,7 @@ registerSuite({
 					this.skip('No echo server available');
 				}
 				const options = {includeRequestedWithHeader: false};
-				return xhrRequest('/__echo/default', options).then(function (response: any) {
+				return xhrRequest('/__echo/default?norequestedwith', options).then(function (response: any) {
 					return response.json().then((data: any) => {
 						assert.isUndefined(data.headers['x-requested-with']);
 					});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding an XHR request option, `includeRequestedWith` that defaults to `true`, that can be used to disable the automatic inclusion of the `X-Requested-With`.

Example,

```typescript
xhr('some-url', { includeRequestedWith: false }).then(...)
```

Resolves #328 
