### PR TITLE
Guarantee util.throttle delay

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -107,7 +107,9 @@ export function guaranteeMinimumTimeout(callback: (...args: any[]) => void, dela
 		} else {
 			// Cast setTimeout return value to fix TypeScript parsing bug.  Without it,
 			// it thinks we are using the Node version of setTimeout.
-			timerId = <any> setTimeout(timeoutHandler, delta);
+			// Revisit this with the next TypeScript update.
+			// Set another timer for the mount of time that we came up short.
+			timerId = <any> setTimeout(timeoutHandler, delay - delta);
 		}
 	}
 	timerId = setTimeout(timeoutHandler, delay);

--- a/src/util.ts
+++ b/src/util.ts
@@ -105,7 +105,9 @@ export function guaranteeMinimumTimeout(callback: (...args: any[]) => void, dela
 		if (delay == null || delta >= delay) {
 			callback();
 		} else {
-			timerId = setTimeout(timeoutHandler);
+			// Cast setTimeout return value to fix TypeScript parsing bug.  Without it,
+			// it thinks we are using the Node version of setTimeout.
+			timerId = <any> setTimeout(timeoutHandler, delta);
 		}
 	}
 	timerId = setTimeout(timeoutHandler, delay);

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -24,233 +24,278 @@ import { Handle } from '@dojo/interfaces/core';
 import * as util from '../../src/util';
 
 const TIMEOUT = 3000;
