### PR TITLE
Update intern.json so it can be used with both grunt and intern commands

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -1,5 +1,5 @@
 {
-	"capabilities": {
+	"capabilities+": {
 		"project": "Dojo 2",
 		"name": "@dojo/core",
 		"fixSessionCapabilities": false,
@@ -23,6 +23,7 @@
 	],
 
 	"browser": {
+		"loader": "./node_modules/grunt-dojo2/lib/intern/internLoader.js",
 		"suites+": [
 			"./_build/tests/unit/all-browser.js"
 		]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/multer": "~1.3.3",
+    "@types/node": "^6.0.0",
     "@types/sinon": "~1.16.0",
     "benchmark": "^1.0.0",
     "grunt": "^1.0.1",


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates `intern.json` so that using both `./node_modules/.bin/intern` and `grunt intern` will properly load the `@dojo/shim` patches for `tslib`.