### PR TITLE
Remove destructuring from generateRequestUrl signature

### DIFF
--- a/src/request/util.ts
+++ b/src/request/util.ts
@@ -8,10 +8,9 @@ import { forOf } from '@dojo/shim/iterator';
  * @param url The base URL.
  * @param options The RequestOptions used to generate the query string or cacheBust.
  */
-export function generateRequestUrl(url: string,
-		{ query, cacheBust }: RequestOptions = {}): string {
-	query = new UrlSearchParams(query).toString();
-	if (cacheBust) {
+export function generateRequestUrl(url: string, options: RequestOptions = {}): string {
+	let query = new UrlSearchParams(options.query).toString();
+	if (options.cacheBust) {
 		const bustString = String(Date.now());
 		query += query ? `&${bustString}` : bustString;
 	}


### PR DESCRIPTION
**Description:**

The `generateRequestUrl` function is correct, but its usage of destructuring with a default argument is throwing an error in the way that ts-loader reads the code. Issue TypeStrong/ts-loader#442 describes the issue, but it hasn't really had much progress, and it's easier to just change this.