+let timerHandle: any = null;
 
 registerSuite('utility functions', {
-	createTimer: (function () {
-		let timer: Handle | null;
+	afterEach() {
+		timerHandle && clearTimeout(timerHandle);
+		timerHandle = null;
+	},
 
-		return {
-			afterEach() {
-				timer && timer.destroy();
-				timer = null;
+	tests: {
+		createTimer: (function () {
+			let timer: Handle | null;
+
+			return {
+				afterEach() {
+					timer && timer.destroy();
+					timer = null;
+				},
+
+				destroy(this: any) {
+					const dfd = this.async(1000);
+					const spy = sinon.spy();
+					timer = util.createTimer(spy, 100);
+
+					setTimeout(function () {
+						if (timer) {
+							timer.destroy();
+						}
+					}, 50);
+
+					setTimeout(dfd.callback(function () {
+						assert.strictEqual(spy.callCount, 0);
+					}), 110);
+				},
+
+				timeout(this: any) {
+					const dfd = this.async(1000);
+					const spy = sinon.spy();
+					timer = util.createTimer(spy, 100);
+
+					setTimeout(dfd.callback(function () {
+						assert.strictEqual(spy.callCount, 1);
+					}), 110);
+				}
+			};
+		})(),
+
+		guaranteeMinimumTimeout: (function () {
+			let timer: Handle | null;
+
+			return {
+				afterEach() {
+					timer && timer.destroy();
+					timer = null;
+				},
+
+				destroy(this: any) {
+					const dfd = this.async(1000);
+					const spy = sinon.spy();
+					timer = util.guaranteeMinimumTimeout(spy, 100);
+
+					setTimeout(function () {
+						if (timer) {
+							timer.destroy();
+						}
+					}, 50);
+
+					setTimeout(dfd.callback(function () {
+						assert.strictEqual(spy.callCount, 0);
+					}), 110);
+				},
+
+				timeout(this: any) {
+					const dfd = this.async(1000);
+					const startTime = Date.now();
+					timer = util.guaranteeMinimumTimeout(dfd.callback(function () {
+						const dif = Date.now() - startTime;
+						assert.isTrue(dif >= 100, 'Delay was ' + dif + 'ms.');
+					}), 100);
+				},
+
+				'timeout no delay'(this: any) {
+					const dfd = this.async(1000);
+					timer = util.guaranteeMinimumTimeout(dfd.callback(function () {
+						assert.isTrue(true);
+					}));
+				}
+			};
+		})(),
+
+		debounce: {
+			'preserves context'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				// FIXME
+				let foo = {
+					bar: util.debounce(dfd.callback(function (this: any) {
+						assert.strictEqual(this, foo, 'Function should be executed with correct context');
+					}), 0)
+				};
+
+				foo.bar();
 			},
 
-			destroy(this: any) {
-				const dfd = this.async(1000);
-				const spy = sinon.spy();
-				timer = util.createTimer(spy, 100);
+			'receives arguments'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				const testArg1 = 5;
+				const testArg2 = 'a';
+				const debouncedFunction = util.debounce(dfd.callback(function (a: number, b: string) {
+					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+				}), 0);
 
-				setTimeout(function () {
-					if (timer) {
-						timer.destroy();
+				debouncedFunction(testArg1, testArg2);
+			},
+
+			'debounces callback'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				const debouncedFunction = util.debounce(dfd.callback(function () {
+					assert.isAbove(Date.now() - lastCallTick, 10, 'Function should not be called until period has elapsed without further calls');
+
+					// Typically, we expect the 3rd invocation to be the one that is executed.
+					// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may
+					// take longer. If 25+ ms has actually elapsed, then the first or second invocation may end up
+					// being eligible for execution.
+				}), 25);
+
+				let runCount = 1;
+				let lastCallTick: number;
+
+				function run() {
+					lastCallTick = Date.now();
+					debouncedFunction();
+					runCount += 1;
+
+					if (runCount < 4) {
+						timerHandle = setTimeout(run, 5);
 					}
-				}, 50);
+				}
 
-				setTimeout(dfd.callback(function () {
-					assert.strictEqual(spy.callCount, 0);
-				}), 110);
+				run();
+			}
+		},
+
+		throttle: {
+			'preserves context'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				// FIXME
+				const foo = {
+					bar: util.throttle(dfd.callback(function(this: any) {
+						assert.strictEqual(this, foo, 'Function should be executed with correct context');
+					}), 0)
+				};
+
+				foo.bar();
 			},
 
-			timeout(this: any) {
-				const dfd = this.async(1000);
-				const spy = sinon.spy();
-				timer = util.createTimer(spy, 100);
+			'receives arguments'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				const testArg1 = 5;
+				const testArg2 = 'a';
+				const throttledFunction = util.throttle(dfd.callback(function (a: number, b: string) {
+					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+				}), 0);
 
-				setTimeout(dfd.callback(function () {
-					assert.strictEqual(spy.callCount, 1);
-				}), 110);
+				throttledFunction(testArg1, testArg2);
+			},
+
+			'throttles callback'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				let callCount = 0;
+				let cleared = false;
+				let handle: Handle | null;
+				const throttledFunction = util.throttle(dfd.rejectOnError(function (a: string) {
+					callCount++;
+					assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
+					// Rounding errors?
+					// Technically, the time diff should be greater than 24ms, but in some cases
+					// it is equal to 24ms.
+					assert.isAbove(Date.now() - lastRunTick, 23,
+						'Function should not be called until throttle delay has elapsed');
+
+					lastRunTick = Date.now();
+					if (callCount > 1) {
+						handle && handle.destroy();
+						cleared = true;
+						dfd.resolve();
+					}
+				}), 25);
+
+				let runCount = 1;
+				let lastRunTick = 0;
+
+				function run() {
+					throttledFunction('a');
+					throttledFunction('b');
+					runCount += 1;
+
+					if (runCount < 10 && !cleared) {
+						handle = util.guaranteeMinimumTimeout(run, 5);
+					}
+				}
+
+				run();
+				assert.strictEqual(callCount, 1,
+					'Function should be called as soon as it is first invoked');
 			}
-		};
-	})(),
-
-	debounce: {
-		'preserves context'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			// FIXME
-			var foo = {
-				bar: util.debounce(dfd.callback(function (this: any) {
-					assert.strictEqual(this, foo, 'Function should be executed with correct context');
-				}), 0)
-			};
-
-			foo.bar();
 		},
 
-		'receives arguments'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			const testArg1 = 5;
-			const testArg2 = 'a';
-			const debouncedFunction = util.debounce(dfd.callback(function (a: number, b: string) {
-				assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-				assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-			}), 0);
+		throttleAfter: {
+			'preserves context'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				// FIXME
+				const foo = {
+					bar: util.throttleAfter(dfd.callback(function(this: any) {
+						assert.strictEqual(this, foo, 'Function should be executed with correct context');
+					}), 0)
+				};
 
-			debouncedFunction(testArg1, testArg2);
-		},
+				foo.bar();
+			},
 
-		'debounces callback'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			const debouncedFunction = util.debounce(dfd.callback(function () {
-				assert.isAbove(Date.now() - lastCallTick, 10, 'Function should not be called until period has elapsed without further calls');
+			'receives arguments'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				const testArg1 = 5;
+				const testArg2 = 'a';
+				const throttledFunction = util.throttleAfter(dfd.callback(function (a: number, b: string) {
+					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+				}), 0);
 
-				// Typically, we expect the 3rd invocation to be the one that is executed.
-				// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may
-				// take longer. If 25+ ms has actually elapsed, then the first or second invocation may end up
-				// being eligible for execution.
-				// If the first or second invocation has been called there's no need to let the run loop continue.
-				clearTimeout(handle);
-			}), 25);
+				throttledFunction(testArg1, testArg2);
+			},
 
