### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:browserstack
+- grunt intern:browserstack --test-reporter
 - grunt uploadCoverage
 - if [ "$TRAVIS_BRANCH" = "master" ]; then grunt doc; fi
 notifications:

--- a/intern.json
+++ b/intern.json
@@ -1,4 +1,11 @@
 {
+	"capabilities": {
+		"project": "Dojo 2",
+		"name": "@dojo/core",
+		"fixSessionCapabilities": false,
+		"browserstack.debug": false
+	},
+
 	"environments": [
 		{ "browserName": "node" }
 	],
@@ -44,21 +51,8 @@
 	],
 
 	"configs": {
-		"remoteCapabilities": {
-			"capabilities": {
-				"project": "Dojo 2",
-				"name": "@dojo/core",
-				"fixSessionCapabilities": false
-			}
-		},
-
 		"browserstack": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "browserstack",
-			"capabilities+": {
-				"browserstack.debug": false
-			},
 
 			"environments+": [
 				{ "browserName": "internet explorer", "version": "11" },
@@ -90,8 +84,6 @@
 		},
 
 		"local": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "selenium",
 			"tunnelOptions": {
 				"hostname": "localhost",
@@ -104,8 +96,6 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},
 

--- a/intern.json
+++ b/intern.json
@@ -39,13 +39,11 @@
 		]
 	},
 
-	"configs": {
-		"coverage": {
-			"coverage": [
-				"./_build/src/**/*.js"
-			]
-		},
+	"coverage": [
+		"./_build/src/**/*.js"
+	],
 
+	"configs": {
 		"remoteCapabilities": {
 			"capabilities": {
 				"project": "Dojo 2",
@@ -55,7 +53,7 @@
 		},
 
 		"browserstack": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "browserstack",
 			"capabilities+": {
@@ -73,8 +71,6 @@
 		},
 
 		"node-loader": {
-			"extends": [ "coverage" ],
-
 			"node": {
 				"loader": {
 					"script": "dojo2",
@@ -94,7 +90,7 @@
 		},
 
 		"local": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "selenium",
 			"tunnelOptions": {
@@ -108,7 +104,7 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,40 +2090,6 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
-    "fileset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-      "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-      "dev": true,
-      "requires": {
-        "glob": "5.0.15",
-        "minimatch": "2.0.10"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        }
-      }
-    },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
@@ -3520,45 +3486,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
-        }
-      }
-    },
-    "istanbul": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
-      "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "fileset": "0.2.1",
-        "handlebars": "4.0.10",
-        "js-yaml": "3.5.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.2.14",
-        "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "grunt": "^1.0.1",
     "grunt-dojo2": "latest",
     "intern": "~4.0.2",
-    "istanbul": "0.4.3",
     "multer": "~1.3.0",
     "sinon": "~1.17.6",
     "typescript": "~2.4.1"


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this will pass.