### PR TITLE
Move compare from dojo/test-extras to dojo/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/core",
-  "version": "0.3.1-pre",
+  "version": "0.3.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -6,9 +6,17 @@ import Set from '@dojo/shim/Set';
 const objectCreate = Object.create;
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 const defineProperty = Object.defineProperty;
-const isArray = Array.isArray;
 const isFrozen = Object.isFrozen;
 const isSealed = Object.isSealed;
+
+function isArray(item: any) {
+	return Array.isArray(item) || isTypedArray(item);
+
+}
+
+function isTypedArray(item: any) {
+	return item != null && item.buffer instanceof ArrayBuffer && item.BYTES_PER_ELEMENT;
+}
 
 export type IgnorePropertyFunction = (name: string, a: any, b: any) => boolean;
 

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,5 +1,4 @@
-import { assign } from '@dojo/shim/object';
-import { keys } from '@dojo/shim/object';
+import { assign, keys } from '@dojo/shim/object';
 import Set from '@dojo/shim/Set';
 
 /* Assigning to local variables to improve minification and readability */
@@ -104,36 +103,36 @@ export interface ConstructRecord extends AnonymousConstructRecord {
  * like another
  */
 export type PatchRecord = {
-		/**
-		 * The name of the property on the Object
-		 */
-		name: string;
+	/**
+	 * The name of the property on the Object
+	 */
+	name: string;
 
-		/**
-		 * The type of the patch
-		 */
-		type: 'delete';
-	} | {
-		/**
-		 * A property descriptor that describes the property in `name`
-		 */
-		descriptor: PropertyDescriptor;
+	/**
+	 * The type of the patch
+	 */
+	type: 'delete';
+} | {
+	/**
+	 * A property descriptor that describes the property in `name`
+	 */
+	descriptor: PropertyDescriptor;
 
-		/**
-		 * The name of the property on the Object
-		 */
-		name: string;
+	/**
+	 * The name of the property on the Object
+	 */
+	name: string;
 
-		/**
-		 * The type of the patch
-		 */
-		type: 'add' | 'update';
+	/**
+	 * The type of the patch
+	 */
+	type: 'add' | 'update';
 
-		/**
-		 * Additional patch records which describe the value of the property
-		 */
-		valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[];
-	};
+	/**
+	 * Additional patch records which describe the value of the property
+	 */
+	valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[];
+};
 
 /**
  * The different types of patch records supported
@@ -376,7 +375,7 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
  * describe the differences
  *
  * @param a The first plain object to compare to
- * @param b The second plain bject to compare to
+ * @param b The second plain object to compare to
  * @param options An options bag that allows configuration of the behaviour of `diffPlainObject()`
  */
 function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord | PatchRecord)[] {
@@ -391,29 +390,16 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 		const bHasOwnProperty = hasOwnProperty.call(comparableB, name);
 
 		if (bHasOwnProperty && (valueA === valueB ||
-			(allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))) { /* not different */
-				/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
-				return patchRecords;
+				(allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))) { /* not different */
+			/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
+			return patchRecords;
 		}
 
 		const type = bHasOwnProperty ? 'update' : 'add';
 
 		const isValueAArray = isArray(valueA);
 		const isValueAPlainObject = isPlainObject(valueA);
-
-		if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
-			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
-			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
-			* the valueA with that */
-			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
-				valueB : isValueAArray ?
-					[] : objectCreate(null);
-			const valueRecords = diff(valueA, value, options);
-			if (valueRecords.length) { /* only add if there are changes */
-				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
-			}
-		}
-		else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
+		if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
 			const result = valueA.diff(valueB, name, b);
 			if (result) {
 				patchRecords.push(result);
@@ -425,10 +411,22 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 				patchRecords.push(result);
 			}
 		}
+		else if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
+			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
+			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
+			* the valueA with that */
+			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
+				valueB : isValueAArray ?
+					[] : objectCreate(null);
+			const valueRecords = diff(valueA, value, options);
+			if (valueRecords.length) { /* only add if there are changes */
+				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
+			}
+		}
 		else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') ||
 			isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
