### PR TITLE
Fix "random" XHR test fail.  

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -55,7 +55,8 @@
 			"tunnel": "browserstack",
 
 			"environments+": [
-				{ "browserName": "internet explorer", "version": "11" },
+				{ "browserName": "internet explorer", "version": "11", "os": "WINDOWS", "os_version": "8.1"},
+				{ "browserName": "internet explorer", "version": "11", "os": "WINDOWS", "os_version": "10"},
 				{ "browserName": "edge" },
 				{ "browserName": "firefox", "platform": "WINDOWS" },
 				{ "browserName": "chrome", "platform": "WINDOWS" }

--- a/src/has.ts
+++ b/src/has.ts
@@ -28,8 +28,9 @@ add('node-buffer', 'Buffer' in global && typeof global.Buffer === 'function', tr
 add('fetch', 'fetch' in global && typeof global.fetch === 'function', true);
 
 add('web-worker-xhr-upload', new Promise((resolve) => {
-	if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
-		const blob = new Blob([ `(function () {
+	try {
+		if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
+			const blob = new Blob([ `(function () {
 self.addEventListener('message', function () {
 	var xhr = new XMLHttpRequest();
 	try {
@@ -40,12 +41,16 @@ self.addEventListener('message', function () {
 	}
 });
 		})()` ], { type: 'application/javascript' });
-		const worker = new Worker(URL.createObjectURL(blob));
-		worker.addEventListener('message', ({ data: result }) => {
-			resolve(result === 'true');
-		});
-		worker.postMessage({});
-	} else {
+			const worker = new Worker(URL.createObjectURL(blob));
+			worker.addEventListener('message', ({ data: result }) => {
+				resolve(result === 'true');
+			});
+			worker.postMessage({});
+		} else {
+			resolve(false);
+		}
+	} catch (e) {
+		// IE11 on Winodws 8.1 encounters a security error.
 		resolve(false);
 	}
 }));


### PR DESCRIPTION
A security error occurs in IE11 on Windows 8.1 (and probably older) in the web-worker-xhr-upload `has` test causing the `has` test to be removed from the cache.  This fix makes the `has` test return false when the security error occurs.

This test failure appeared to be random because we were asking for IE11 on "WINDOWS" in the intern configuration.  I added more specific operating system requests to intern.json.

Searching in Google revealed that the security error was occurring in Windows 10 but a fix in Windows 10 was released.

Fixes #358 