-			let runCount = 1;
-			let lastCallTick: number;
-			let handle: any;
+			'throttles callback'(this: any) {
+				const dfd = this.async(TIMEOUT);
+				// FIXME
+				let callCount = 0;
+				let cleared = false;
+				const throttledFunction = util.throttle(dfd.rejectOnError(function (a: string) {
+					callCount++;
+					assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
+					// Rounding errors?
+					// Technically, the time diff should be greater than 24ms, but in some cases
+					// it is equal to 24ms.
+					assert.isAbove(Date.now() - lastRunTick, 23,
+						'Function should not be called until throttle delay has elapsed');
 
-			function run() {
-				lastCallTick = Date.now();
-				debouncedFunction();
-				runCount += 1;
+					lastRunTick = Date.now();
+					if (callCount > 1) {
+						clearTimeout(timerHandle);
+						cleared = true;
+						dfd.resolve();
+					}
+				}), 25);
 
-				if (runCount < 4) {
-					handle = setTimeout(run, 5);
+				let runCount = 1;
+				let lastRunTick = 0;
+
+				function run() {
+					throttledFunction('a');
+					throttledFunction('b');
+					runCount += 1;
+
+					if (runCount < 10 && !cleared) {
+						timerHandle = setTimeout(run, 5);
+					}
 				}
+
+				run();
+				assert.strictEqual(callCount, 1,
+					'Function should be called as soon as it is first invoked');
 			}
-
-			run();
-		}
-	},
-
-	throttle: {
-		'preserves context'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			// FIXME
-			var foo = {
-				bar: util.throttle(dfd.callback(function (this: any) {
-					assert.strictEqual(this, foo, 'Function should be executed with correct context');
-				}), 0)
-			};
-
-			foo.bar();
-		},
-
-		'receives arguments'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			const testArg1 = 5;
-			const testArg2 = 'a';
-			const throttledFunction = util.throttle(dfd.callback(function (a: number, b: string) {
-				assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-				assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-			}), 0);
-
-			throttledFunction(testArg1, testArg2);
-		},
-
-		'throttles callback'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			// FIXME
-
-			let callCount = 0;
-			let cleared = false;
-			const throttledFunction = util.throttle(dfd.rejectOnError(function (a: string) {
-				callCount++;
-				assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
-				// Rounding errors?
-				// Technically, the time diff should be greater than 24ms, but in some cases
-				// it is equal to 24ms.
-				assert.isAbove(Date.now() - lastRunTick, 23,
-					'Function should not be called until throttle delay has elapsed');
-
-				lastRunTick = Date.now();
-				if (callCount > 1) {
-					clearTimeout(handle);
-					cleared = true;
-					dfd.resolve();
-				}
-			}), 25);
-
-			let runCount = 1;
-			let lastRunTick = 0;
-			let handle: any;
-
-			function run() {
-				throttledFunction('a');
-				throttledFunction('b');
-				runCount += 1;
-
-				if (runCount < 10 && !cleared) {
-					handle = setTimeout(run, 5);
-				}
-			}
-
-			run();
-			assert.strictEqual(callCount, 1,
-				'Function should be called as soon as it is first invoked');
-		}
-	},
-
-	throttleAfter: {
-		'preserves context'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			// FIXME
-			var foo = {
-				bar: util.throttleAfter(dfd.callback(function(this: any) {
-					assert.strictEqual(this, foo, 'Function should be executed with correct context');
-				}), 0)
-			};
-
-			foo.bar();
-		},
-
-		'receives arguments'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			const testArg1 = 5;
-			const testArg2 = 'a';
-			const throttledFunction = util.throttleAfter(dfd.callback(function (a: number, b: string) {
-				assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-				assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-			}), 0);
-
-			throttledFunction(testArg1, testArg2);
-		},
-
-		'throttles callback'(this: any) {
-			const dfd = this.async(TIMEOUT);
-			// FIXME
-			let callCount = 0;
-			let cleared = false;
-			const throttledFunction = util.throttle(dfd.rejectOnError(function (a: string) {
-				callCount++;
-				assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
-				// Rounding errors?
-				// Technically, the time diff should be greater than 24ms, but in some cases
-				// it is equal to 24ms.
-				assert.isAbove(Date.now() - lastRunTick, 23,
-					'Function should not be called until throttle delay has elapsed');
-
-				lastRunTick = Date.now();
-				if (callCount > 1) {
-					clearTimeout(handle);
-					cleared = true;
-					dfd.resolve();
-				}
-			}), 25);
-
-			let runCount = 1;
-			let lastRunTick = 0;
-			let handle: any;
-
-			function run() {
-				throttledFunction('a');
-				throttledFunction('b');
-				runCount += 1;
-
-				if (runCount < 10 && !cleared) {
-					handle = setTimeout(run, 5);
-				}
-			}
-
-			run();
-			assert.strictEqual(callCount, 1,
-				'Function should be called as soon as it is first invoked');
 		}
 	}
 });


### PR DESCRIPTION
setTimeout in Edge and IE 11 do not guarantee the delay value.  In my testing, if the delay is greater than 200ms, then setTimeout is reliable but with a smaller delay, the callback function can fire early roughly 50% of the time.

I created `util.guaranteeMinimumTimeout()` which makes sure the desired amount of time has passed.

Fixes: #357 