### PR TITLE
Removing usages of forOf in favor of downlevelIteration

### DIFF
--- a/src/List.ts
+++ b/src/List.ts
@@ -1,4 +1,4 @@
-import { forOf, Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import { Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 import WeakMap from '@dojo/shim/WeakMap';
 
 const listItems: WeakMap<List<any>, any[]> = new WeakMap<List<any>, any[]>();
@@ -20,9 +20,9 @@ export default class List<T> {
 		listItems.set(this, []);
 
 		if (source) {
-			forOf(source, (item: T) => {
+			for (const item of source) {
 				this.add(item);
-			});
+			}
 		}
 	}
 

--- a/src/MultiMap.ts
+++ b/src/MultiMap.ts
@@ -1,7 +1,7 @@
 import '@dojo/shim/Symbol';
 import Map from '@dojo/shim/Map';
 import { from as arrayFrom } from '@dojo/shim/array';
-import { forOf, Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import { Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 
 /**
  * A map implmentation that supports multiple keys for specific value.
@@ -21,9 +21,9 @@ export default class MultiMap<T> implements Map<any[], T> {
 		this._map = new Map<any, any>();
 		this._key = Symbol();
 		if (iterable) {
-			forOf(iterable, (value: [any[], T]) => {
+			for (const value of iterable) {
 				this.set(value[0], value[1]);
-			});
+			}
 		}
 	}
 
@@ -47,7 +47,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 			childMap = new Map<any, any>();
 			map.set(keys[i], childMap);
 			map = childMap;
-		};
+		}
 
 		map.set(this._key, value);
 		return this;
@@ -211,9 +211,9 @@ export default class MultiMap<T> implements Map<any[], T> {
 	forEach(callback: (value: T, key: any[], mapInstance: MultiMap<T>) => any, context?: {}): void {
 		const entries = this.entries();
 
-	forOf(entries, (value: [any[], T]) => {
-			callback.call(context, value[1], value[0], this);
-		});
+		for (const value of entries) {
+			callback.call(context, value[ 1 ], value[ 0 ], this);
+		}
 	}
 
 	/**

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -1,4 +1,4 @@
-import { Iterable, forOf, isIterable, isArrayLike } from '@dojo/shim/iterator';
+import { Iterable, isIterable, isArrayLike } from '@dojo/shim/iterator';
 import Promise, { Executor } from '@dojo/shim/Promise';
 import { Thenable } from '@dojo/shim/interfaces';
 import '@dojo/shim/Symbol';
@@ -12,9 +12,9 @@ import '@dojo/shim/Symbol';
  */
 export function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 	const unwrapped: any[] = [];
-	forOf(iterable, function (item: any): void {
+	for (const item of iterable) {
 		unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
-	});
+	}
 	return unwrapped;
 }
 

--- a/src/load/util.ts
+++ b/src/load/util.ts
@@ -1,4 +1,4 @@
-import { forOf, isIterable, isArrayLike } from '@dojo/shim/iterator';
+import { isIterable, isArrayLike } from '@dojo/shim/iterator';
 import { Load } from '../load';
 
 export interface LoadPlugin<T> {
@@ -39,9 +39,9 @@ export function useDefault(modules: any | any[]): any[] | any {
 	if (isIterable(modules) || isArrayLike(modules)) {
 		let processedModules: any[] = [];
 
-		forOf(modules, (module) => {
+		for (const module of modules) {
 			processedModules.push((module.__esModule && module.default) ? module.default : module);
-		});
+		}
 
 		return processedModules;
 	}

--- a/src/request/Headers.ts
+++ b/src/request/Headers.ts
@@ -1,5 +1,5 @@
 import { Headers as HeadersInterface } from './interfaces';
-import { IterableIterator, forOf, ShimIterator } from '@dojo/shim/iterator';
+import { IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 import Map from '@dojo/shim/Map';
 
 function isHeadersLike(object: any): object is HeadersInterface {
@@ -15,9 +15,9 @@ export default class Headers implements HeadersInterface {
 				this.map = new Map(headers.map);
 			}
 			else if (isHeadersLike(headers)) {
-				forOf(headers, ([key, value]) => {
+				for (const [key, value] of headers) {
 					this.append(key, value);
-				});
+				}
 			}
 			else {
 				for (let key in headers) {
@@ -44,11 +44,11 @@ export default class Headers implements HeadersInterface {
 
 	entries(): IterableIterator<[string, string]> {
 		const entries: [string, string][] = [];
-		forOf(this.map.entries(), ([key, values]) => {
+		for (const [key, values] of this.map.entries()) {
 			values.forEach(value => {
 				entries.push([key, value]);
 			});
-		});
+		}
 		return new ShimIterator(entries);
 	}
 
@@ -88,9 +88,9 @@ export default class Headers implements HeadersInterface {
 
 	values(): IterableIterator<string> {
 		const values: string[] = [];
-		forOf(this.map.values(), value => {
+		for (const value of this.map.values()) {
 			values.push(...value);
-		});
+		}
 		return new ShimIterator(values);
 	}
 

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -1,6 +1,5 @@
 import { Handle } from '@dojo/interfaces/core';
 import global from '@dojo/shim/global';
-import { forOf } from '@dojo/shim/iterator';
 import WeakMap from '@dojo/shim/WeakMap';
 import Task, { State } from '../../async/Task';
 import has from '../../has';
@@ -286,9 +285,9 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 		hasRequestedWithHeader = requestHeaders.has('x-requested-with');
 		hasContentTypeHeader = requestHeaders.has('content-type');
 
-		forOf(requestHeaders, ([key, value]) => {
+		for (const [key, value] of requestHeaders) {
 			request.setRequestHeader(key, value);
-		});
+		}
 	}
 
 	if (!hasRequestedWithHeader && includeRequestedWithHeader) {

--- a/src/request/util.ts
+++ b/src/request/util.ts
@@ -1,6 +1,5 @@
 import { RequestOptions } from './interfaces';
 import UrlSearchParams from '../UrlSearchParams';
-import { forOf } from '@dojo/shim/iterator';
 
 /**
  * Returns a URL formatted with optional query string and cache-busting segments.
@@ -22,9 +21,9 @@ export function generateRequestUrl(url: string,
 export function getStringFromFormData(formData: any): string {
 	const fields: string[] = [];
 
-	forOf(formData.keys(), (key: string) => {
+	for (const key of formData.keys()) {
 		fields.push(encodeURIComponent(key) + '=' + encodeURIComponent(formData.get(key)));
-	});
+	}
 
 	return fields.join('&');
 }

--- a/tests/unit/List.ts
+++ b/tests/unit/List.ts
@@ -1,7 +1,6 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import List from '../../src/List';
-import { forOf } from '@dojo/shim/iterator';
 import Set from '@dojo/shim/Set';
 
 registerSuite(function () {
@@ -51,9 +50,9 @@ registerSuite(function () {
 
 			let entries: [number, string][] = [];
 
-			forOf(list.entries(), (value: [number, string]) => {
+			for (const value of list.entries()) {
 				entries.push(value);
-			});
+			}
 
 			assert.deepEqual(entries, [
 				[ 0, 'one' ],
@@ -99,9 +98,9 @@ registerSuite(function () {
 
 			let keys: number[] = [];
 
-			forOf(list.keys(), (key: number) => {
+			for (const key of list.keys()) {
 				keys.push(key);
-			});
+			}
 
 			assert.deepEqual(keys, [ 0, 1, 2 ]);
 		},
@@ -111,9 +110,9 @@ registerSuite(function () {
 
 			let values: string[] = [];
 
-			forOf(list.values(), (value: string) => {
+			for (const value of list.values()) {
 				values.push(value);
-			});
+			}
 
 			assert.deepEqual(values, [ 'one', 'two', 'three' ]);
 		},
@@ -192,9 +191,9 @@ registerSuite(function () {
 			const list = listWith('the', 'quick', 'brown', 'fox');
 			let values: string[] = [];
 
-			forOf(list, (value: string) => {
+			for (const value of list) {
 				values.push(value);
-			});
+			}
 
 			assert.deepEqual(values, [ 'the', 'quick', 'brown', 'fox' ]);
 		},

--- a/tests/unit/MultiMap.ts
+++ b/tests/unit/MultiMap.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import MultiMap from '../../src/MultiMap';
-import { forOf, isIterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import { isIterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 
 let map: MultiMap<any>;
 function foo() {}
@@ -104,13 +104,13 @@ registerSuite({
 		assert.isTrue(isIterable(entries), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(entries, function (value: [ any[], any ]): void {
+		for (const value of entries) {
 			value[0].forEach((key, index) => {
 				assert.strictEqual(key, mapArgs[i][0][index]);
 			});
 			assert.strictEqual(value[1], mapArgs[i][1]);
 			i++;
-		});
+		}
 	},
 
 	'Symbol iterator'() {
@@ -120,13 +120,13 @@ registerSuite({
 		assert.isTrue(isIterable(entries), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(entries, function (value: [ any[], any ]): void {
+		for (const value of entries) {
 			value[0].forEach((key, index) => {
 				assert.strictEqual(key, mapArgs[i][0][index]);
 			});
 			assert.strictEqual(value[1], mapArgs[i][1]);
 			i++;
-		});
+		}
 	},
 
 	forEach: {
@@ -187,12 +187,12 @@ registerSuite({
 		assert.isTrue(isIterable(keys), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(keys, function (value: any[]): void {
+		for (const value of keys) {
 			value.forEach((key, index) => {
 				assert.strictEqual(key, mapArgs[i][0][index]);
 			});
 			i++;
-		});
+		}
 	},
 
 	set: {
@@ -231,9 +231,9 @@ registerSuite({
 		assert.isTrue(isIterable(values), 'Returns an iterable.');
 
 		let i = 0;
-		forOf(values, function (value: any): void {
+		for (const value of values) {
 			assert.strictEqual(value, mapArgs[i][1]);
 			i++;
-		});
+		}
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": false,
+		"downlevelIteration": true,
 		"experimentalDecorators": true,
 		"lib": [
 			"dom",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removing usages of `forOf` in favor of `for..of` with the help of the `domlevelIteration` flag.