-				/* primitive values, functions values if allowed, or ignored property values can just be copied */
-				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(valueA)));
+			/* primitive values, functions values if allowed, or ignored property values can just be copied */
+			patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(valueA)));
 		}
 		else {
 			throw new TypeError(`Value of property named "${name}" from first argument is not a primative, plain Object, or Array.`);
@@ -468,8 +466,8 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 	const comparableA = keys(a).reduce((obj, name) => {
 		if (isIgnoredProperty(name) ||
 			hasOwnProperty.call(b, name) && isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
-				ignore.add(name);
-				return obj;
+			ignore.add(name);
+			return obj;
 		}
 
 		keep.add(name);
@@ -487,6 +485,14 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 	}, {} as { [key: string]: any });
 
 	return { comparableA, comparableB, ignore };
+}
+
+/**
+ * A guard that determines if the value is a `CustomDiff`
+ * @param value The value to check
+ */
+export function isCustomDiff<T>(value: any): value is CustomDiff<T> {
+	return typeof value === 'object' && value instanceof CustomDiff;
 }
 
 /**
@@ -548,14 +554,6 @@ function isPrimitive(value: any): value is (string | number | boolean | undefine
 		typeofValue === 'string' ||
 		typeofValue === 'number' ||
 		typeofValue === 'boolean';
-}
-
-/**
- * A guard that determines if the value is a `CustomDiff`
- * @param value The value to check
- */
-function isCustomDiff<T>(value: any): value is CustomDiff<T> {
-	return typeof value === 'object' && value instanceof CustomDiff;
 }
 
 /**
@@ -635,7 +633,7 @@ function resolveTargetValue(patchValue: any, targetValue: any): any {
 			patchIsSpliceRecordArray ?
 				isArray(targetValue) ?
 					targetValue : [] : isPlainObject(targetValue) ?
-						targetValue : objectCreate(null),
+				targetValue : objectCreate(null),
 			patchValue
 		) :
 		patchValue;

--- a/tests/unit/compare.ts
+++ b/tests/unit/compare.ts
@@ -1198,6 +1198,63 @@ registerSuite('compare', {
 			assert.throws(() => {
 				diff({}, foo);
 			}, TypeError, 'Arguments are not plain Objects or Arrays.');
+		},
+
+		'typed arrays': {
+			'matching': {
+				'integers'() {
+					const patchRecords = diff(new Int8Array([1, 2, 3]), new Int8Array([1, 2, 3]));
+
+					assert.deepEqual(patchRecords, [ ]);
+				},
+
+				'arrays of typed arrays'() {
+					const array1 = [ new Int8Array([1, 2, 3]), new Int8Array([1, 2, 3]) ];
+					const array2 = [ new Int8Array([1, 2, 3]), new Int8Array([1, 2, 3]) ];
+					const patchRecords = diff(array1, array2);
+
+					assert.deepEqual(patchRecords, [ ]);
+				}
+			},
+
+			'not matching': {
+				'integers'() {
+					const patchRecords = diff(new Int8Array([1, 5, 3]), new Int8Array([1, 2, 3]));
+
+					assert.deepEqual(patchRecords, [
+						{
+							add: [ 5 ],
+							deleteCount: 1,
+							start: 1,
+							type: 'splice'
+						}
+					]);
+				},
+
+				'arrays of typed arrays'() {
+					const array1 = [ new Int8Array([1, 2, 3]), new Int8Array([1, 2, 5]) ];
+					const array2 = [ new Int8Array([1, 2, 3]), new Int8Array([1, 2, 3]) ];
+					const patchRecords = diff(array1, array2);
+
+					assert.deepEqual(patchRecords, [
+						{
+							add: [
+								[
+									{
+										add: [ 5 ],
+										deleteCount: 1,
+										start: 2,
+										type: 'splice'
+									}
+								]
+							],
+							deleteCount: 1,
+							start: 1,
+							type: 'splice'
+						}
+					]);
+				}
+			}
 		}
 	},
 

--- a/tests/unit/compare.ts
+++ b/tests/unit/compare.ts
@@ -1214,6 +1214,18 @@ registerSuite('compare', {
 					const patchRecords = diff(array1, array2);
 
 					assert.deepEqual(patchRecords, [ ]);
+				},
+
+				'object with typed array'() {
+					const patchRecords = diff({
+						name: 'foo',
+						values: new Int8Array([1, 2, 3])
+					}, {
+						name: 'foo',
+						values: new Int8Array([1, 2, 3])
+					});
+
+					assert.deepEqual(patchRecords, [ ]);
 				}
 			},
 
@@ -1253,6 +1265,38 @@ registerSuite('compare', {
 							type: 'splice'
 						}
 					]);
+				},
+
+				'object with typed array'() {
+					const patchRecords = diff({
+						name: 'foo',
+						values: new Int8Array([1, 2, 3])
+					}, {
+						name: 'foo',
+						values: new Int8Array([1, 2, 5])
+					});
+
+					assert.deepEqual(patchRecords, [
+							{
+								type: 'update',
+								name: 'values',
+								descriptor: {
+									value: [ 1, 2, 5 ],
+									writable: true,
+									enumerable: true,
+									configurable: true
+								},
+								valueRecords: [
+									{
+										add: [ 3 ],
+										start: 2,
+										deleteCount: 1,
+										type: 'splice'
+									}
+								]
+							}
+						]
+					);
 				}
 			}
 		}


### PR DESCRIPTION
dojo/test-extras/compare and dojo/core/compare where nearly identical.  I copied the more recent updates to dojo/test-extras/compare into dojo/compare.  Then I updated dojo/compare to support typed array.

Resolves dojo/test-extras#75.
