### PR TITLE
Using importHelpers instead of noEmitHelpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@dojo/has": "~0.1.0",
-    "@dojo/shim": "~0.2.1"
+    "@dojo/shim": "~0.2.2"
   },
   "devDependencies": {
     "@dojo/interfaces": "~0.1.0",

--- a/src/List.ts
+++ b/src/List.ts
@@ -22,7 +22,7 @@ export default class List<T> {
 		if (source) {
 			if (isArrayLike(source)) {
 				for (let i = 0; i < source.length; i++) {
-					this.add(source[ i ]);
+					this.add(source[i]);
 				}
 			}
 			else if (isIterable(source)) {
@@ -52,7 +52,7 @@ export default class List<T> {
 	}
 
 	entries(): IterableIterator<[number, T]> {
-		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [ index, value ]));
+		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [index, value]));
 	}
 
 	forEach(fn: (value: T, idx: number, list: this) => void, thisArg?: any): void {

--- a/src/List.ts
+++ b/src/List.ts
@@ -52,7 +52,7 @@ export default class List<T> {
 	}
 
 	entries(): IterableIterator<[number, T]> {
-		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [index, value]));
+		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [ index, value ]));
 	}
 
 	forEach(fn: (value: T, idx: number, list: this) => void, thisArg?: any): void {

--- a/src/List.ts
+++ b/src/List.ts
@@ -1,4 +1,4 @@
-import { Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import { isArrayLike, isIterable, Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 import WeakMap from '@dojo/shim/WeakMap';
 
 const listItems: WeakMap<List<any>, any[]> = new WeakMap<List<any>, any[]>();
@@ -20,8 +20,15 @@ export default class List<T> {
 		listItems.set(this, []);
 
 		if (source) {
-			for (const item of source) {
-				this.add(item);
+			if (isArrayLike(source)) {
+				for (let i = 0; i < source.length; i++) {
+					this.add(source[ i ]);
+				}
+			}
+			else if (isIterable(source)) {
+				for (const item of source) {
+					this.add(item);
+				}
 			}
 		}
 	}

--- a/src/MultiMap.ts
+++ b/src/MultiMap.ts
@@ -23,13 +23,13 @@ export default class MultiMap<T> implements Map<any[], T> {
 		if (iterable) {
 			if (isArrayLike(iterable)) {
 				for (let i = 0; i < iterable.length; i++) {
-					const value = iterable[ i ];
-					this.set(value[ 0 ], value[ 1 ]);
+					const value = iterable[i];
+					this.set(value[0], value[1]);
 				}
 			}
 			else if (isIterable(iterable)) {
 				for (const value of iterable) {
-					this.set(value[ 0 ], value[ 1 ]);
+					this.set(value[0], value[1]);
 				}
 			}
 		}

--- a/src/MultiMap.ts
+++ b/src/MultiMap.ts
@@ -1,7 +1,7 @@
-import '@dojo/shim/Symbol';
-import Map from '@dojo/shim/Map';
 import { from as arrayFrom } from '@dojo/shim/array';
-import { Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import { isArrayLike, isIterable, Iterable, IterableIterator, ShimIterator } from '@dojo/shim/iterator';
+import Map from '@dojo/shim/Map';
+import '@dojo/shim/Symbol';
 
 /**
  * A map implmentation that supports multiple keys for specific value.
@@ -21,8 +21,16 @@ export default class MultiMap<T> implements Map<any[], T> {
 		this._map = new Map<any, any>();
 		this._key = Symbol();
 		if (iterable) {
-			for (const value of iterable) {
-				this.set(value[0], value[1]);
+			if (isArrayLike(iterable)) {
+				for (let i = 0; i < iterable.length; i++) {
+					const value = iterable[ i ];
+					this.set(value[ 0 ], value[ 1 ]);
+				}
+			}
+			else if (isIterable(iterable)) {
+				for (const value of iterable) {
+					this.set(value[ 0 ], value[ 1 ]);
+				}
 			}
 		}
 	}

--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -11,7 +11,7 @@ export type ParamList = Hash<string | string[]>;
  */
 function parseQueryString(input: string): ParamList {
 	const query: Hash<string[]> = {};
-	for (const entry of input.split('&')) {
+	input.split('&').forEach(entry => {
 		const indexOfFirstEquals = entry.indexOf('=');
 		let key: string;
 		let value = '';
@@ -32,7 +32,7 @@ function parseQueryString(input: string): ParamList {
 		else {
 			query[key] = [ value ];
 		}
-	}
+	});
 	return query;
 }
 
@@ -186,9 +186,9 @@ export default class UrlSearchParams {
 			const values = this._list[key];
 			if (values) {
 				const encodedKey = encodeURIComponent(key);
-				for (const value of values) {
+				values.forEach(value => {
 					query.push(encodedKey + (value ? ('=' + encodeURIComponent(value)) : ''));
-				}
+				});
 			}
 		}
 

--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -11,7 +11,10 @@ export type ParamList = Hash<string | string[]>;
  */
 function parseQueryString(input: string): ParamList {
 	const query: Hash<string[]> = {};
-	input.split('&').forEach(entry => {
+	const splits = input.split('&');
+
+	for (let i = 0; i < splits.length; i++) {
+		const entry = splits[ i ];
 		const indexOfFirstEquals = entry.indexOf('=');
 		let key: string;
 		let value = '';
@@ -19,7 +22,8 @@ function parseQueryString(input: string): ParamList {
 		if (indexOfFirstEquals >= 0) {
 			key = entry.slice(0, indexOfFirstEquals);
 			value = entry.slice(indexOfFirstEquals + 1);
-		} else {
+		}
+		else {
 			key = entry;
 		}
 
@@ -27,12 +31,12 @@ function parseQueryString(input: string): ParamList {
 		value = value ? decodeURIComponent(value) : '';
 
 		if (key in query) {
-			query[key].push(value);
+			query[ key ].push(value);
 		}
 		else {
-			query[key] = [ value ];
+			query[ key ] = [ value ];
 		}
-	});
+	}
 	return query;
 }
 
@@ -186,9 +190,9 @@ export default class UrlSearchParams {
 			const values = this._list[key];
 			if (values) {
 				const encodedKey = encodeURIComponent(key);
-				values.forEach(value => {
-					query.push(encodedKey + (value ? ('=' + encodeURIComponent(value)) : ''));
-				});
+				for (let i = 0; i < values.length; i++) {
+					query.push(encodedKey + (values[ i ] ? ('=' + encodeURIComponent(values[ i ])) : ''));
+				}
 			}
 		}
 

--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -14,7 +14,7 @@ function parseQueryString(input: string): ParamList {
 	const splits = input.split('&');
 
 	for (let i = 0; i < splits.length; i++) {
-		const entry = splits[ i ];
+		const entry = splits[i];
 		const indexOfFirstEquals = entry.indexOf('=');
 		let key: string;
 		let value = '';
@@ -31,10 +31,10 @@ function parseQueryString(input: string): ParamList {
 		value = value ? decodeURIComponent(value) : '';
 
 		if (key in query) {
-			query[ key ].push(value);
+			query[key].push(value);
 		}
 		else {
-			query[ key ] = [ value ];
+			query[key] = [value];
 		}
 	}
 	return query;
@@ -191,7 +191,7 @@ export default class UrlSearchParams {
 			if (values) {
 				const encodedKey = encodeURIComponent(key);
 				for (let i = 0; i < values.length; i++) {
-					query.push(encodedKey + (values[ i ] ? ('=' + encodeURIComponent(values[ i ])) : ''));
+					query.push(encodedKey + (values[i] ? ('=' + encodeURIComponent(values[i])) : ''));
 				}
 			}
 		}

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -15,7 +15,7 @@ export function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 
 	if (isArrayLike(iterable)) {
 		for (let i = 0; i < iterable.length; i++) {
-			const item = iterable[ i ];
+			const item = iterable[i];
 			unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
 		}
 	}

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -1,6 +1,6 @@
-import { Iterable, isIterable, isArrayLike } from '@dojo/shim/iterator';
-import Promise, { Executor } from '@dojo/shim/Promise';
 import { Thenable } from '@dojo/shim/interfaces';
+import { isArrayLike, isIterable, Iterable } from '@dojo/shim/iterator';
+import Promise, { Executor } from '@dojo/shim/Promise';
 import '@dojo/shim/Symbol';
 
 /**
@@ -12,9 +12,19 @@ import '@dojo/shim/Symbol';
  */
 export function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 	const unwrapped: any[] = [];
-	for (const item of iterable) {
-		unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
+
+	if (isArrayLike(iterable)) {
+		for (let i = 0; i < iterable.length; i++) {
+			const item = iterable[ i ];
+			unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
+		}
 	}
+	else {
+		for (const item of iterable) {
+			unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
+		}
+	}
+
 	return unwrapped;
 }
 

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -152,7 +152,16 @@ export default class Task<T> extends ExtensiblePromise<T> {
 		return new Task((resolve, reject) => {
 			super.all(iterable).then(resolve, reject);
 		}, () => {
-			if (isIterable(iterable) || isArrayLike(iterable)) {
+			if (isArrayLike(iterable)) {
+				for (let i = 0; i < iterable.length; i++) {
+					const promiseLike = iterable[ i ];
+
+					if (isTask(promiseLike)) {
+						promiseLike.cancel();
+					}
+				}
+			}
+			else if (isIterable(iterable)) {
 				for (const promiseLike of iterable) {
 					if (isTask(promiseLike)) {
 						promiseLike.cancel();

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -154,7 +154,7 @@ export default class Task<T> extends ExtensiblePromise<T> {
 		}, () => {
 			if (isArrayLike(iterable)) {
 				for (let i = 0; i < iterable.length; i++) {
-					const promiseLike = iterable[ i ];
+					const promiseLike = iterable[i];
 
 					if (isTask(promiseLike)) {
 						promiseLike.cancel();

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -23,7 +23,7 @@ function shouldDeepCopyObject(value: any): value is Object {
 function copyArray<T>(array: T[], inherited: boolean): T[] {
 	return array.map(function (item: T): T {
 		if (Array.isArray(item)) {
-			return <any>copyArray(<any> item, inherited);
+			return <any> copyArray(<any> item, inherited);
 		}
 
 		return !shouldDeepCopyObject(item) ?
@@ -31,7 +31,7 @@ function copyArray<T>(array: T[], inherited: boolean): T[] {
 			_mixin({
 				deep: true,
 				inherited: inherited,
-				sources: <Array<T>>[item],
+				sources: <Array<T>> [ item ],
 				target: <T> {}
 			});
 	});

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -51,9 +51,9 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 	const copied = kwArgs.copied || [];
 	const copiedClone = [ ...copied ];
 
-	for (let source of kwArgs.sources) {
+	kwArgs.sources.forEach(source => {
 		if (source === null || source === undefined) {
-			continue;
+			return;
 		}
 		for (let key in source) {
 			if (inherited || hasOwnProperty.call(source, key)) {
@@ -82,7 +82,8 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 				target[key] = value;
 			}
 		}
-	}
+
+	});
 
 	return <T&U> target;
 }
@@ -279,8 +280,8 @@ export function createHandle(destructor: () => void): Handle {
  */
 export function createCompositeHandle(...handles: Handle[]): Handle {
 	return createHandle(function () {
-		for (let handle of handles) {
+		handles.forEach(handle => {
 			handle.destroy();
-		}
+		});
 	});
 }

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -23,7 +23,7 @@ function shouldDeepCopyObject(value: any): value is Object {
 function copyArray<T>(array: T[], inherited: boolean): T[] {
 	return array.map(function (item: T): T {
 		if (Array.isArray(item)) {
-			return  <any> copyArray(<any> item, inherited);
+			return <any> copyArray(<any> item, inherited);
 		}
 
 		return !shouldDeepCopyObject(item) ?
@@ -31,7 +31,7 @@ function copyArray<T>(array: T[], inherited: boolean): T[] {
 			_mixin({
 				deep: true,
 				inherited: inherited,
-				sources: <Array<T>> [ item ],
+				sources: <Array<T>> [item],
 				target: <T> {}
 			});
 	});
@@ -45,22 +45,22 @@ interface MixinArgs<T extends {}, U extends {}> {
 	copied?: any[];
 }
 
-function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
+function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
 	const deep = kwArgs.deep;
 	const inherited = kwArgs.inherited;
 	const target: any = kwArgs.target;
 	const copied = kwArgs.copied || [];
-	const copiedClone = [ ...copied ];
+	const copiedClone = [...copied];
 
 	for (let i = 0; i < kwArgs.sources.length; i++) {
-		const source = kwArgs.sources[ i ];
+		const source = kwArgs.sources[i];
 
 		if (source === null || source === undefined) {
 			continue;
 		}
 		for (let key in source) {
 			if (inherited || hasOwnProperty.call(source, key)) {
-				let value: any = source[ key ];
+				let value: any = source[key];
 
 				if (copiedClone.indexOf(value) !== -1) {
 					continue;
@@ -71,29 +71,32 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 						value = copyArray(value, inherited);
 					}
 					else if (shouldDeepCopyObject(value)) {
-						const targetValue: any = target[ key ] || {};
+						const targetValue: any = target[key] || {};
 						copied.push(source);
 						value = _mixin({
 							deep: true,
 							inherited: inherited,
-							sources: [ value ],
+							sources: [value],
 							target: targetValue,
 							copied
 						});
 					}
 				}
-				target[ key ] = value;
+				target[key] = value;
 			}
 		}
 	}
 
-	return <T&U> target;
+	return <T & U> target;
 }
 
 interface ObjectAssignConstructor extends ObjectConstructor {
 	assign<T, U>(target: T, source: U): T & U;
+
 	assign<T, U1, U2>(target: T, source1: U1, source2: U2): T & U1 & U2;
+
 	assign<T, U1, U2, U3>(target: T, source1: U1, source2: U2, source3: U3): T & U1 & U2 & U3;
+
 	assign(target: any, ...sources: any[]): any;
 }
 
@@ -268,7 +271,8 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
 export function createHandle(destructor: () => void): Handle {
 	return {
 		destroy: function (this: Handle) {
-			this.destroy = function () {};
+			this.destroy = function () {
+			};
 			destructor.call(this);
 		}
 	};
@@ -283,7 +287,7 @@ export function createHandle(destructor: () => void): Handle {
 export function createCompositeHandle(...handles: Handle[]): Handle {
 	return createHandle(function () {
 		for (let i = 0; i < handles.length; i++) {
-			handles[ i ].destroy();
+			handles[i].destroy();
 		}
 	});
 }

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -1,5 +1,6 @@
 import { Handle } from '@dojo/interfaces/core';
 import { assign } from '@dojo/shim/object';
+
 export { assign } from '@dojo/shim/object';
 
 const slice = Array.prototype.slice;
@@ -51,13 +52,15 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 	const copied = kwArgs.copied || [];
 	const copiedClone = [ ...copied ];
 
-	kwArgs.sources.forEach(source => {
+	for (let i = 0; i < kwArgs.sources.length; i++) {
+		const source = kwArgs.sources[ i ];
+
 		if (source === null || source === undefined) {
-			return;
+			continue;
 		}
 		for (let key in source) {
 			if (inherited || hasOwnProperty.call(source, key)) {
-				let value: any = source[key];
+				let value: any = source[ key ];
 
 				if (copiedClone.indexOf(value) !== -1) {
 					continue;
@@ -68,7 +71,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 						value = copyArray(value, inherited);
 					}
 					else if (shouldDeepCopyObject(value)) {
-						const targetValue: any = target[key] || {};
+						const targetValue: any = target[ key ] || {};
 						copied.push(source);
 						value = _mixin({
 							deep: true,
@@ -79,11 +82,10 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 						});
 					}
 				}
-				target[key] = value;
+				target[ key ] = value;
 			}
 		}
-
-	});
+	}
 
 	return <T&U> target;
 }
@@ -280,8 +282,8 @@ export function createHandle(destructor: () => void): Handle {
  */
 export function createCompositeHandle(...handles: Handle[]): Handle {
 	return createHandle(function () {
-		handles.forEach(handle => {
-			handle.destroy();
-		});
+		for (let i = 0; i < handles.length; i++) {
+			handles[ i ].destroy();
+		}
 	});
 }

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -23,7 +23,7 @@ function shouldDeepCopyObject(value: any): value is Object {
 function copyArray<T>(array: T[], inherited: boolean): T[] {
 	return array.map(function (item: T): T {
 		if (Array.isArray(item)) {
-			return <any> copyArray(<any> item, inherited);
+			return <any>copyArray(<any> item, inherited);
 		}
 
 		return !shouldDeepCopyObject(item) ?
@@ -31,7 +31,7 @@ function copyArray<T>(array: T[], inherited: boolean): T[] {
 			_mixin({
 				deep: true,
 				inherited: inherited,
-				sources: <Array<T>> [item],
+				sources: <Array<T>>[item],
 				target: <T> {}
 			});
 	});
@@ -45,12 +45,12 @@ interface MixinArgs<T extends {}, U extends {}> {
 	copied?: any[];
 }
 
-function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
+function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 	const deep = kwArgs.deep;
 	const inherited = kwArgs.inherited;
 	const target: any = kwArgs.target;
 	const copied = kwArgs.copied || [];
-	const copiedClone = [...copied];
+	const copiedClone = [ ...copied ];
 
 	for (let i = 0; i < kwArgs.sources.length; i++) {
 		const source = kwArgs.sources[i];
@@ -76,7 +76,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
 						value = _mixin({
 							deep: true,
 							inherited: inherited,
-							sources: [value],
+							sources: [ value ],
 							target: targetValue,
 							copied
 						});
@@ -87,16 +87,13 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
 		}
 	}
 
-	return <T & U> target;
+	return <T&U> target;
 }
 
 interface ObjectAssignConstructor extends ObjectConstructor {
 	assign<T, U>(target: T, source: U): T & U;
-
 	assign<T, U1, U2>(target: T, source1: U1, source2: U2): T & U1 & U2;
-
 	assign<T, U1, U2, U3>(target: T, source1: U1, source2: U2, source3: U3): T & U1 & U2 & U3;
-
 	assign(target: any, ...sources: any[]): any;
 }
 
@@ -271,8 +268,7 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
 export function createHandle(destructor: () => void): Handle {
 	return {
 		destroy: function (this: Handle) {
-			this.destroy = function () {
-			};
+			this.destroy = function () {};
 			destructor.call(this);
 		}
 	};

--- a/src/load/util.ts
+++ b/src/load/util.ts
@@ -36,7 +36,16 @@ export function isPlugin(value: any): value is LoadPlugin<any> {
 export function useDefault(modules: any[]): any[];
 export function useDefault(module: any): any;
 export function useDefault(modules: any | any[]): any[] | any {
-	if (isIterable(modules) || isArrayLike(modules)) {
+	if (isArrayLike(modules)) {
+		let processedModules: any[] = [];
+
+		for (let i = 0; i < modules.length; i++) {
+			const module = modules[ i ];
+			processedModules.push((module.__esModule && module.default) ? module.default : module);
+		}
+
+		return processedModules;
+	} else if (isIterable(modules)) {
 		let processedModules: any[] = [];
 
 		for (const module of modules) {

--- a/src/load/util.ts
+++ b/src/load/util.ts
@@ -40,7 +40,7 @@ export function useDefault(modules: any | any[]): any[] | any {
 		let processedModules: any[] = [];
 
 		for (let i = 0; i < modules.length; i++) {
-			const module = modules[ i ];
+			const module = modules[i];
 			processedModules.push((module.__esModule && module.default) ? module.default : module);
 		}
 

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -94,9 +94,9 @@ export class XhrResponse extends Response {
 			const lines = responseHeaders.split(/\r\n/g);
 
 			for (let i = 0; i < lines.length; i++) {
-				const match = lines[ i ].match(/^(.*?): (.*)$/);
+				const match = lines[i].match(/^(.*?): (.*)$/);
 				if (match) {
-					headers.append(match[ 1 ], match[ 2 ]);
+					headers.append(match[1], match[2]);
 				}
 			}
 		}

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -91,12 +91,12 @@ export class XhrResponse extends Response {
 
 		const responseHeaders = request.getAllResponseHeaders();
 		if (responseHeaders) {
-			for (let line of responseHeaders.split(/\r\n/g)) {
+			responseHeaders.split(/\r\n/g).forEach(line => {
 				const match = line.match(/^(.*?): (.*)$/);
 				if (match) {
 					headers.append(match[1], match[2]);
 				}
-			}
+			});
 		}
 
 		this.status = request.status;

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -3,14 +3,14 @@ import global from '@dojo/shim/global';
 import WeakMap from '@dojo/shim/WeakMap';
 import Task, { State } from '../../async/Task';
 import has from '../../has';
+import Observable from '../../Observable';
 import { createTimer } from '../../util';
 import Headers from '../Headers';
 import { RequestOptions, UploadObservableTask } from '../interfaces';
 import Response, { getArrayBufferFromBlob, getTextFromBlob } from '../Response';
+import SubscriptionPool from '../SubscriptionPool';
 import TimeoutError from '../TimeoutError';
 import { generateRequestUrl } from '../util';
-import Observable from '../../Observable';
-import SubscriptionPool from '../SubscriptionPool';
 
 /**
  * Request options specific to an XHR request
@@ -91,12 +91,14 @@ export class XhrResponse extends Response {
 
 		const responseHeaders = request.getAllResponseHeaders();
 		if (responseHeaders) {
-			responseHeaders.split(/\r\n/g).forEach(line => {
-				const match = line.match(/^(.*?): (.*)$/);
+			const lines = responseHeaders.split(/\r\n/g);
+
+			for (let i = 0; i < lines.length; i++) {
+				const match = lines[ i ].match(/^(.*?): (.*)$/);
 				if (match) {
-					headers.append(match[1], match[2]);
+					headers.append(match[ 1 ], match[ 2 ]);
 				}
-			});
+			}
 		}
 
 		this.status = request.status;

--- a/tests/unit/List.ts
+++ b/tests/unit/List.ts
@@ -8,7 +8,7 @@ registerSuite('List', function () {
 		const list = new List<T>();
 
 		for (let i = 0; i < items.length; i++) {
-			list.add(items[ i ]);
+			list.add(items[i]);
 		}
 
 		return list;

--- a/tests/unit/List.ts
+++ b/tests/unit/List.ts
@@ -1,15 +1,15 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import List from '../../src/List';
 import Set from '@dojo/shim/Set';
+import List from '../../src/List';
 
 registerSuite('List', function () {
 	function listWith<T>(...items: T[]): List<T> {
 		const list = new List<T>();
 
-		items.forEach(item => {
-			list.add(item);
-		});
+		for (let i = 0; i < items.length; i++) {
+			list.add(items[ i ]);
+		}
 
 		return list;
 	}

--- a/tests/unit/List.ts
+++ b/tests/unit/List.ts
@@ -7,9 +7,9 @@ registerSuite('List', function () {
 	function listWith<T>(...items: T[]): List<T> {
 		const list = new List<T>();
 
-		for (let item of items) {
+		items.forEach(item => {
 			list.add(item);
-		}
+		});
 
 		return list;
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
 		"strictNullChecks": true,
 		"target": "es5",
 		"types": [ "intern" ],
-		"noEmitHelpers": true,
+		"importHelpers": true,
 		"downlevelIteration": true
 	},
 	"include": [


### PR DESCRIPTION
Using `importHelpers` instead of `noEmitHelpers`. Helpers will be provided by `tslib` but augmented by `@dojo/shim/main`.