### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -101,7 +101,17 @@ The `@dojo/core/async/Task` class is an extension of `@dojo/core/Promise` that p
 ## How Do I Contribute?
 
 We appreciate your interest! Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme)
-for the Contributing Guidelines and Style Guide.
+for the Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2140,9 +2140,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
-      "integrity": "sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
       "dev": true,
       "requires": {
         "fast-diff": "1.1.2",
@@ -2888,6 +2888,12 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2902,11 +2908,34 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -3039,9 +3068,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -7852,9 +7881,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7863,9 +7892,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7887,6 +7917,15 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
       }
     },
@@ -7896,7 +7935,7 @@
       "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
       "dev": true,
       "requires": {
-        "eslint-plugin-prettier": "2.3.1",
+        "eslint-plugin-prettier": "2.4.0",
         "tslib": "1.8.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7881,23 +7881,50 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
-      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "diff": "3.4.0",
-        "findup-sync": "0.3.0",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "1.9.1"
+        "tsutils": "2.13.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -7918,6 +7945,12 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "resolve": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -7925,6 +7958,24 @@
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.8.1"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -423,6 +423,12 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -435,6 +441,12 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -444,12 +456,18 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-field": {
       "version": "0.1.0",
@@ -487,7 +505,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-differ": {
@@ -589,7 +607,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -959,7 +977,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "electron-to-chromium": "1.3.28"
       }
     },
@@ -1045,15 +1063,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1138,6 +1156,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1152,6 +1176,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1308,7 +1379,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1323,7 +1394,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1383,6 +1454,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1612,6 +1722,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1715,6 +1831,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1910,6 +2032,12 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1983,6 +2111,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
+      "integrity": "sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -2031,6 +2169,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2121,6 +2265,12 @@
         "time-stamp": "1.1.0"
       }
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2149,6 +2299,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2196,6 +2356,12 @@
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2373,6 +2539,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -3021,7 +3193,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html-comment-regex": {
@@ -3080,6 +3252,31 @@
         "agent-base": "2.1.1",
         "debug": "2.6.9",
         "extend": "3.0.1"
+      }
+    },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
@@ -3395,6 +3592,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3480,6 +3692,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3507,10 +3728,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3750,6 +3983,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -3852,6 +4146,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3871,11 +4171,241 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4061,6 +4591,62 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
     "lolex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -4101,7 +4687,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -4271,7 +4857,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -4376,7 +4962,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -4412,6 +4998,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4419,6 +5014,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4497,6 +5111,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4535,6 +5155,18 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -4628,6 +5260,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -5933,6 +6571,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6018,7 +6689,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -6409,6 +7080,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6426,6 +7103,16 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -6464,10 +7151,27 @@
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "samsam": {
@@ -6479,7 +7183,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "seek-bzip": {
@@ -6494,7 +7198,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "semver-diff": {
@@ -6619,6 +7323,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6692,6 +7402,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -6705,6 +7421,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "streamsearch": {
@@ -6734,7 +7459,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -6763,6 +7488,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6851,6 +7587,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -6950,7 +7692,7 @@
     "throat": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+      "integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY=",
       "dev": true
     },
     "through": {
@@ -7106,7 +7848,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7117,6 +7859,16 @@
             "path-is-absolute": "1.0.1"
           }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.3.1",
+        "tslib": "1.8.0"
       }
     },
     "tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -54,7 +54,7 @@
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -69,7 +69,7 @@
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
@@ -91,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -106,13 +106,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -132,7 +138,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/fs-extra": {
@@ -141,17 +147,18 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "6.0.94"
       }
     },
     "@types/grunt": {
@@ -160,7 +167,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/handlebars": {
@@ -240,9 +247,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -264,9 +271,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/multer": {
@@ -279,9 +286,9 @@
       }
     },
     "@types/node": {
-      "version": "6.0.92",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+      "version": "6.0.94",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.94.tgz",
+      "integrity": "sha512-CwopBfOTONzc1bDDTh8/KzW+zssiIPw+nSf27Y1cuGIkZJ7zuhkig6xO5p9pBW/RY99DznOMCIj+FXx8EIy+qw==",
       "dev": true
     },
     "@types/platform": {
@@ -296,7 +303,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/serve-static": {
@@ -321,7 +328,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/sinon": {
@@ -348,13 +355,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.94"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abbrev": {
@@ -429,6 +436,15 @@
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -439,6 +455,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "any-observable": {
@@ -456,7 +478,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -505,7 +527,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-differ": {
@@ -671,14 +693,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -1323,6 +1345,12 @@
         "color-name": "1.1.3"
       }
     },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
@@ -1379,7 +1407,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1394,7 +1422,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -2256,12 +2284,13 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
     },
@@ -3035,7 +3064,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3193,7 +3222,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-comment-regex": {
@@ -3365,7 +3394,7 @@
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3376,7 +3405,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3406,7 +3435,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -4687,7 +4716,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -4857,7 +4886,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -4962,7 +4991,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -6689,7 +6718,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -6923,9 +6952,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -7171,7 +7200,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "samsam": {
@@ -7183,7 +7212,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "seek-bzip": {
@@ -7198,7 +7227,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "semver-diff": {
@@ -7459,7 +7488,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -7692,7 +7721,7 @@
     "throat": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY=",
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
       "dev": true
     },
     "through": {
@@ -7817,9 +7846,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
@@ -7848,7 +7877,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7868,7 +7897,7 @@
       "dev": true,
       "requires": {
         "eslint-plugin-prettier": "2.3.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -9064,7 +9093,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "peerDependencies": {
@@ -41,18 +43,35 @@
     "grunt": "^1.0.1",
     "grunt-contrib-clean": ">=1.0.0",
     "grunt-contrib-copy": ">=1.0.0",
+    "grunt-dojo2": "latest",
     "grunt-postcss": "^0.8.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
     "grunt-tslint": "^4.0.1",
     "grunt-typings": "^0.1.5",
-    "grunt-dojo2": "latest",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "multer": "~1.3.0",
+    "prettier": "1.9.2",
     "remap-istanbul": ">=0.6.3",
     "sinon": "~1.17.6",
     "tslib": "~1.8.0",
-    "tslint": "^4.5.1",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "remap-istanbul": ">=0.6.3",
     "sinon": "~1.17.6",
     "tslib": "~1.8.0",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-postcss": "^0.8.0",
     "grunt-text-replace": ">=0.4.0",
     "grunt-ts": ">=5.0.0",
-    "grunt-tslint": "^4.0.1",
+    "grunt-tslint": "5.0.1",
     "grunt-typings": "^0.1.5",
     "husky": "0.14.3",
     "intern": "~4.1.0",
@@ -57,6 +57,7 @@
     "remap-istanbul": ">=0.6.3",
     "sinon": "~1.17.6",
     "tslib": "~1.8.0",
+    "tslint": "5.2.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/src/DateObject.ts
+++ b/src/DateObject.ts
@@ -36,9 +36,9 @@ export interface DateProperties {
 	year: number;
 }
 
-const days = [ NaN, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 ];
+const days = [NaN, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
-const isLeapYear = (function () {
+const isLeapYear = (function() {
 	const date = new Date();
 	function isLeapYear(year: number): boolean {
 		date.setFullYear(year, 1, 29);
@@ -47,7 +47,7 @@ const isLeapYear = (function () {
 	return isLeapYear;
 })();
 
-const operationOrder = [ 'years', 'months', 'days', 'hours', 'minutes', 'seconds', 'milliseconds' ];
+const operationOrder = ['years', 'months', 'days', 'hours', 'minutes', 'seconds', 'milliseconds'];
 const operationHash: Hash<string> = Object.create(null, {
 	days: { value: 'Date' },
 	hours: { value: 'UTCHours' },
@@ -79,14 +79,11 @@ export default class DateObject implements DateProperties {
 		let _date: Date;
 		if (!arguments.length) {
 			_date = new Date();
-		}
-		else if (value instanceof Date) {
+		} else if (value instanceof Date) {
 			_date = new Date(+value);
-		}
-		else if (typeof value === 'number' || typeof value === 'string') {
-			_date = new Date(<any> value);
-		}
-		else {
+		} else if (typeof value === 'number' || typeof value === 'string') {
+			_date = new Date(<any>value);
+		} else {
 			_date = new Date(
 				value.year,
 				value.month - 1,
@@ -173,7 +170,7 @@ export default class DateObject implements DateProperties {
 					return self._date.getUTCDay();
 				},
 
-				toString: function (): string {
+				toString: function(): string {
 					return self._date.toUTCString();
 				}
 			},
@@ -276,8 +273,7 @@ export default class DateObject implements DateProperties {
 
 		if (typeof value === 'number') {
 			result.time += value;
-		}
-		else {
+		} else {
 			// Properties have to be added in a particular order to properly handle
 			// date overshoots in month and year calculations
 			operationOrder.forEach((property: string): void => {
@@ -286,12 +282,9 @@ export default class DateObject implements DateProperties {
 				}
 
 				const dateMethod = operationHash[property];
-				(<any> result._date)[`set${dateMethod}`](
-					(<any> this._date)[`get${dateMethod}`]() + value[property]
-				);
+				(<any>result._date)[`set${dateMethod}`]((<any>this._date)[`get${dateMethod}`]() + value[property]);
 
-				if ((property === 'years' || property === 'months') &&
-					result.dayOfMonth < this.dayOfMonth) {
+				if ((property === 'years' || property === 'months') && result.dayOfMonth < this.dayOfMonth) {
 					// Set the day of the month to 0 to move the date to the first day of the previous
 					// month to fix overshoots when adding a month and the date is the 31st or adding
 					// a year and the date is the 29th

--- a/src/Evented.ts
+++ b/src/Evented.ts
@@ -32,13 +32,11 @@ export function isGlobMatch(globString: string | symbol, targetString: string | 
 		let regex: RegExp;
 		if (regexMap.has(globString)) {
 			regex = regexMap.get(globString)!;
-		}
-		else {
-			regex = new RegExp(`^${ globString.replace(/\*/g, '.*') }$`);
+		} else {
+			regex = new RegExp(`^${globString.replace(/\*/g, '.*')}$`);
 			regexMap.set(globString, regex);
 		}
 		return regex.test(targetString);
-
 	} else {
 		return globString === targetString;
 	}
@@ -59,13 +57,14 @@ export type EventedCallback<T = EventType, E extends EventObject<T> = EventObjec
  * @template T The type of target for the events
  * @template E The event type for the events
  */
-export type EventedCallbackOrArray<T = EventType, E extends EventObject<T> = EventObject<T>> = EventedCallback<T, E> | EventedCallback<T, E>[];
+export type EventedCallbackOrArray<T = EventType, E extends EventObject<T> = EventObject<T>> =
+	| EventedCallback<T, E>
+	| EventedCallback<T, E>[];
 
 /**
  * Event Class
  */
 export class Evented<M extends {} = {}, T = EventType, O extends EventObject<T> = EventObject<T>> extends Destroyable {
-
 	// The following member is purely so TypeScript remembers the type of `M` when extending so
 	// that the utilities in `on.ts` will work
 	// https://github.com/Microsoft/TypeScript/issues/20348
@@ -117,8 +116,7 @@ export class Evented<M extends {} = {}, T = EventType, O extends EventObject<T> 
 		if (Array.isArray(listener)) {
 			const handles = listener.map((listener) => aspectOn(this.listenersMap, type, listener));
 			return handlesArraytoHandle(handles);
-		}
-		else {
+		} else {
 			return aspectOn(this.listenersMap, type, listener);
 		}
 	}

--- a/src/IdentityRegistry.ts
+++ b/src/IdentityRegistry.ts
@@ -5,7 +5,7 @@ import { Handle } from './interfaces';
 import '@dojo/shim/Symbol';
 import List from './List';
 
-const noop = () => { };
+const noop = () => {};
 
 interface Entry<V> {
 	readonly handle: Handle;
@@ -175,4 +175,4 @@ export default class IdentityRegistry<V extends object> implements Iterable<[Ide
 	[Symbol.iterator](): IterableIterator<[Identity, V]> {
 		return this.entries();
 	}
-};
+}

--- a/src/List.ts
+++ b/src/List.ts
@@ -24,8 +24,7 @@ export default class List<T> {
 				for (let i = 0; i < source.length; i++) {
 					this.add(source[i]);
 				}
-			}
-			else if (isIterable(source)) {
+			} else if (isIterable(source)) {
 				for (const item of source) {
 					this.add(item);
 				}
@@ -52,7 +51,7 @@ export default class List<T> {
 	}
 
 	entries(): IterableIterator<[number, T]> {
-		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [ index, value ]));
+		return new ShimIterator<[number, T]>(getListItems(this).map<[number, T]>((value, index) => [index, value]));
 	}
 
 	forEach(fn: (value: T, idx: number, list: this) => void, thisArg?: any): void {
@@ -92,8 +91,9 @@ export default class List<T> {
 	}
 
 	splice(start: number, deleteCount?: number, ...newItems: T[]): T[] {
-		return getListItems(this).splice(start,
-			deleteCount === undefined ? (this.size - start) : deleteCount,
+		return getListItems(this).splice(
+			start,
+			deleteCount === undefined ? this.size - start : deleteCount,
 			...newItems
 		);
 	}

--- a/src/MatchRegistry.ts
+++ b/src/MatchRegistry.ts
@@ -62,11 +62,11 @@ export default class MatchRegistry<T> {
 			value: value
 		};
 
-		(<any> entries)[(first ? 'unshift' : 'push')](entry);
+		(<any>entries)[first ? 'unshift' : 'push'](entry);
 
 		return {
-			destroy: function (this: Handle) {
-				this.destroy = function (): void {};
+			destroy: function(this: Handle) {
+				this.destroy = function(): void {};
 				let i = 0;
 				if (entries && entry) {
 					while ((i = entries.indexOf(entry, i)) > -1) {

--- a/src/MultiMap.ts
+++ b/src/MultiMap.ts
@@ -26,8 +26,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 					const value = iterable[i];
 					this.set(value[0], value[1]);
 				}
-			}
-			else if (isIterable(iterable)) {
+			} else if (isIterable(iterable)) {
 				for (const value of iterable) {
 					this.set(value[0], value[1]);
 				}
@@ -55,7 +54,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 			childMap = new Map<any, any>();
 			map.set(keys[i], childMap);
 			map = childMap;
-		};
+		}
 
 		map.set(this._key, value);
 		return this;
@@ -77,7 +76,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 			if (!map) {
 				return undefined;
 			}
-		};
+		}
 
 		return map.get(this._key);
 	}
@@ -149,8 +148,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 			map.forEach((value, key) => {
 				if (key === this._key) {
 					values.push(value);
-				}
-				else {
+				} else {
 					getValues(value);
 				}
 			});
@@ -172,8 +170,7 @@ export default class MultiMap<T> implements Map<any[], T> {
 			map.forEach((value, key) => {
 				if (key === this._key) {
 					finalKeys.push(keys);
-				}
-				else {
+				} else {
 					const nextKeys = [...keys, key];
 					getKeys(value, nextKeys);
 				}
@@ -190,14 +187,13 @@ export default class MultiMap<T> implements Map<any[], T> {
 	 * @return An iterator for each key/value pair in the instance.
 	 */
 	entries(): IterableIterator<[any[], T]> {
-		const finalEntries: [ any[], T ][] = [];
+		const finalEntries: [any[], T][] = [];
 
 		const getKeys = (map: Map<any, any>, keys: any[] = []) => {
 			map.forEach((value, key) => {
 				if (key === this._key) {
-					finalEntries.push([ keys, value ]);
-				}
-				else {
+					finalEntries.push([keys, value]);
+				} else {
 					const nextKeys = [...keys, key];
 					getKeys(value, nextKeys);
 				}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -7,32 +7,30 @@ function isSubscribable(object: any): object is Subscribable<any> {
 }
 
 export default class Observable<T> extends ObservableShim<T> {
-
 	static of<T>(...items: T[]): Observable<T> {
-		return <Observable<T>> super.of(...items);
+		return <Observable<T>>super.of(...items);
 	}
 
 	static from<T>(item: Iterable<T> | ArrayLike<T> | ObservableObject): Observable<T> {
-		return <Observable<T>> super.from(item);
+		return <Observable<T>>super.from(item);
 	}
 
 	static defer<T>(deferFunction: () => Subscribable<T>): Observable<T> {
-		return new Observable<T>(observer => {
-				const trueObservable = deferFunction();
+		return new Observable<T>((observer) => {
+			const trueObservable = deferFunction();
 
-				return trueObservable.subscribe({
-					next(value: T) {
-						return observer.next(value);
-					},
-					error(errorValue ?: any) {
-						return observer.error(errorValue);
-					},
-					complete(completeValue ?: any) {
-						observer.complete(completeValue);
-					}
-				});
-			}
-		);
+			return trueObservable.subscribe({
+				next(value: T) {
+					return observer.next(value);
+				},
+				error(errorValue?: any) {
+					return observer.error(errorValue);
+				},
+				complete(completeValue?: any) {
+					observer.complete(completeValue);
+				}
+			});
+		});
 	}
 
 	toPromise(): Promise<T> {
@@ -61,8 +59,7 @@ export default class Observable<T> extends ObservableShim<T> {
 					try {
 						const result: U = mapFunction(value);
 						return observer.next(result);
-					}
-					catch (e) {
+					} catch (e) {
 						return observer.error(e);
 					}
 				},
@@ -90,8 +87,7 @@ export default class Observable<T> extends ObservableShim<T> {
 						if (filterFunction(value)) {
 							return observer.next(value);
 						}
-					}
-					catch (e) {
+					} catch (e) {
 						return observer.error(e);
 					}
 				},
@@ -108,7 +104,7 @@ export default class Observable<T> extends ObservableShim<T> {
 	toArray(): Observable<T[]> {
 		const self = this;
 
-		return new Observable<T[]>(observer => {
+		return new Observable<T[]>((observer) => {
 			const values: T[] = [];
 
 			self.subscribe({
@@ -136,8 +132,7 @@ export default class Observable<T> extends ObservableShim<T> {
 			function checkForComplete() {
 				if (active.length === 0 && queue.length === 0) {
 					observer.complete();
-				}
-				else if (queue.length > 0 && active.length < concurrent) {
+				} else if (queue.length > 0 && active.length < concurrent) {
 					const item = queue.shift();
 
 					if (isSubscribable(item)) {
@@ -153,8 +148,7 @@ export default class Observable<T> extends ObservableShim<T> {
 								checkForComplete();
 							}
 						});
-					}
-					else {
+					} else {
 						observer.next(item);
 						checkForComplete();
 					}
@@ -174,8 +168,4 @@ export default class Observable<T> extends ObservableShim<T> {
 }
 
 // for convienence, re-export some interfaces from shim
-export {
-	Observable,
-	Subscribable,
-	SubscriptionObserver as Observer
-}
+export { Observable, Subscribable, SubscriptionObserver as Observer };

--- a/src/QueuingEvented.ts
+++ b/src/QueuingEvented.ts
@@ -9,7 +9,11 @@ import Evented, { isGlobMatch, EventedCallbackOrArray } from './Evented';
  *
  * @property maxEvents  The number of events to queue before old events are discarded. If zero (default), an unlimited number of events is queued.
  */
-class QueuingEvented<M extends {} = {}, T = EventType, O extends EventObject<T> = EventObject<T>> extends Evented<M, T, O> {
+class QueuingEvented<M extends {} = {}, T = EventType, O extends EventObject<T> = EventObject<T>> extends Evented<
+	M,
+	T,
+	O
+> {
 	private _queue: Map<string | symbol, EventObject[]>;
 
 	maxEvents = 0;

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -3,8 +3,8 @@ import { QueueItem, queueTask } from './queue';
 
 function getQueueHandle(item: QueueItem): Handle {
 	return {
-		destroy: function (this: Handle) {
-			this.destroy = function () {};
+		destroy: function(this: Handle) {
+			this.destroy = function() {};
 			item.isActive = false;
 			item.callback = null;
 		}
@@ -60,7 +60,7 @@ export default class Scheduler {
 		const queue = this._queue;
 		let item: QueueItem | undefined;
 
-		while (item = queue.shift()) {
+		while ((item = queue.shift())) {
 			if (item.isActive && item.callback) {
 				item.callback();
 			}
@@ -73,7 +73,7 @@ export default class Scheduler {
 			this._deferred = null;
 
 			let item: QueueItem | undefined;
-			while (item = deferred.shift()) {
+			while ((item = deferred.shift())) {
 				this._schedule(item);
 			}
 		}
@@ -88,8 +88,8 @@ export default class Scheduler {
 	}
 
 	constructor(kwArgs?: KwArgs) {
-		this.deferWhileProcessing = (kwArgs && 'deferWhileProcessing' in kwArgs) ? kwArgs.deferWhileProcessing : true;
-		this.queueFunction = (kwArgs && kwArgs.queueFunction) ? kwArgs.queueFunction : queueTask;
+		this.deferWhileProcessing = kwArgs && 'deferWhileProcessing' in kwArgs ? kwArgs.deferWhileProcessing : true;
+		this.queueFunction = kwArgs && kwArgs.queueFunction ? kwArgs.queueFunction : queueTask;
 
 		this._boundDispatch = this._dispatch.bind(this);
 		this._isProcessing = false;

--- a/src/UrlSearchParams.ts
+++ b/src/UrlSearchParams.ts
@@ -22,8 +22,7 @@ function parseQueryString(input: string): ParamList {
 		if (indexOfFirstEquals >= 0) {
 			key = entry.slice(0, indexOfFirstEquals);
 			value = entry.slice(indexOfFirstEquals + 1);
-		}
-		else {
+		} else {
 			key = entry;
 		}
 
@@ -32,8 +31,7 @@ function parseQueryString(input: string): ParamList {
 
 		if (key in query) {
 			query[key].push(value);
-		}
-		else {
+		} else {
 			query[key] = [value];
 		}
 	}
@@ -53,30 +51,25 @@ export default class UrlSearchParams {
 
 		if (input instanceof UrlSearchParams) {
 			// Copy the incoming UrlSearchParam's internal list
-			list = <ParamList> duplicate(input._list);
-		}
-		else if (typeof input === 'object') {
+			list = <ParamList>duplicate(input._list);
+		} else if (typeof input === 'object') {
 			// Copy the incoming object, assuming its property values are either arrays or strings
 			list = {};
 			for (const key in input) {
-				const value = (<ParamList> input)[key];
+				const value = (<ParamList>input)[key];
 
 				if (Array.isArray(value)) {
-					list[key] = value.length ? value.slice() : [ '' ];
-				}
-				else if (value == null) {
-					list[key] = [ '' ];
-				}
-				else {
-					list[key] = [ <string> value ];
+					list[key] = value.length ? value.slice() : [''];
+				} else if (value == null) {
+					list[key] = [''];
+				} else {
+					list[key] = [<string>value];
 				}
 			}
-		}
-		else if (typeof input === 'string') {
+		} else if (typeof input === 'string') {
 			// Parse the incoming string as a query string
 			list = parseQueryString(input);
-		}
-		else {
+		} else {
 			list = {};
 		}
 
@@ -97,8 +90,7 @@ export default class UrlSearchParams {
 	append(key: string, value: string): void {
 		if (!this.has(key)) {
 			this.set(key, value);
-		}
-		else {
+		} else {
 			const values = this._list[key];
 			if (values) {
 				values.push(value);
@@ -172,7 +164,7 @@ export default class UrlSearchParams {
 	 * @param key The key to set the value of
 	 */
 	set(key: string, value: string): void {
-		this._list[key] = [ value ];
+		this._list[key] = [value];
 	}
 
 	/**
@@ -191,7 +183,7 @@ export default class UrlSearchParams {
 			if (values) {
 				const encodedKey = encodeURIComponent(key);
 				for (let i = 0; i < values.length; i++) {
-					query.push(encodedKey + (values[i] ? ('=' + encodeURIComponent(values[i])) : ''));
+					query.push(encodedKey + (values[i] ? '=' + encodeURIComponent(values[i]) : ''));
 				}
 			}
 		}

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -18,8 +18,7 @@ export function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 			const item = iterable[i];
 			unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
 		}
-	}
-	else {
+	} else {
 		for (const item of iterable) {
 			unwrapped.push(item instanceof ExtensiblePromise ? item._promise : item);
 		}
@@ -29,7 +28,7 @@ export function unwrapPromises(iterable: Iterable<any> | any[]): any[] {
 }
 
 export type DictionaryOfPromises<T> = { [_: string]: T | Promise<T> | Thenable<T> };
-export type ListOfPromises<T> = Iterable<(T | Thenable<T>)>;
+export type ListOfPromises<T> = Iterable<T | Thenable<T>>;
 
 /**
  * An extensible base to allow Promises to be extended in ES5. This class basically wraps a native Promise object,
@@ -138,13 +137,15 @@ export default class ExtensiblePromise<T> {
 	 * @param iterable    An iterable of values to resolve, or a key/value pair of values to resolve. These can be Promises, ExtensiblePromises, or other objects
 	 * @returns An extensible promise
 	 */
-	static all<T>(iterable: DictionaryOfPromises<T> | ListOfPromises<T>): ExtensiblePromise<T[] | { [key: string]: T }> {
+	static all<T>(
+		iterable: DictionaryOfPromises<T> | ListOfPromises<T>
+	): ExtensiblePromise<T[] | { [key: string]: T }> {
 		if (!isArrayLike(iterable) && !isIterable(iterable)) {
 			const promiseKeys = Object.keys(iterable);
 
 			return new this((resolve, reject) => {
-				Promise.all(promiseKeys.map(key => iterable[key])).then((promiseResults: T[]) => {
-					const returnValue: { [key: string]: T} = {};
+				Promise.all(promiseKeys.map((key) => iterable[key])).then((promiseResults: T[]) => {
+					const returnValue: { [key: string]: T } = {};
 
 					promiseResults.forEach((value: T, index: number) => {
 						returnValue[promiseKeys[index]] = value;
@@ -156,7 +157,7 @@ export default class ExtensiblePromise<T> {
 		}
 
 		return new this((resolve, reject) => {
-			Promise.all(unwrapPromises(<Iterable<T>> iterable)).then(resolve, reject);
+			Promise.all(unwrapPromises(<Iterable<T>>iterable)).then(resolve, reject);
 		});
 	}
 
@@ -166,7 +167,7 @@ export default class ExtensiblePromise<T> {
 	 * @param iterable    An iterable of values to resolve. These can be Promises, ExtensiblePromises, or other objects
 	 * @returns {ExtensiblePromise}
 	 */
-	static race<T>(iterable: Iterable<(T | PromiseLike<T>)> | (T | PromiseLike<T>)[]): ExtensiblePromise<T> {
+	static race<T>(iterable: Iterable<T | PromiseLike<T>> | (T | PromiseLike<T>)[]): ExtensiblePromise<T> {
 		return new this((resolve, reject) => {
 			Promise.race(unwrapPromises(iterable)).then(resolve, reject);
 		});
@@ -201,7 +202,9 @@ export default class ExtensiblePromise<T> {
 	 *
 	 * @returns {ExtensiblePromise}
 	 */
-	catch<TResult = never>(onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): ExtensiblePromise<T | TResult> {
+	catch<TResult = never>(
+		onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null
+	): ExtensiblePromise<T | TResult> {
 		return this.then(undefined, onRejected);
 	}
 
@@ -224,15 +227,12 @@ export default class ExtensiblePromise<T> {
 				if (typeof callback === 'function') {
 					try {
 						resolve(callback(valueOrError));
-					}
-					catch (error) {
+					} catch (error) {
 						reject(error);
 					}
-				}
-				else if (rejected) {
+				} else if (rejected) {
 					reject(valueOrError);
-				}
-				else {
+				} else {
 					resolve(valueOrError as TResult1);
 				}
 			}

--- a/src/async/iteration.ts
+++ b/src/async/iteration.ts
@@ -7,7 +7,7 @@ function isThenable<T>(value: any): value is Thenable<T> {
 	return value && typeof value.then === 'function';
 }
 
-type ValuesAndResults<T, U> = { values: T[] | undefined; results: U[] | undefined; };
+type ValuesAndResults<T, U> = { values: T[] | undefined; results: U[] | undefined };
 
 /**
  * Processes all items and then applies the callback to each item and eventually returns an object containing the
@@ -16,15 +16,16 @@ type ValuesAndResults<T, U> = { values: T[] | undefined; results: U[] | undefine
  * @param callback a callback that maps values to synchronous/asynchronous results
  * @return a list of objects holding the synchronous values and synchronous results.
  */
-function processValuesAndCallback<T, U>(items: Iterable<T | Promise<T>> | (T | Thenable<T>)[], callback: Mapper<T, U>): Promise<ValuesAndResults<T, U>> {
-	return Promise.all(items)
-		.then(function (results) {
-			const pass: (U | Promise<U>)[] = Array.prototype.map.call(results, callback);
-			return Promise.all(pass)
-				.then(function (pass) {
-					return { values: results, results: pass };
-				});
+function processValuesAndCallback<T, U>(
+	items: Iterable<T | Promise<T>> | (T | Thenable<T>)[],
+	callback: Mapper<T, U>
+): Promise<ValuesAndResults<T, U>> {
+	return Promise.all(items).then(function(results) {
+		const pass: (U | Promise<U>)[] = Array.prototype.map.call(results, callback);
+		return Promise.all(pass).then(function(pass) {
+			return { values: results, results: pass };
 		});
+	});
 }
 
 /**
@@ -53,69 +54,73 @@ function findLastValueIndex(list: ArrayLike<any>, offset?: number): number {
 	return -1;
 }
 
-function generalReduce<T, U>(findNextIndex: (list: ArrayLike<any>, offset?: number) => number, items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Reducer<T, U>, initialValue?: U): Promise<U> {
+function generalReduce<T, U>(
+	findNextIndex: (list: ArrayLike<any>, offset?: number) => number,
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Reducer<T, U>,
+	initialValue?: U
+): Promise<U> {
 	const hasInitialValue = arguments.length > 3;
-	return Promise.all(items)
-		.then(function (results) {
-			return new Promise<U>(function (resolve, reject) {
-				// As iterators do not have indices like `ArrayLike` objects, the results array
-				// is used to determine the next value.
-				const list = isArrayLike(items) ? items : results;
-				let i: number;
-				function next(currentValue: U | undefined): void {
-					i = findNextIndex(list, i);
-					if (i >= 0) {
-						if (results) {
-							if (currentValue) {
-								const result = callback(currentValue, results[i], i, results);
+	return Promise.all(items).then(function(results) {
+		return new Promise<U>(function(resolve, reject) {
+			// As iterators do not have indices like `ArrayLike` objects, the results array
+			// is used to determine the next value.
+			const list = isArrayLike(items) ? items : results;
+			let i: number;
+			function next(currentValue: U | undefined): void {
+				i = findNextIndex(list, i);
+				if (i >= 0) {
+					if (results) {
+						if (currentValue) {
+							const result = callback(currentValue, results[i], i, results);
 
-								if (isThenable(result)) {
-									result.then(next, reject);
-								}
-								else {
-									next(result);
-								}
+							if (isThenable(result)) {
+								result.then(next, reject);
+							} else {
+								next(result);
 							}
 						}
 					}
-					else {
-						resolve(currentValue);
-					}
+				} else {
+					resolve(currentValue);
 				}
+			}
 
-				let value: U | undefined;
-				if (hasInitialValue) {
-					value = initialValue;
-				}
-				else {
-					i = findNextIndex(list);
+			let value: U | undefined;
+			if (hasInitialValue) {
+				value = initialValue;
+			} else {
+				i = findNextIndex(list);
 
-					if (i < 0) {
-						throw new Error('reduce array with no initial value');
-					}
-					if (results) {
-						value = <any> results[i];
-					}
+				if (i < 0) {
+					throw new Error('reduce array with no initial value');
 				}
-				next(value);
-			});
+				if (results) {
+					value = <any>results[i];
+				}
+			}
+			next(value);
 		});
+	});
 }
 
-function testAndHaltOnCondition<T>(condition: boolean, items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Filterer<T>): Promise<boolean> {
-	return Promise.all(items).then(function (results) {
+function testAndHaltOnCondition<T>(
+	condition: boolean,
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Filterer<T>
+): Promise<boolean> {
+	return Promise.all(items).then(function(results) {
 		return new Promise<boolean>(function(resolve) {
-			let result: (boolean | Thenable<boolean>);
+			let result: boolean | Thenable<boolean>;
 			let pendingCount = 0;
 			if (results) {
 				for (let i = 0; i < results.length; i++) {
 					result = callback(results[i], i, results);
 					if (result === condition) {
 						return resolve(result);
-					}
-					else if (isThenable(result)) {
+					} else if (isThenable(result)) {
 						pendingCount++;
-						result.then(function (result) {
+						result.then(function(result) {
 							if (result === condition) {
 								resolve(result);
 							}
@@ -140,7 +145,10 @@ function testAndHaltOnCondition<T>(condition: boolean, items: Iterable<T | Promi
  * @param callback a synchronous/asynchronous test
  * @return eventually returns true if all values pass; otherwise false
  */
-export function every<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Filterer<T>): Promise<boolean> {
+export function every<T>(
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Filterer<T>
+): Promise<boolean> {
 	return testAndHaltOnCondition(false, items, callback);
 }
 
@@ -151,7 +159,7 @@ export function every<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], c
  * @return eventually returns a new array with only values that have passed
  */
 export function filter<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Filterer<T>): Promise<T[]> {
-	return processValuesAndCallback(items, callback).then(function (result) {
+	return processValuesAndCallback(items, callback).then(function(result) {
 		let arr: T[] = [];
 		if (result && result.results && result.values) {
 			for (let i = 0; i < result.results.length; i++) {
@@ -168,9 +176,12 @@ export function filter<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], 
  * @param callback a synchronous/asynchronous test
  * @return a promise eventually containing the item or undefined if a match is not found
  */
-export function find<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Filterer<T>): Promise<T | undefined> {
+export function find<T>(
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Filterer<T>
+): Promise<T | undefined> {
 	const list = isArrayLike(items) ? items : array.from(items);
-	return findIndex(list, callback).then<T | undefined>(function (i) {
+	return findIndex(list, callback).then<T | undefined>(function(i) {
 		return i !== undefined && i >= 0 ? list[i] : undefined;
 	});
 }
@@ -181,9 +192,12 @@ export function find<T>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], ca
  * @param callback a synchronous/asynchronous test
  * @return a promise eventually containing the index of the matching item or -1 if a match is not found
  */
-export function findIndex<T>(items: Iterable<T | Promise<T>> | (T | Thenable<T>)[], callback: Filterer<T>): Promise<number> {
+export function findIndex<T>(
+	items: Iterable<T | Promise<T>> | (T | Thenable<T>)[],
+	callback: Filterer<T>
+): Promise<number> {
 	// TODO we can improve this by returning immediately
-	return processValuesAndCallback(items, callback).then(function (result: ValuesAndResults<T, boolean>) {
+	return processValuesAndCallback(items, callback).then(function(result: ValuesAndResults<T, boolean>) {
 		if (result && result.results) {
 			for (let i = 0; i < result.results.length; i++) {
 				if (result.results[i]) {
@@ -201,11 +215,13 @@ export function findIndex<T>(items: Iterable<T | Promise<T>> | (T | Thenable<T>)
  * @param callback a synchronous/asynchronous transform function
  * @return a promise eventually containing a collection of each transformed value
  */
-export function map<T, U>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Mapper<T, U>): Promise<U[] | null | undefined> {
-	return processValuesAndCallback(items, callback)
-			.then(function (result) {
-				return result ? result.results : null;
-			});
+export function map<T, U>(
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Mapper<T, U>
+): Promise<U[] | null | undefined> {
+	return processValuesAndCallback(items, callback).then(function(result) {
+		return result ? result.results : null;
+	});
 }
 
 /**
@@ -215,44 +231,65 @@ export function map<T, U>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], 
  * @param [initialValue] the first value to pass to the callback
  * @return a promise eventually containing a value that is the result of the reduction
  */
-export function reduce<T, U>(this: any, items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Reducer<T, U>, initialValue?: U): Promise<U> {
-	const args: any[] = <any[]> array.from(arguments);
+export function reduce<T, U>(
+	this: any,
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Reducer<T, U>,
+	initialValue?: U
+): Promise<U> {
+	const args: any[] = <any[]>array.from(arguments);
 	args.unshift(findNextValueIndex);
 	return generalReduce.apply(this, args);
 }
 
-export function reduceRight<T, U>(this: any, items: Iterable<T | Promise<T>> | (T | Promise<T>)[], callback: Reducer<T, U>, initialValue?: U): Promise<U> {
-	const args: any[] = <any[]> array.from(arguments);
+export function reduceRight<T, U>(
+	this: any,
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	callback: Reducer<T, U>,
+	initialValue?: U
+): Promise<U> {
+	const args: any[] = <any[]>array.from(arguments);
 	args.unshift(findLastValueIndex);
 	return generalReduce.apply(this, args);
 }
 
-export function series<T, U>(items: Iterable<T | Promise<T>> | (T | Promise<T>)[], operation: Mapper<T, U>): Promise<U[]> {
-	return generalReduce(findNextValueIndex, items, function (previousValue, currentValue: T, index: number, array: T[]) {
-		const result = operation(currentValue, index, array);
+export function series<T, U>(
+	items: Iterable<T | Promise<T>> | (T | Promise<T>)[],
+	operation: Mapper<T, U>
+): Promise<U[]> {
+	return generalReduce(
+		findNextValueIndex,
+		items,
+		function(previousValue, currentValue: T, index: number, array: T[]) {
+			const result = operation(currentValue, index, array);
 
-		if (isThenable(result)) {
-			return result.then(function (value) {
-				previousValue.push(value);
-				return previousValue;
-			});
-		}
+			if (isThenable(result)) {
+				return result.then(function(value) {
+					previousValue.push(value);
+					return previousValue;
+				});
+			}
 
-		previousValue.push(result);
-		return previousValue;
-	}, [] as U[]);
+			previousValue.push(result);
+			return previousValue;
+		},
+		[] as U[]
+	);
 }
 
-export function some<T>(items: Iterable<T | Promise<T>> | Array<T | Promise<T>>, callback: Filterer<T>): Promise<boolean> {
+export function some<T>(
+	items: Iterable<T | Promise<T>> | Array<T | Promise<T>>,
+	callback: Filterer<T>
+): Promise<boolean> {
 	return testAndHaltOnCondition(true, items, callback);
 }
 
 export interface Filterer<T> extends Mapper<T, boolean> {}
 
 export interface Mapper<T, U> {
-	(value: T, index: number, array: T[]): (U | Thenable<U>);
+	(value: T, index: number, array: T[]): U | Thenable<U>;
 }
 
 export interface Reducer<T, U> {
-	(previousValue: U, currentValue: T, index: number, array: T[]): (U | Thenable<U>);
+	(previousValue: U, currentValue: T, index: number, array: T[]): U | Thenable<U>;
 }

--- a/src/async/timing.ts
+++ b/src/async/timing.ts
@@ -13,9 +13,9 @@ export interface Identity<T> {
  * @return {function (value: T | (() => T | Thenable<T>)): Promise<T>} a function producing a promise that eventually returns the value or executes the value function passed to it; usable with Thenable.then()
  */
 export function delay<T>(milliseconds: number): Identity<T> {
-	return function (value?: IdentityValue<T>): Promise<T> {
-		return new Promise(function (resolve) {
-			setTimeout(function () {
+	return function(value?: IdentityValue<T>): Promise<T> {
+		return new Promise(function(resolve) {
+			setTimeout(function() {
 				resolve(typeof value === 'function' ? value() : value);
 			}, milliseconds);
 		});
@@ -31,7 +31,7 @@ export function delay<T>(milliseconds: number): Identity<T> {
  */
 export function timeout<T>(milliseconds: number, reason: Error): Identity<T> {
 	const start = Date.now();
-	return function (value?: IdentityValue<T>): Promise<T> {
+	return function(value?: IdentityValue<T>): Promise<T> {
 		if (Date.now() - milliseconds > start) {
 			return Promise.reject<T>(reason);
 		}
@@ -52,10 +52,9 @@ export class DelayedRejection extends Promise<any> {
 	 * @param reason the reason for the rejection
 	 */
 	constructor(milliseconds: number, reason?: Error) {
-		super(() => {
-		});
+		super(() => {});
 
-		return new Promise(function (resolve, reject) {
+		return new Promise(function(resolve, reject) {
 			setTimeout(() => {
 				reject(reason);
 			}, milliseconds);

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -8,20 +8,35 @@ hasAdd('atob', 'atob' in global, true);
  * Take a string encoded in base64 and decode it
  * @param encodedString The base64 encoded string
  */
-export const decode: (encodedString: string) => string = has('atob') ? function (encodedString: string) {
-	/* this allows for utf8 characters to be decoded properly */
-	return decodeURIComponent(Array.prototype.map.call(atob(encodedString), (char: string) => '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2)).join(''));
-} : function (encodedString: string): string {
-	return new Buffer(encodedString.toString(), 'base64').toString('utf8');
-};
+export const decode: (encodedString: string) => string = has('atob')
+	? function(encodedString: string) {
+			/* this allows for utf8 characters to be decoded properly */
+			return decodeURIComponent(
+				Array.prototype.map
+					.call(
+						atob(encodedString),
+						(char: string) => '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2)
+					)
+					.join('')
+			);
+		}
+	: function(encodedString: string): string {
+			return new Buffer(encodedString.toString(), 'base64').toString('utf8');
+		};
 
 /**
  * Take a string and encode it to base64
  * @param rawString The string to encode
  */
-export const encode: (rawString: string) => string = has('btoa') ? function (decodedString: string) {
-	/* this allows for utf8 characters to be encoded properly */
-	return btoa(encodeURIComponent(decodedString).replace(/%([0-9A-F]{2})/g, (match, code: string) => String.fromCharCode(Number('0x' + code))));
-} : function (rawString: string): string {
-	return new Buffer(rawString.toString(), 'utf8').toString('base64');
-};
+export const encode: (rawString: string) => string = has('btoa')
+	? function(decodedString: string) {
+			/* this allows for utf8 characters to be encoded properly */
+			return btoa(
+				encodeURIComponent(decodedString).replace(/%([0-9A-F]{2})/g, (match, code: string) =>
+					String.fromCharCode(Number('0x' + code))
+				)
+			);
+		}
+	: function(rawString: string): string {
+			return new Buffer(rawString.toString(), 'utf8').toString('base64');
+		};

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -103,37 +103,39 @@ export interface ConstructRecord extends AnonymousConstructRecord {
  * A record that describes the mutations necessary to a property of an object to make that property look
  * like another
  */
-export type PatchRecord = {
-		/**
-		 * The name of the property on the Object
-		 */
-		name: string;
+export type PatchRecord =
+	| {
+			/**
+			 * The name of the property on the Object
+			 */
+			name: string;
 
-		/**
-		 * The type of the patch
-		 */
-		type: 'delete';
-	} | {
-		/**
-		 * A property descriptor that describes the property in `name`
-		 */
-		descriptor: PropertyDescriptor;
+			/**
+			 * The type of the patch
+			 */
+			type: 'delete';
+		}
+	| {
+			/**
+			 * A property descriptor that describes the property in `name`
+			 */
+			descriptor: PropertyDescriptor;
 
-		/**
-		 * The name of the property on the Object
-		 */
-		name: string;
+			/**
+			 * The name of the property on the Object
+			 */
+			name: string;
 
-		/**
-		 * The type of the patch
-		 */
-		type: 'add' | 'update';
+			/**
+			 * The type of the patch
+			 */
+			type: 'add' | 'update';
 
-		/**
-		 * Additional patch records which describe the value of the property
-		 */
-		valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[];
-	};
+			/**
+			 * Additional patch records which describe the value of the property
+			 */
+			valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[];
+		};
 
 /**
  * The different types of patch records supported
@@ -171,7 +173,11 @@ export interface SpliceRecord {
  * @param args Any arguments to be passed to the constructor function
  */
 /* tslint:disable:variable-name */
-export function createConstructRecord(Ctor: Constructor, args?: any[], descriptor?: ConstructDescriptor): AnonymousConstructRecord {
+export function createConstructRecord(
+	Ctor: Constructor,
+	args?: any[],
+	descriptor?: ConstructDescriptor
+): AnonymousConstructRecord {
 	const record: AnonymousConstructRecord = assign(objectCreate(null), { Ctor });
 	if (args) {
 		record.args = args;
@@ -191,7 +197,12 @@ export function createConstructRecord(Ctor: Constructor, args?: any[], descripto
  * @param descriptor The property descriptor to be installed on the object
  * @param valueRecords Any subsequenet patch recrds to be applied to the value of the descriptor
  */
-function createPatchRecord(type: PatchTypes, name: string, descriptor?: PropertyDescriptor, valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[]): PatchRecord {
+function createPatchRecord(
+	type: PatchTypes,
+	name: string,
+	descriptor?: PropertyDescriptor,
+	valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[]
+): PatchRecord {
 	const patchRecord = assign(objectCreate(null), {
 		type,
 		name
@@ -237,7 +248,12 @@ function createSpliceRecord(start: number, deleteCount: number, add?: any[]): Sp
  * @param enumerable Defaults to `true` if not specified
  * @param configurable Defaults to `true` if not specified
  */
-function createValuePropertyDescriptor(value: any, writable: boolean = true, enumerable: boolean = true, configurable: boolean = true): PropertyDescriptor {
+function createValuePropertyDescriptor(
+	value: any,
+	writable: boolean = true,
+	enumerable: boolean = true,
+	configurable: boolean = true
+): PropertyDescriptor {
 	return assign(objectCreate(null), {
 		value,
 		writable,
@@ -249,7 +265,11 @@ function createValuePropertyDescriptor(value: any, writable: boolean = true, enu
 /**
  * A function that returns a constructor record or `undefined` when diffing a value
  */
-export type CustomDiffFunction<T> = (value: T, nameOrIndex: string | number, parent: object) => AnonymousConstructRecord | void;
+export type CustomDiffFunction<T> = (
+	value: T,
+	nameOrIndex: string | number,
+	parent: object
+) => AnonymousConstructRecord | void;
 
 /**
  * A class which is used when making a custom comparison of a non-plain object or array
@@ -298,7 +318,8 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
 	const lengthB = arrayB.length;
 	const patchRecords: SpliceRecord[] = [];
 
-	if (!lengthA && lengthB) { /* empty array */
+	if (!lengthA && lengthB) {
+		/* empty array */
 		patchRecords.push(createSpliceRecord(0, lengthB));
 		return patchRecords;
 	}
@@ -310,12 +331,15 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
 
 	function flushSpliceRecord() {
 		if (deleteCount || add.length) {
-			patchRecords.push(createSpliceRecord(start, start + deleteCount > lengthB ? lengthB - start : deleteCount, add));
+			patchRecords.push(
+				createSpliceRecord(start, start + deleteCount > lengthB ? lengthB - start : deleteCount, add)
+			);
 		}
 	}
 
 	function addDifference(index: number, adding: boolean, value?: any) {
-		if (index > (last + 1)) { /* flush the splice */
+		if (index > last + 1) {
+			/* flush the splice */
 			flushSpliceRecord();
 			start = index;
 			deleteCount = 0;
@@ -334,7 +358,10 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
 	arrayA.forEach((valueA, index) => {
 		const valueB = arrayB[index];
 
-		if (index in arrayB && (valueA === valueB || (allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))) {
+		if (
+			index in arrayB &&
+			(valueA === valueB || (allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))
+		) {
 			return; /* not different */
 		}
 
@@ -342,20 +369,22 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
 		const isValueAPlainObject = isPlainObject(valueA);
 
 		if (isValueAArray || isValueAPlainObject) {
-			const value = isValueAArray ? isArray(valueB) ? valueB : [] : isPlainObject(valueB) ? valueB : Object.create(null);
+			const value = isValueAArray
+				? isArray(valueB) ? valueB : []
+				: isPlainObject(valueB) ? valueB : Object.create(null);
 			const valueRecords = diff(valueA, value, options);
-			if (valueRecords.length) { /* only add if there are changes */
+			if (valueRecords.length) {
+				/* only add if there are changes */
 				addDifference(index, true, diff(valueA, value, options));
 			}
-		}
-		else if (isPrimitive(valueA)) {
+		} else if (isPrimitive(valueA)) {
 			addDifference(index, true, valueA);
-		}
-		else if (allowFunctionValues && typeof valueA === 'function') {
+		} else if (allowFunctionValues && typeof valueA === 'function') {
 			addDifference(index, true, valueA);
-		}
-		else {
-			throw new TypeError(`Value of array element "${index}" from first argument is not a primative, plain Object, or Array.`);
+		} else {
+			throw new TypeError(
+				`Value of array element "${index}" from first argument is not a primative, plain Object, or Array.`
+			);
 		}
 	});
 
@@ -390,10 +419,13 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 		const valueB = b[name];
 		const bHasOwnProperty = hasOwnProperty.call(comparableB, name);
 
-		if (bHasOwnProperty && (valueA === valueB ||
-			(allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))) { /* not different */
-				/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
-				return patchRecords;
+		if (
+			bHasOwnProperty &&
+			(valueA === valueB || (allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))
+		) {
+			/* not different */
+			/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
+			return patchRecords;
 		}
 
 		const type = bHasOwnProperty ? 'update' : 'add';
@@ -401,37 +433,45 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 		const isValueAArray = isArray(valueA);
 		const isValueAPlainObject = isPlainObject(valueA);
 
-		if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
+		if (isValueAArray || isValueAPlainObject) {
+			/* non-primitive values we can diff */
 			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
 			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
 			* the valueA with that */
-			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
-				valueB : isValueAArray ?
-					[] : objectCreate(null);
+			const value =
+				(isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB))
+					? valueB
+					: isValueAArray ? [] : objectCreate(null);
 			const valueRecords = diff(valueA, value, options);
-			if (valueRecords.length) { /* only add if there are changes */
-				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
+			if (valueRecords.length) {
+				/* only add if there are changes */
+				patchRecords.push(
+					createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options))
+				);
 			}
-		}
-		else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
+		} else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) {
+			/* complex diff left hand */
 			const result = valueA.diff(valueB, name, b);
 			if (result) {
 				patchRecords.push(result);
 			}
-		}
-		else if (isCustomDiff(valueB)) { /* complex diff right hand */
+		} else if (isCustomDiff(valueB)) {
+			/* complex diff right hand */
 			const result = valueB.diff(valueA, name, a);
 			if (result) {
 				patchRecords.push(result);
 			}
-		}
-		else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') ||
-			isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
-				/* primitive values, functions values if allowed, or ignored property values can just be copied */
-				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(valueA)));
-		}
-		else {
-			throw new TypeError(`Value of property named "${name}" from first argument is not a primative, plain Object, or Array.`);
+		} else if (
+			isPrimitive(valueA) ||
+			(allowFunctionValues && typeof valueA === 'function') ||
+			isIgnoredPropertyValue(name, a, b, ignorePropertyValues)
+		) {
+			/* primitive values, functions values if allowed, or ignored property values can just be copied */
+			patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(valueA)));
+		} else {
+			throw new TypeError(
+				`Value of property named "${name}" from first argument is not a primative, plain Object, or Array.`
+			);
 		}
 		return patchRecords;
 	}, patchRecords);
@@ -461,30 +501,42 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 	const ignore = new Set<string>();
 	const keep = new Set<string>();
 
-	const isIgnoredProperty = Array.isArray(ignoreProperties) ? (name: string) => {
-		return ignoreProperties.some((value) => typeof value === 'string' ? name === value : value.test(name));
-	} : (name: string) => ignoreProperties(name, a, b);
+	const isIgnoredProperty = Array.isArray(ignoreProperties)
+		? (name: string) => {
+				return ignoreProperties.some(
+					(value) => (typeof value === 'string' ? name === value : value.test(name))
+				);
+			}
+		: (name: string) => ignoreProperties(name, a, b);
 
-	const comparableA = keys(a).reduce((obj, name) => {
-		if (isIgnoredProperty(name) ||
-			hasOwnProperty.call(b, name) && isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
+	const comparableA = keys(a).reduce(
+		(obj, name) => {
+			if (
+				isIgnoredProperty(name) ||
+				(hasOwnProperty.call(b, name) && isIgnoredPropertyValue(name, a, b, ignorePropertyValues))
+			) {
 				ignore.add(name);
 				return obj;
-		}
+			}
 
-		keep.add(name);
-		obj[name] = a[name];
-		return obj;
-	}, {} as { [key: string]: any });
-
-	const comparableB = keys(b).reduce((obj, name) => {
-		if (ignore.has(name) || !keep.has(name) && isIgnoredProperty(name)) {
+			keep.add(name);
+			obj[name] = a[name];
 			return obj;
-		}
+		},
+		{} as { [key: string]: any }
+	);
 
-		obj[name] = b[name];
-		return obj;
-	}, {} as { [key: string]: any });
+	const comparableB = keys(b).reduce(
+		(obj, name) => {
+			if (ignore.has(name) || (!keep.has(name) && isIgnoredProperty(name))) {
+				return obj;
+			}
+
+			obj[name] = b[name];
+			return obj;
+		},
+		{} as { [key: string]: any }
+	);
 
 	return { comparableA, comparableB, ignore };
 }
@@ -497,10 +549,17 @@ function isConstructRecord(value: any): value is ConstructRecord {
 	return Boolean(value && typeof value === 'object' && value !== null && value.Ctor && value.name);
 }
 
-function isIgnoredPropertyValue(name: string, a: any, b: any, ignoredPropertyValues: (string | RegExp)[] | IgnorePropertyFunction) {
-	return Array.isArray(ignoredPropertyValues) ? ignoredPropertyValues.some((value) => {
-		return typeof value === 'string' ? name === value : value.test(name);
-	}) : ignoredPropertyValues(name, a, b);
+function isIgnoredPropertyValue(
+	name: string,
+	a: any,
+	b: any,
+	ignoredPropertyValues: (string | RegExp)[] | IgnorePropertyFunction
+) {
+	return Array.isArray(ignoredPropertyValues)
+		? ignoredPropertyValues.some((value) => {
+				return typeof value === 'string' ? name === value : value.test(name);
+			})
+		: ignoredPropertyValues(name, a, b);
 }
 
 /**
@@ -529,9 +588,7 @@ function isPatchRecordArray(value: any): value is PatchRecord[] {
  */
 function isPlainObject(value: any): value is Object {
 	return Boolean(
-		value &&
-		typeof value === 'object' &&
-		(value.constructor === Object || value.constructor === undefined)
+		value && typeof value === 'object' && (value.constructor === Object || value.constructor === undefined)
 	);
 }
 
@@ -541,13 +598,15 @@ function isPlainObject(value: any): value is Object {
  *
  * @param value The value to check
  */
-function isPrimitive(value: any): value is (string | number | boolean | undefined | null) {
+function isPrimitive(value: any): value is string | number | boolean | undefined | null {
 	const typeofValue = typeof value;
-	return value === null ||
+	return (
+		value === null ||
 		typeofValue === 'undefined' ||
 		typeofValue === 'string' ||
 		typeofValue === 'number' ||
-		typeofValue === 'boolean';
+		typeofValue === 'boolean'
+	);
 }
 
 /**
@@ -584,8 +643,7 @@ function patchSplice(target: any[], { add, deleteCount, start }: SpliceRecord): 
 		const deletedItems = deleteCount ? target.slice(start, start + deleteCount) : [];
 		add = add.map((value, index) => resolveTargetValue(value, deletedItems[index]));
 		target.splice(start, deleteCount, ...add);
-	}
-	else {
+	} else {
 		target.splice(start, deleteCount);
 	}
 	return target;
@@ -618,7 +676,9 @@ function patchConstruct(target: any, record: ConstructRecord): any {
 	const { args, descriptor = defaultConstructDescriptor, Ctor, name, propertyRecords } = record;
 	const value = new Ctor(...(args || []));
 	if (propertyRecords) {
-		propertyRecords.forEach((record) => isConstructRecord(record) ? patchConstruct(value, record) : patchPatch(value, record));
+		propertyRecords.forEach(
+			(record) => (isConstructRecord(record) ? patchConstruct(value, record) : patchPatch(value, record))
+		);
 	}
 	defineProperty(target, name, assign({ value }, descriptor));
 	return target;
@@ -630,15 +690,14 @@ function patchConstruct(target: any, record: ConstructRecord): any {
  */
 function resolveTargetValue(patchValue: any, targetValue: any): any {
 	const patchIsSpliceRecordArray = isSpliceRecordArray(patchValue);
-	return (patchIsSpliceRecordArray || isPatchRecordArray(patchValue)) ?
-		patch(
-			patchIsSpliceRecordArray ?
-				isArray(targetValue) ?
-					targetValue : [] : isPlainObject(targetValue) ?
-						targetValue : objectCreate(null),
-			patchValue
-		) :
-		patchValue;
+	return patchIsSpliceRecordArray || isPatchRecordArray(patchValue)
+		? patch(
+				patchIsSpliceRecordArray
+					? isArray(targetValue) ? targetValue : []
+					: isPlainObject(targetValue) ? targetValue : objectCreate(null),
+				patchValue
+			)
+		: patchValue;
 }
 
 /**
@@ -687,7 +746,8 @@ export function patch(target: any, records: (ConstructRecord | PatchRecord | Spl
 	records.forEach((record) => {
 		target = isSpliceRecord(record)
 			? patchSplice(isArray(target) ? target : [], record) /* patch arrays */
-			: isConstructRecord(record) ? patchConstruct(target, record) /* patch complex object */
+			: isConstructRecord(record)
+				? patchConstruct(target, record) /* patch complex object */
 				: patchPatch(isPlainObject(target) ? target : {}, record); /* patch plain object */
 	});
 	return target;

--- a/src/has.ts
+++ b/src/has.ts
@@ -11,26 +11,34 @@ add('formdata', typeof global.FormData !== 'undefined', true);
 add('filereader', typeof global.FileReader !== 'undefined', true);
 add('xhr', typeof global.XMLHttpRequest !== 'undefined', true);
 add('xhr2', has('xhr') && 'responseType' in global.XMLHttpRequest.prototype, true);
-add('blob', function () {
-	if (!has('xhr2')) {
-		return false;
-	}
+add(
+	'blob',
+	function() {
+		if (!has('xhr2')) {
+			return false;
+		}
 
-	const request = new global.XMLHttpRequest();
-	request.open('GET', 'http://www.google.com', true);
-	request.responseType = 'blob';
-	request.abort();
-	return request.responseType === 'blob';
-}, true);
+		const request = new global.XMLHttpRequest();
+		request.open('GET', 'http://www.google.com', true);
+		request.responseType = 'blob';
+		request.abort();
+		return request.responseType === 'blob';
+	},
+	true
+);
 
 add('node-buffer', 'Buffer' in global && typeof global.Buffer === 'function', true);
 
 add('fetch', 'fetch' in global && typeof global.fetch === 'function', true);
 
-add('web-worker-xhr-upload', new Promise((resolve) => {
-	try {
-		if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
-			const blob = new Blob([ `(function () {
+add(
+	'web-worker-xhr-upload',
+	new Promise((resolve) => {
+		try {
+			if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
+				const blob = new Blob(
+					[
+						`(function () {
 self.addEventListener('message', function () {
 	var xhr = new XMLHttpRequest();
 	try {
@@ -40,17 +48,22 @@ self.addEventListener('message', function () {
 		postMessage('false');
 	}
 });
-		})()` ], { type: 'application/javascript' });
-			const worker = new Worker(URL.createObjectURL(blob));
-			worker.addEventListener('message', ({ data: result }) => {
-				resolve(result === 'true');
-			});
-			worker.postMessage({});
-		} else {
+		})()`
+					],
+					{ type: 'application/javascript' }
+				);
+				const worker = new Worker(URL.createObjectURL(blob));
+				worker.addEventListener('message', ({ data: result }) => {
+					resolve(result === 'true');
+				});
+				worker.postMessage({});
+			} else {
+				resolve(false);
+			}
+		} catch (e) {
+			// IE11 on Winodws 8.1 encounters a security error.
 			resolve(false);
 		}
-	} catch (e) {
-		// IE11 on Winodws 8.1 encounters a security error.
-		resolve(false);
-	}
-}), true);
+	}),
+	true
+);

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -47,11 +47,9 @@ export function deprecated({ message, name, warn, url }: DeprecatedOptions = {})
 		}
 		if (warn) {
 			warn(warning);
-		}
-		else if (globalWarn) {
+		} else if (globalWarn) {
 			globalWarn(warning);
-		}
-		else {
+		} else {
 			console.warn(warning);
 		}
 	}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,7 +54,7 @@ export interface Handle {
  * A general interface that can be used to renference a general index map of values of a particular type
  */
 export interface Hash<T> {
-	[ id: string ]: T;
+	[id: string]: T;
 }
 
 /**

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -89,13 +89,6 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
 	return <T & U>target;
 }
 
-interface ObjectAssignConstructor extends ObjectConstructor {
-	assign<T, U>(target: T, source: U): T & U;
-	assign<T, U1, U2>(target: T, source1: U1, source2: U2): T & U1 & U2;
-	assign<T, U1, U2, U3>(target: T, source1: U1, source2: U2, source3: U3): T & U1 & U2 & U3;
-	assign(target: any, ...sources: any[]): any;
-}
-
 /**
  * Creates a new object from the given prototype, and copies all enumerable own properties of one or more
  * source objects to the newly created target object.

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -21,19 +21,19 @@ function shouldDeepCopyObject(value: any): value is Object {
 }
 
 function copyArray<T>(array: T[], inherited: boolean): T[] {
-	return array.map(function (item: T): T {
+	return array.map(function(item: T): T {
 		if (Array.isArray(item)) {
-			return <any> copyArray(<any> item, inherited);
+			return <any>copyArray(<any>item, inherited);
 		}
 
-		return !shouldDeepCopyObject(item) ?
-			item :
-			_mixin({
-				deep: true,
-				inherited: inherited,
-				sources: <Array<T>> [ item ],
-				target: <T> {}
-			});
+		return !shouldDeepCopyObject(item)
+			? item
+			: _mixin({
+					deep: true,
+					inherited: inherited,
+					sources: <Array<T>>[item],
+					target: <T>{}
+				});
 	});
 }
 
@@ -45,12 +45,12 @@ interface MixinArgs<T extends {}, U extends {}> {
 	copied?: any[];
 }
 
-function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
+function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T & U {
 	const deep = kwArgs.deep;
 	const inherited = kwArgs.inherited;
 	const target: any = kwArgs.target;
 	const copied = kwArgs.copied || [];
-	const copiedClone = [ ...copied ];
+	const copiedClone = [...copied];
 
 	for (let i = 0; i < kwArgs.sources.length; i++) {
 		const source = kwArgs.sources[i];
@@ -69,14 +69,13 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 				if (deep) {
 					if (Array.isArray(value)) {
 						value = copyArray(value, inherited);
-					}
-					else if (shouldDeepCopyObject(value)) {
+					} else if (shouldDeepCopyObject(value)) {
 						const targetValue: any = target[key] || {};
 						copied.push(source);
 						value = _mixin({
 							deep: true,
 							inherited: inherited,
-							sources: [ value ],
+							sources: [value],
 							target: targetValue,
 							copied
 						});
@@ -87,7 +86,7 @@ function _mixin<T extends {}, U extends {}>(kwArgs: MixinArgs<T, U>): T&U {
 		}
 	}
 
-	return <T&U> target;
+	return <T & U>target;
 }
 
 interface ObjectAssignConstructor extends ObjectConstructor {
@@ -105,10 +104,36 @@ interface ObjectAssignConstructor extends ObjectConstructor {
  * @param mixins Any number of objects whose enumerable own properties will be copied to the created object
  * @return The new object
  */
-export function create<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}, Z extends {}>(prototype: T, mixin1: U, mixin2: V, mixin3: W, mixin4: X, mixin5: Y, mixin6: Z): T & U & V & W & X & Y & Z;
-export function create<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(prototype: T, mixin1: U, mixin2: V, mixin3: W, mixin4: X, mixin5: Y): T & U & V & W & X & Y;
-export function create<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(prototype: T, mixin1: U, mixin2: V, mixin3: W, mixin4: X): T & U & V & W & X;
-export function create<T extends {}, U extends {}, V extends {}, W extends {}>(prototype: T, mixin1: U, mixin2: V, mixin3: W): T & U & V & W;
+export function create<
+	T extends {},
+	U extends {},
+	V extends {},
+	W extends {},
+	X extends {},
+	Y extends {},
+	Z extends {}
+>(prototype: T, mixin1: U, mixin2: V, mixin3: W, mixin4: X, mixin5: Y, mixin6: Z): T & U & V & W & X & Y & Z;
+export function create<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(
+	prototype: T,
+	mixin1: U,
+	mixin2: V,
+	mixin3: W,
+	mixin4: X,
+	mixin5: Y
+): T & U & V & W & X & Y;
+export function create<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(
+	prototype: T,
+	mixin1: U,
+	mixin2: V,
+	mixin3: W,
+	mixin4: X
+): T & U & V & W & X;
+export function create<T extends {}, U extends {}, V extends {}, W extends {}>(
+	prototype: T,
+	mixin1: U,
+	mixin2: V,
+	mixin3: W
+): T & U & V & W;
 export function create<T extends {}, U extends {}, V extends {}>(prototype: T, mixin1: U, mixin2: V): T & U & V;
 export function create<T extends {}, U extends {}>(prototype: T, mixin: U): T & U;
 export function create<T extends {}>(prototype: T): T;
@@ -131,10 +156,36 @@ export function create(prototype: any, ...mixins: any[]): any {
  * @param sources Any number of objects whose enumerable own properties will be copied to the target object
  * @return The modified target object
  */
-export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}, Z extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y, source6: Z): T & U & V & W & X & Y & Z;
-export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y): T & U & V & W & X & Y;
-export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(target: T, source1: U, source2: V, source3: W, source4: X): T & U & V & W & X;
-export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+export function deepAssign<
+	T extends {},
+	U extends {},
+	V extends {},
+	W extends {},
+	X extends {},
+	Y extends {},
+	Z extends {}
+>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y, source6: Z): T & U & V & W & X & Y & Z;
+export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X,
+	source5: Y
+): T & U & V & W & X & Y;
+export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X
+): T & U & V & W & X;
+export function deepAssign<T extends {}, U extends {}, V extends {}, W extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W
+): T & U & V & W;
 export function deepAssign<T extends {}, U extends {}, V extends {}>(target: T, source1: U, source2: V): T & U & V;
 export function deepAssign<T extends {}, U extends {}>(target: T, source: U): T & U;
 export function deepAssign(target: any, ...sources: any[]): any {
@@ -154,10 +205,36 @@ export function deepAssign(target: any, ...sources: any[]): any {
  * @param sources Any number of objects whose enumerable properties will be copied to the target object
  * @return The modified target object
  */
-export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}, Z extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y, source6: Z): T & U & V & W & X & Y & Z;
-export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y): T & U & V & W & X & Y;
-export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(target: T, source1: U, source2: V, source3: W, source4: X): T & U & V & W & X;
-export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+export function deepMixin<
+	T extends {},
+	U extends {},
+	V extends {},
+	W extends {},
+	X extends {},
+	Y extends {},
+	Z extends {}
+>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y, source6: Z): T & U & V & W & X & Y & Z;
+export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X,
+	source5: Y
+): T & U & V & W & X & Y;
+export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X
+): T & U & V & W & X;
+export function deepMixin<T extends {}, U extends {}, V extends {}, W extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W
+): T & U & V & W;
 export function deepMixin<T extends {}, U extends {}, V extends {}>(target: T, source1: U, source2: V): T & U & V;
 export function deepMixin<T extends {}, U extends {}>(target: T, source: U): T & U;
 export function deepMixin(target: any, ...sources: any[]): any {
@@ -190,9 +267,11 @@ export function duplicate<T extends {}>(source: T): T {
  * @return true if the values are the same; false otherwise
  */
 export function isIdentical(a: any, b: any): boolean {
-	return a === b ||
+	return (
+		a === b ||
 		/* both values are NaN */
-		(a !== a && b !== b);
+		(a !== a && b !== b)
+	);
 }
 
 /**
@@ -207,17 +286,17 @@ export function isIdentical(a: any, b: any): boolean {
  * @return The bound function
  */
 export function lateBind(instance: {}, method: string, ...suppliedArgs: any[]): (...args: any[]) => any {
-	return suppliedArgs.length ?
-		function () {
-			const args: any[] = arguments.length ? suppliedArgs.concat(slice.call(arguments)) : suppliedArgs;
+	return suppliedArgs.length
+		? function() {
+				const args: any[] = arguments.length ? suppliedArgs.concat(slice.call(arguments)) : suppliedArgs;
 
-			// TS7017
-			return (<any> instance)[method].apply(instance, args);
-		} :
-		function () {
-			// TS7017
-			return (<any> instance)[method].apply(instance, arguments);
-		};
+				// TS7017
+				return (<any>instance)[method].apply(instance, args);
+			}
+		: function() {
+				// TS7017
+				return (<any>instance)[method].apply(instance, arguments);
+			};
 }
 
 /**
@@ -226,10 +305,36 @@ export function lateBind(instance: {}, method: string, ...suppliedArgs: any[]): 
  *
  * @return The modified target object
  */
-export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}, Z extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y, source6: Z): T & U & V & W & X & Y & Z;
-export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(target: T, source1: U, source2: V, source3: W, source4: X, source5: Y): T & U & V & W & X & Y;
-export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(target: T, source1: U, source2: V, source3: W, source4: X): T & U & V & W & X;
-export function mixin<T extends {}, U extends {}, V extends {}, W extends {}>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}, Z extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X,
+	source5: Y,
+	source6: Z
+): T & U & V & W & X & Y & Z;
+export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}, Y extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X,
+	source5: Y
+): T & U & V & W & X & Y;
+export function mixin<T extends {}, U extends {}, V extends {}, W extends {}, X extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W,
+	source4: X
+): T & U & V & W & X;
+export function mixin<T extends {}, U extends {}, V extends {}, W extends {}>(
+	target: T,
+	source1: U,
+	source2: V,
+	source3: W
+): T & U & V & W;
 export function mixin<T extends {}, U extends {}, V extends {}>(target: T, source1: U, source2: V): T & U & V;
 export function mixin<T extends {}, U extends {}>(target: T, source: U): T & U;
 export function mixin(target: any, ...sources: any[]): any {
@@ -250,7 +355,7 @@ export function mixin(target: any, ...sources: any[]): any {
  * @return The bound function
  */
 export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs: any[]): (...args: any[]) => any {
-	return function (this: any) {
+	return function(this: any) {
 		const args: any[] = arguments.length ? suppliedArgs.concat(slice.call(arguments)) : suppliedArgs;
 
 		return targetFunction.apply(this, args);
@@ -267,8 +372,8 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
  */
 export function createHandle(destructor: () => void): Handle {
 	return {
-		destroy: function (this: Handle) {
-			this.destroy = function () {};
+		destroy: function(this: Handle) {
+			this.destroy = function() {};
 			destructor.call(this);
 		}
 	};
@@ -281,7 +386,7 @@ export function createHandle(destructor: () => void): Handle {
  * @return The handle object
  */
 export function createCompositeHandle(...handles: Handle[]): Handle {
-	return createHandle(function () {
+	return createHandle(function() {
 		for (let i = 0; i < handles.length; i++) {
 			handles[i].destroy();
 		}

--- a/src/load.ts
+++ b/src/load.ts
@@ -21,10 +21,10 @@ export function isNodeRequire(object: any): object is NodeRequire {
 	return typeof object.resolve === 'function';
 }
 
-const load: Load = (function (): Load {
-	const resolver = isAmdRequire(require) ? require.toUrl :
-		isNodeRequire(require) ? require.resolve :
-		(resourceId: string) => resourceId;
+const load: Load = (function(): Load {
+	const resolver = isAmdRequire(require)
+		? require.toUrl
+		: isNodeRequire(require) ? require.resolve : (resourceId: string) => resourceId;
 
 	function pluginLoad(moduleIds: string[], load: Load, loader: (modulesIds: string[]) => Promise<any>) {
 		const pluginResourceIds: string[] = [];
@@ -41,9 +41,10 @@ const load: Load = (function (): Load {
 					const defaultExport = module['default'] || module;
 
 					if (isPlugin(defaultExport)) {
-						resourceId = typeof defaultExport.normalize === 'function' ?
-							defaultExport.normalize(resourceId, resolver) :
-							resolver(resourceId);
+						resourceId =
+							typeof defaultExport.normalize === 'function'
+								? defaultExport.normalize(resourceId, resolver)
+								: resolver(resourceId);
 
 						modules[i] = defaultExport.load(resourceId, load);
 					}
@@ -63,17 +64,17 @@ const load: Load = (function (): Load {
 
 			return pluginLoad(moduleIds, load, (moduleIds: string[]) => {
 				try {
-					return Promise.resolve(moduleIds.map(function (moduleId): any {
-						return contextualRequire(moduleId.split('!')[0]);
-					}));
-				}
-				catch (error) {
+					return Promise.resolve(
+						moduleIds.map(function(moduleId): any {
+							return contextualRequire(moduleId.split('!')[0]);
+						})
+					);
+				} catch (error) {
 					return Promise.reject(error);
 				}
 			});
 		};
-	}
-	else if (typeof define === 'function' && define.amd) {
+	} else if (typeof define === 'function' && define.amd) {
 		return function load(contextualRequire: any, ...moduleIds: string[]): Promise<any[]> {
 			if (typeof contextualRequire === 'string') {
 				moduleIds.unshift(contextualRequire);
@@ -81,7 +82,7 @@ const load: Load = (function (): Load {
 			}
 
 			return pluginLoad(moduleIds, load, (moduleIds: string[]) => {
-				return new Promise(function (resolve, reject) {
+				return new Promise(function(resolve, reject) {
 					let errorHandle: { remove: () => void };
 
 					if (typeof contextualRequire.on === 'function') {
@@ -91,23 +92,19 @@ const load: Load = (function (): Load {
 						});
 					}
 
-					contextualRequire(moduleIds, function (...modules: any[]) {
+					contextualRequire(moduleIds, function(...modules: any[]) {
 						errorHandle && errorHandle.remove();
 						resolve(modules);
 					});
 				});
 			});
 		};
-	}
-	else {
-		return function () {
+	} else {
+		return function() {
 			return Promise.reject(new Error('Unknown loader'));
 		};
 	}
 })();
 export default load;
 
-export {
-	isPlugin,
-	useDefault
-};
+export { isPlugin, useDefault };

--- a/src/load/util.ts
+++ b/src/load/util.ts
@@ -41,7 +41,7 @@ export function useDefault(modules: any | any[]): any[] | any {
 
 		for (let i = 0; i < modules.length; i++) {
 			const module = modules[i];
-			processedModules.push((module.__esModule && module.default) ? module.default : module);
+			processedModules.push(module.__esModule && module.default ? module.default : module);
 		}
 
 		return processedModules;
@@ -49,12 +49,11 @@ export function useDefault(modules: any | any[]): any[] | any {
 		let processedModules: any[] = [];
 
 		for (const module of modules) {
-			processedModules.push((module.__esModule && module.default) ? module.default : module);
+			processedModules.push(module.__esModule && module.default ? module.default : module);
 		}
 
 		return processedModules;
-	}
-	else {
-		return (modules.__esModule && modules.default) ? modules.default : modules;
+	} else {
+		return modules.__esModule && modules.default ? modules.default : modules;
 	}
 }

--- a/src/load/webpack.ts
+++ b/src/load/webpack.ts
@@ -75,7 +75,10 @@ function resolveRelative(base: string, mid: string): string {
  * The parent directory of the path returned by the context function.
  */
 function getBasePath(context: () => string): string {
-	return context().split('/').slice(0, -1).join('/');
+	return context()
+		.split('/')
+		.slice(0, -1)
+		.join('/');
 }
 
 /**
@@ -97,15 +100,21 @@ export default function load(contextRequire: () => string, ...mids: string[]): P
 export default function load(...mids: string[]): Promise<any[]>;
 export default function load(...args: any[]): Promise<any[]> {
 	const req = __webpack_require__;
-	const context = typeof args[0] === 'function' ? args[0] : function () { return ''; };
+	const context =
+		typeof args[0] === 'function'
+			? args[0]
+			: function() {
+					return '';
+				};
 
 	const modules = __modules__ || {};
 	const base = getBasePath(context);
 
-	const results = args.filter((mid: string | Function) => typeof mid === 'string')
+	const results = args
+		.filter((mid: string | Function) => typeof mid === 'string')
 		.map((mid: string) => resolveRelative(base, mid))
 		.map((mid: string) => {
-			let [ moduleId, pluginResourceId ] = mid.split('!');
+			let [moduleId, pluginResourceId] = mid.split('!');
 			const moduleMeta = modules[mid] || modules[moduleId];
 
 			if (!moduleMeta) {
@@ -120,11 +129,12 @@ export default function load(...args: any[]): Promise<any[]> {
 			const defaultExport = module['default'] || module;
 
 			if (isPlugin(defaultExport)) {
-				pluginResourceId = typeof defaultExport.normalize === 'function' ?
-					defaultExport.normalize(pluginResourceId, (mid: string) => resolveRelative(base, mid)) :
-					resolveRelative(base, pluginResourceId);
+				pluginResourceId =
+					typeof defaultExport.normalize === 'function'
+						? defaultExport.normalize(pluginResourceId, (mid: string) => resolveRelative(base, mid))
+						: resolveRelative(base, pluginResourceId);
 
-				return Promise.resolve(defaultExport.load(pluginResourceId, <any> load));
+				return Promise.resolve(defaultExport.load(pluginResourceId, <any>load));
 			}
 
 			return Promise.resolve(module);

--- a/src/on.ts
+++ b/src/on.ts
@@ -23,26 +23,32 @@ interface DOMEventObject extends EventObject {
  * @return Boolean indicating if preventDefault was called on the event object (only relevant for DOM events;
  *     always false for other event emitters)
  */
-export function emit<M, T, O extends EventObject<T> = EventObject<T>, K extends keyof M = keyof M>(target: Evented<M, T, O>, event: M[K]): boolean;
+export function emit<M, T, O extends EventObject<T> = EventObject<T>, K extends keyof M = keyof M>(
+	target: Evented<M, T, O>,
+	event: M[K]
+): boolean;
 export function emit<T, O extends EventObject<T> = EventObject<T>>(target: Evented<any, T, O>, event: O): boolean;
-export function emit<O extends EventObject<string> = EventObject<string>>(target: EventTarget | EventEmitter, event: O): boolean;
+export function emit<O extends EventObject<string> = EventObject<string>>(
+	target: EventTarget | EventEmitter,
+	event: O
+): boolean;
 export function emit(target: any, event: EventObject<any>): boolean {
 	if (
-		target.dispatchEvent && /* includes window and document */
-			((target.ownerDocument && target.ownerDocument.createEvent) || /* matches nodes */
-			(target.document && target.document.createEvent) || /* matches window */
+		target.dispatchEvent /* includes window and document */ &&
+		((target.ownerDocument && target.ownerDocument.createEvent) /* matches nodes */ ||
+		(target.document && target.document.createEvent) /* matches window */ ||
 			target.createEvent) /* matches document */
 	) {
 		const nativeEvent = (target.ownerDocument || target.document || target).createEvent('HTMLEvents');
 		nativeEvent.initEvent(
 			event.type,
-			Boolean((<DOMEventObject> event).bubbles),
-			Boolean((<DOMEventObject> event).cancelable)
+			Boolean((<DOMEventObject>event).bubbles),
+			Boolean((<DOMEventObject>event).cancelable)
 		);
 
 		for (let key in event) {
 			if (!(key in nativeEvent)) {
-				nativeEvent[key] = (<any> event)[key];
+				nativeEvent[key] = (<any>event)[key];
 			}
 		}
 
@@ -54,8 +60,7 @@ export function emit(target: any, event: EventObject<any>): boolean {
 			// Node.js EventEmitter
 			target.emit(event.type, event);
 			return false;
-		}
-		else if (target.on) {
+		} else if (target.on) {
 			// Dojo Evented or similar
 			target.emit(event);
 			return false;
@@ -73,27 +78,40 @@ export function emit(target: any, event: EventObject<any>): boolean {
  * @param capture Whether the listener should be registered in the capture phase (DOM events only)
  * @return A handle which will remove the listener when destroy is called
  */
-export default function on<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(target: Evented<M, T, O>, type: K | K[], listener: EventCallback<M[K]>): Handle;
-export default function on<T, O extends EventObject<T> = EventObject<T>>(target: Evented<any, T, O>, type: T | T[], listener: EventCallback<O>): Handle;
+export default function on<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<M, T, O>,
+	type: K | K[],
+	listener: EventCallback<M[K]>
+): Handle;
+export default function on<T, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<any, T, O>,
+	type: T | T[],
+	listener: EventCallback<O>
+): Handle;
 export default function on(target: EventEmitter, type: string | string[], listener: EventCallback): Handle;
-export default function on(target: EventTarget, type: string | string[], listener: EventCallback, capture?: boolean): Handle;
+export default function on(
+	target: EventTarget,
+	type: string | string[],
+	listener: EventCallback,
+	capture?: boolean
+): Handle;
 export default function on(target: any, type: any, listener: any, capture?: boolean): Handle {
 	if (Array.isArray(type)) {
-		let handles: Handle[] = type.map(function (type: string): Handle {
+		let handles: Handle[] = type.map(function(type: string): Handle {
 			return on(target, type, listener, capture);
 		});
 
 		return createCompositeHandle(...handles);
 	}
 
-	const callback = function (this: any) {
+	const callback = function(this: any) {
 		listener.apply(this, arguments);
 	};
 
 	// DOM EventTarget
 	if (target.addEventListener && target.removeEventListener) {
 		target.addEventListener(type, callback, capture);
-		return createHandle(function () {
+		return createHandle(function() {
 			target.removeEventListener(type, callback, capture);
 		});
 	}
@@ -102,12 +120,11 @@ export default function on(target: any, type: any, listener: any, capture?: bool
 		// EventEmitter
 		if (target.removeListener) {
 			target.on(type, callback);
-			return createHandle(function () {
+			return createHandle(function() {
 				target.removeListener(type, callback);
 			});
-		}
-		// Evented
-		else if (target.emit) {
+		} else if (target.emit) {
+			// Evented
 			return target.on(type, listener);
 		}
 	}
@@ -124,17 +141,30 @@ export default function on(target: any, type: any, listener: any, capture?: bool
  * @param capture Whether the listener should be registered in the capture phase (DOM events only)
  * @return A handle which will remove the listener when destroy is called
  */
-export function once<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(target: Evented<M, T, O>, type: K | K[], listener: EventCallback<M[K]>): Handle;
-export function once<T, O extends EventObject<T> = EventObject<T>>(target: Evented<any, T, O>, type: T | T[], listener: EventCallback<O>): Handle;
+export function once<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<M, T, O>,
+	type: K | K[],
+	listener: EventCallback<M[K]>
+): Handle;
+export function once<T, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<any, T, O>,
+	type: T | T[],
+	listener: EventCallback<O>
+): Handle;
 export function once(target: EventTarget, type: string | string[], listener: EventCallback, capture?: boolean): Handle;
 export function once(target: EventEmitter, type: string | string[], listener: EventCallback): Handle;
 export function once(target: any, type: any, listener: any, capture?: boolean): Handle {
 	// FIXME
 	// tslint:disable-next-line:no-var-keyword
-	var handle = on(target, type, function (this: any) {
-		handle.destroy();
-		return listener.apply(this, arguments);
-	}, capture);
+	var handle = on(
+		target,
+		type,
+		function(this: any) {
+			handle.destroy();
+			return listener.apply(this, arguments);
+		},
+		capture
+	);
 
 	return handle;
 }
@@ -152,24 +182,42 @@ export interface PausableHandle extends Handle {
  * @param capture Whether the listener should be registered in the capture phase (DOM events only)
  * @return A handle with additional pause and resume methods; the listener will never fire when paused
  */
-export function pausable<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(target: Evented<M, T, O>, type: K | K[], listener: EventCallback<M[K]>): PausableHandle;
-export function pausable<T, O extends EventObject<T> = EventObject<T>>(target: Evented<any, T, O>, type: T | T[], listener: EventCallback<O>): PausableHandle;
-export function pausable(target: EventTarget, type: string | string[], listener: EventCallback, capture?: boolean): PausableHandle;
+export function pausable<M, T, K extends keyof M = keyof M, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<M, T, O>,
+	type: K | K[],
+	listener: EventCallback<M[K]>
+): PausableHandle;
+export function pausable<T, O extends EventObject<T> = EventObject<T>>(
+	target: Evented<any, T, O>,
+	type: T | T[],
+	listener: EventCallback<O>
+): PausableHandle;
+export function pausable(
+	target: EventTarget,
+	type: string | string[],
+	listener: EventCallback,
+	capture?: boolean
+): PausableHandle;
 export function pausable(target: EventEmitter, type: string | string[], listener: EventCallback): PausableHandle;
 export function pausable(target: any, type: any, listener: any, capture?: boolean): PausableHandle {
 	let paused: boolean;
 
-	const handle = <PausableHandle> on(target, type, function (this: any) {
-		if (!paused) {
-			return listener.apply(this, arguments);
-		}
-	}, capture);
+	const handle = <PausableHandle>on(
+		target,
+		type,
+		function(this: any) {
+			if (!paused) {
+				return listener.apply(this, arguments);
+			}
+		},
+		capture
+	);
 
-	handle.pause = function () {
+	handle.pause = function() {
 		paused = true;
 	};
 
-	handle.resume = function () {
+	handle.resume = function() {
 		paused = false;
 	};
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -16,16 +16,15 @@ const request: {
 	put(url: string, options?: RequestOptions): UploadObservableTask<Response>;
 
 	setDefaultProvider(provider: Provider): void;
-} = <any> function request(url: string, options: RequestOptions = {}): Task<Response> {
+} = <any>function request(url: string, options: RequestOptions = {}): Task<Response> {
 	try {
 		return providerRegistry.match(url, options)(url, options);
-	}
-	catch (error) {
+	} catch (error) {
 		return Task.reject<Response>(error);
 	}
 };
 
-[ 'DELETE', 'GET', 'HEAD', 'OPTIONS' ].forEach(method => {
+['DELETE', 'GET', 'HEAD', 'OPTIONS'].forEach((method) => {
 	Object.defineProperty(request, method.toLowerCase(), {
 		value(url: string, options: RequestOptions = {}): Task<Response> {
 			options = Object.create(options);
@@ -35,12 +34,12 @@ const request: {
 	});
 });
 
-[ 'POST', 'PUT' ].forEach(method => {
+['POST', 'PUT'].forEach((method) => {
 	Object.defineProperty(request, method.toLowerCase(), {
 		value(url: string, options: RequestOptions = {}): UploadObservableTask<Response> {
 			options = Object.create(options);
 			options.method = method;
-			return <UploadObservableTask<Response>> request(url, options);
+			return <UploadObservableTask<Response>>request(url, options);
 		}
 	});
 });
@@ -55,7 +54,7 @@ providerRegistry.setDefaultProvider(xhr);
 
 if (has('host-node')) {
 	// tslint:disable-next-line
-	import('./request/providers/node').then(node => {
+	import('./request/providers/node').then((node) => {
 		providerRegistry.setDefaultProvider(node.default);
 	});
 }

--- a/src/request/Headers.ts
+++ b/src/request/Headers.ts
@@ -3,7 +3,11 @@ import { IterableIterator, ShimIterator } from '@dojo/shim/iterator';
 import Map from '@dojo/shim/Map';
 
 function isHeadersLike(object: any): object is HeadersInterface {
-	return typeof object.append === 'function' && typeof object.entries === 'function' && typeof object[Symbol.iterator] === 'function';
+	return (
+		typeof object.append === 'function' &&
+		typeof object.entries === 'function' &&
+		typeof object[Symbol.iterator] === 'function'
+	);
 }
 
 export default class Headers implements HeadersInterface {
@@ -13,13 +17,11 @@ export default class Headers implements HeadersInterface {
 		if (headers) {
 			if (headers instanceof Headers) {
 				this.map = new Map(headers.map);
-			}
-			else if (isHeadersLike(headers)) {
+			} else if (isHeadersLike(headers)) {
 				for (const [key, value] of headers) {
 					this.append(key, value);
 				}
-			}
-			else {
+			} else {
 				for (let key in headers) {
 					this.set(key, headers[key]);
 				}
@@ -32,8 +34,7 @@ export default class Headers implements HeadersInterface {
 
 		if (values) {
 			values.push(value);
-		}
-		else {
+		} else {
 			this.set(name, value);
 		}
 	}
@@ -45,7 +46,7 @@ export default class Headers implements HeadersInterface {
 	entries(): IterableIterator<[string, string]> {
 		const entries: [string, string][] = [];
 		for (const [key, values] of this.map.entries()) {
-			values.forEach(value => {
+			values.forEach((value) => {
 				entries.push([key, value]);
 			});
 		}
@@ -57,8 +58,7 @@ export default class Headers implements HeadersInterface {
 
 		if (values) {
 			return values[0];
-		}
-		else {
+		} else {
 			return null;
 		}
 	}
@@ -68,8 +68,7 @@ export default class Headers implements HeadersInterface {
 
 		if (values) {
 			return values.slice(0);
-		}
-		else {
+		} else {
 			return [];
 		}
 	}
@@ -83,7 +82,7 @@ export default class Headers implements HeadersInterface {
 	}
 
 	set(name: string, value: string) {
-		this.map.set(name.toLowerCase(), [ value ]);
+		this.map.set(name.toLowerCase(), [value]);
 	}
 
 	values(): IterableIterator<string> {

--- a/src/request/ProviderRegistry.ts
+++ b/src/request/ProviderRegistry.ts
@@ -12,13 +12,11 @@ export default class ProviderRegistry extends MatchRegistry<Provider> {
 
 		if (typeof test === 'string') {
 			entryTest = (url, options) => test === url;
-		}
-		else if (test instanceof RegExp) {
+		} else if (test instanceof RegExp) {
 			entryTest = (url, options) => {
 				return test ? test.test(url) : null;
 			};
-		}
-		else {
+		} else {
 			entryTest = test;
 		}
 

--- a/src/request/Response.ts
+++ b/src/request/Response.ts
@@ -21,7 +21,7 @@ abstract class Response implements ResponseInterface {
 	abstract readonly data: Observable<any>;
 
 	json<T>(): Task<T> {
-		return <any> this.text().then(JSON.parse);
+		return <any>this.text().then(JSON.parse);
 	}
 
 	abstract arrayBuffer(): Task<ArrayBuffer>;
@@ -34,10 +34,10 @@ export default Response;
 
 export function getFileReaderPromise<T>(reader: FileReader): Promise<T> {
 	return new Promise((resolve, reject) => {
-		reader.onload = function () {
+		reader.onload = function() {
 			resolve(reader.result);
 		};
-		reader.onerror = function () {
+		reader.onerror = function() {
 			reject(reader.error);
 		};
 	});

--- a/src/request/SubscriptionPool.ts
+++ b/src/request/SubscriptionPool.ts
@@ -31,13 +31,13 @@ export default class SubscriptionPool<T> {
 			}
 		}
 
-		this._observers.forEach(observer => {
+		this._observers.forEach((observer) => {
 			observer.next(value);
 		});
 	}
 
 	complete() {
-		this._observers.forEach(observer => {
+		this._observers.forEach((observer) => {
 			observer.complete();
 		});
 	}

--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -48,7 +48,7 @@ export interface RequestOptions {
 	/**
 	 * Headers to send along with the http request
 	 */
-	headers?: Headers | { [key: string]: string; };
+	headers?: Headers | { [key: string]: string };
 	/**
 	 * HTTP method
 	 */

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -136,7 +136,7 @@ const DEFAULT_REDIRECT_LIMIT = 15;
 interface Options {
 	agent?: any;
 	auth?: string;
-	headers?: { [name: string]: string; };
+	headers?: { [name: string]: string };
 	host?: string;
 	hostname?: string;
 	localAddress?: string;
@@ -175,10 +175,23 @@ interface RequestData {
 
 const dataMap = new WeakMap<NodeResponse, RequestData>();
 const discardedDuplicates = new Set<string>([
-	'age', 'authorization', 'content-length', 'content-type', 'etag',
-	'expires', 'from', 'host', 'if-modified-since', 'if-unmodified-since',
-	'last-modified', 'location', 'max-forwards', 'proxy-authorization',
-	'referer', 'retry-after', 'user-agent'
+	'age',
+	'authorization',
+	'content-length',
+	'content-type',
+	'etag',
+	'expires',
+	'from',
+	'host',
+	'if-modified-since',
+	'if-unmodified-since',
+	'last-modified',
+	'location',
+	'max-forwards',
+	'proxy-authorization',
+	'referer',
+	'retry-after',
+	'user-agent'
 ]);
 
 function getDataTask(response: NodeResponse): Task<RequestData> {
@@ -190,7 +203,7 @@ function getDataTask(response: NodeResponse): Task<RequestData> {
 
 	data.used = true;
 
-	return <Task<RequestData>> data.task.then(_ => data);
+	return <Task<RequestData>>data.task.then((_) => data);
 }
 
 /**
@@ -231,7 +244,7 @@ export class NodeResponse extends Response {
 	constructor(response: http.IncomingMessage) {
 		super();
 
-		const headers = this.headers = new Headers();
+		const headers = (this.headers = new Headers());
 		for (let key in response.headers) {
 			const value = response.headers[key];
 			if (value) {
@@ -250,7 +263,7 @@ export class NodeResponse extends Response {
 	}
 
 	arrayBuffer(): Task<ArrayBuffer> {
-		return <any> getDataTask(this).then(data => {
+		return <any>getDataTask(this).then((data) => {
 			if (data) {
 				return data.data;
 			}
@@ -269,21 +282,24 @@ export class NodeResponse extends Response {
 	}
 
 	text(): Task<string> {
-		return <any> getDataTask(this).then(data => {
+		return <any>getDataTask(this).then((data) => {
 			return String(data ? data.data : '');
 		});
 	}
 }
 
-function redirect(resolve: (p?: any) => void, reject: (_?: Error) => void, originalUrl: string, redirectUrl: string | null, options: NodeRequestOptions): boolean {
+function redirect(
+	resolve: (p?: any) => void,
+	reject: (_?: Error) => void,
+	originalUrl: string,
+	redirectUrl: string | null,
+	options: NodeRequestOptions
+): boolean {
 	if (!options.redirectOptions) {
 		options.redirectOptions = {};
 	}
 
-	const {
-		limit: redirectLimit = DEFAULT_REDIRECT_LIMIT,
-		count: redirectCount = 0
-	} = options.redirectOptions;
+	const { limit: redirectLimit = DEFAULT_REDIRECT_LIMIT, count: redirectCount = 0 } = options.redirectOptions;
 	const { followRedirects = true } = options;
 
 	if (!followRedirects) {
@@ -317,7 +333,7 @@ export function getAuth(proxyAuth: string | undefined, options: NodeRequestOptio
 	}
 
 	if (options.user || options.password) {
-		return `${ options.user || '' }:${ options.password || '' }`;
+		return `${options.user || ''}:${options.password || ''}`;
 	}
 
 	return undefined;
@@ -346,21 +362,25 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 		socketPath: options.socketPath
 	};
 
-	requestOptions.headers = <{ [key: string]: string }> options.headers || {};
+	requestOptions.headers = <{ [key: string]: string }>options.headers || {};
 
-	if (!Object.keys(requestOptions.headers).map(headerName => headerName.toLowerCase()).some(headerName => headerName === 'user-agent')) {
-		requestOptions.headers[ 'user-agent' ] = 'dojo/' + version + ' Node.js/' + process.version.replace(/^v/, '');
+	if (
+		!Object.keys(requestOptions.headers)
+			.map((headerName) => headerName.toLowerCase())
+			.some((headerName) => headerName === 'user-agent')
+	) {
+		requestOptions.headers['user-agent'] = 'dojo/' + version + ' Node.js/' + process.version.replace(/^v/, '');
 	}
 
 	if (options.proxy) {
 		requestOptions.path = url;
 		if (parsedUrl.auth) {
-			requestOptions.headers[ 'proxy-authorization' ] = 'Basic ' + new Buffer(parsedUrl.auth).toString('base64');
+			requestOptions.headers['proxy-authorization'] = 'Basic ' + new Buffer(parsedUrl.auth).toString('base64');
 		}
 
 		const parsedProxyUrl = urlUtil.parse(url);
 		if (parsedProxyUrl.host) {
-			requestOptions.headers[ 'host' ] = parsedProxyUrl.host;
+			requestOptions.headers['host'] = parsedProxyUrl.host;
 		}
 
 		if (parsedProxyUrl.auth) {
@@ -370,273 +390,275 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 
 	const { acceptCompression = true } = options;
 	if (acceptCompression) {
-		requestOptions.headers[ 'Accept-Encoding' ] = 'gzip, deflate';
+		requestOptions.headers['Accept-Encoding'] = 'gzip, deflate';
 	}
 
 	const request = parsedUrl.protocol === 'https:' ? https.request(requestOptions) : http.request(requestOptions);
 
 	const uploadObserverPool = new SubscriptionPool<number>();
 
-	const requestTask = <UploadObservableTask<NodeResponse>> new Task<NodeResponse>((resolve, reject) => {
-		let timeoutHandle: Handle;
-		let timeoutReject: Function = reject;
+	const requestTask = <UploadObservableTask<NodeResponse>>new Task<NodeResponse>(
+		(resolve, reject) => {
+			let timeoutHandle: Handle;
+			let timeoutReject: Function = reject;
 
-		if (options.socketOptions) {
-			if (options.socketOptions.timeout) {
-				request.setTimeout(options.socketOptions.timeout);
-			}
+			if (options.socketOptions) {
+				if (options.socketOptions.timeout) {
+					request.setTimeout(options.socketOptions.timeout);
+				}
 
-			if ('noDelay' in options.socketOptions) {
-				request.setNoDelay(options.socketOptions.noDelay);
-			}
+				if ('noDelay' in options.socketOptions) {
+					request.setNoDelay(options.socketOptions.noDelay);
+				}
 
-			if ('keepAlive' in options.socketOptions) {
-				const initialDelay: number | undefined = options.socketOptions.keepAlive;
-				if (initialDelay !== undefined) {
-					request.setSocketKeepAlive(initialDelay >= 0, initialDelay);
+				if ('keepAlive' in options.socketOptions) {
+					const initialDelay: number | undefined = options.socketOptions.keepAlive;
+					if (initialDelay !== undefined) {
+						request.setSocketKeepAlive(initialDelay >= 0, initialDelay);
+					}
 				}
 			}
-		}
 
-		request.once('response', (message: http.IncomingMessage) => {
-			const response = new NodeResponse(message);
+			request.once('response', (message: http.IncomingMessage) => {
+				const response = new NodeResponse(message);
 
-			// Redirection handling defaults to true in order to harmonise with the XHR provider, which will always
-			// follow redirects
-			if (
-				response.status >= 300 &&
-				response.status < 400
-			) {
-				const redirectOptions = options.redirectOptions || {};
-				const newOptions = deepAssign({}, options);
+				// Redirection handling defaults to true in order to harmonise with the XHR provider, which will always
+				// follow redirects
+				if (response.status >= 300 && response.status < 400) {
+					const redirectOptions = options.redirectOptions || {};
+					const newOptions = deepAssign({}, options);
 
-				switch (response.status) {
-					case 300:
-						/**
-						 * Note about 300 redirects. RFC 2616 doesn't specify what to do with them, it is up to the client to "pick
-						 * the right one".  We're picking like Chrome does, just don't pick any.
-						 */
-						break;
+					switch (response.status) {
+						case 300:
+							/**
+							 * Note about 300 redirects. RFC 2616 doesn't specify what to do with them, it is up to the client to "pick
+							 * the right one".  We're picking like Chrome does, just don't pick any.
+							 */
+							break;
 
-					case 301:
-					case 302:
-						/**
-						 * RFC 2616 says,
-						 *
-						 *     If the 301 status code is received in response to a request other
-						 *     than GET or HEAD, the user agent MUST NOT automatically redirect the
-						 *     request unless it can be confirmed by the user, since this might
-						 *       change the conditions under which the request was issued.
-						 *
-						 *     Note: When automatically redirecting a POST request after
-						 *     receiving a 301 status code, some existing HTTP/1.0 user agents
-						 *     will erroneously change it into a GET request.
-						 *
-						 * We're going to be one of those erroneous agents, to prevent the request from failing..
-						 */
-						if ((requestOptions.method !== 'GET' && requestOptions.method !== 'HEAD') && !redirectOptions.keepOriginalMethod) {
-							newOptions.method = 'GET';
-						}
+						case 301:
+						case 302:
+							/**
+							 * RFC 2616 says,
+							 *
+							 *     If the 301 status code is received in response to a request other
+							 *     than GET or HEAD, the user agent MUST NOT automatically redirect the
+							 *     request unless it can be confirmed by the user, since this might
+							 *       change the conditions under which the request was issued.
+							 *
+							 *     Note: When automatically redirecting a POST request after
+							 *     receiving a 301 status code, some existing HTTP/1.0 user agents
+							 *     will erroneously change it into a GET request.
+							 *
+							 * We're going to be one of those erroneous agents, to prevent the request from failing..
+							 */
+							if (
+								requestOptions.method !== 'GET' &&
+								requestOptions.method !== 'HEAD' &&
+								!redirectOptions.keepOriginalMethod
+							) {
+								newOptions.method = 'GET';
+							}
 
-						if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
-							return;
-						}
-						break;
-
-					case 303:
-
-						/**
-						 * The response to the request can be found under a different URI and
-						 * SHOULD be retrieved using a GET method on that resource.
-						 */
-						if (requestOptions.method !== 'GET') {
-							newOptions.method = 'GET';
-						}
-
-						if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
-							return;
-						}
-						break;
-
-					case 304:
-						// do nothing so this can fall through and return the response as normal. Nothing more can
-						// be done for 304
-						break;
-
-					case 305:
-						if (!response.headers.get('location')) {
-							reject(new Error('expected Location header to contain a proxy url'));
-						}
-						else {
-							newOptions.proxy = response.headers.get('location') || '';
-							if (redirect(resolve, reject, url, '', newOptions)) {
+							if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
 								return;
 							}
-						}
-						break;
+							break;
 
-					case 307:
-						/**
-						 *  If the 307 status code is received in response to a request other
-						 *  than GET or HEAD, the user agent MUST NOT automatically redirect the
-						 *  request unless it can be confirmed by the user, since this might
-						 *  change the conditions under which the request was issued.
-						 */
-						if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
+						case 303:
+							/**
+							 * The response to the request can be found under a different URI and
+							 * SHOULD be retrieved using a GET method on that resource.
+							 */
+							if (requestOptions.method !== 'GET') {
+								newOptions.method = 'GET';
+							}
+
+							if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
+								return;
+							}
+							break;
+
+						case 304:
+							// do nothing so this can fall through and return the response as normal. Nothing more can
+							// be done for 304
+							break;
+
+						case 305:
+							if (!response.headers.get('location')) {
+								reject(new Error('expected Location header to contain a proxy url'));
+							} else {
+								newOptions.proxy = response.headers.get('location') || '';
+								if (redirect(resolve, reject, url, '', newOptions)) {
+									return;
+								}
+							}
+							break;
+
+						case 307:
+							/**
+							 *  If the 307 status code is received in response to a request other
+							 *  than GET or HEAD, the user agent MUST NOT automatically redirect the
+							 *  request unless it can be confirmed by the user, since this might
+							 *  change the conditions under which the request was issued.
+							 */
+							if (redirect(resolve, reject, url, response.headers.get('location'), newOptions)) {
+								return;
+							}
+							break;
+
+						default:
+							reject(new Error('unhandled redirect status ' + response.status));
 							return;
-						}
-						break;
-
-					default:
-						reject(new Error('unhandled redirect status ' + response.status));
-						return;
+					}
 				}
-			}
 
-			options.streamEncoding && message.setEncoding(options.streamEncoding);
+				options.streamEncoding && message.setEncoding(options.streamEncoding);
 
-			const downloadSubscriptionPool = new SubscriptionPool<number>();
-			const dataSubscriptionPool = new SubscriptionPool<any>();
+				const downloadSubscriptionPool = new SubscriptionPool<number>();
+				const dataSubscriptionPool = new SubscriptionPool<any>();
 
-			/*
+				/*
 			 [RFC 2616](https://tools.ietf.org/html/rfc2616#page-118) says that content-encoding can have multiple
 			 values, so we split them here and put them in a list to process later.
 			 */
-			const contentEncodings = response.headers.getAll('content-encoding');
+				const contentEncodings = response.headers.getAll('content-encoding');
 
-			const task = new Task<http.IncomingMessage>((resolve, reject) => {
-				timeoutReject = reject;
+				const task = new Task<http.IncomingMessage>(
+					(resolve, reject) => {
+						timeoutReject = reject;
 
-				// we queue this up for later to allow listeners to register themselves before we start receiving data
-				queueTask(() => {
-					/*
+						// we queue this up for later to allow listeners to register themselves before we start receiving data
+						queueTask(() => {
+							/*
 					 * Note that this is the raw data, if your input stream is zipped, and you are piecing
 					 * together the downloaded data, you'll have to decompress it yourself
 					 */
-					message.on('data', (chunk: any) => {
-						dataSubscriptionPool.next(chunk);
+							message.on('data', (chunk: any) => {
+								dataSubscriptionPool.next(chunk);
 
-						if (response.downloadBody) {
-							data.buffer.push(chunk);
-						}
+								if (response.downloadBody) {
+									data.buffer.push(chunk);
+								}
 
-						data.size += typeof chunk === 'string' ?
-							Buffer.byteLength(chunk, options.streamEncoding) :
-							chunk.length;
+								data.size +=
+									typeof chunk === 'string'
+										? Buffer.byteLength(chunk, options.streamEncoding)
+										: chunk.length;
 
-						downloadSubscriptionPool.next(data.size);
-					});
+								downloadSubscriptionPool.next(data.size);
+							});
 
-					message.once('end', () => {
-						timeoutHandle && timeoutHandle.destroy();
+							message.once('end', () => {
+								timeoutHandle && timeoutHandle.destroy();
 
-						let dataAsBuffer = (options.streamEncoding ? new Buffer(data.buffer.join(''), 'utf8') : Buffer.concat(data.buffer, data.size));
+								let dataAsBuffer = options.streamEncoding
+									? new Buffer(data.buffer.join(''), 'utf8')
+									: Buffer.concat(data.buffer, data.size);
 
-						const handleEncoding = function () {
-							/*
+								const handleEncoding = function() {
+									/*
 							 Content encoding is ordered by the order in which they were applied to the
 							 content, so do undo the encoding we have to start at the end and work backwards.
 							 */
-							if (contentEncodings.length) {
-								const encoding = contentEncodings.pop()!.trim().toLowerCase();
+									if (contentEncodings.length) {
+										const encoding = contentEncodings.pop()!.trim().toLowerCase();
 
-								if (encoding === '' || encoding === 'none' || encoding === 'identity') {
-									// do nothing, response stream is as-is
-									handleEncoding();
-								}
-								else if (encoding === 'gzip') {
-									zlib.gunzip(dataAsBuffer, function (err: Error | null, result: Buffer) {
-										if (err) {
-											reject(err);
+										if (encoding === '' || encoding === 'none' || encoding === 'identity') {
+											// do nothing, response stream is as-is
+											handleEncoding();
+										} else if (encoding === 'gzip') {
+											zlib.gunzip(dataAsBuffer, function(err: Error | null, result: Buffer) {
+												if (err) {
+													reject(err);
+												}
+
+												dataAsBuffer = result;
+												handleEncoding();
+											});
+										} else if (encoding === 'deflate') {
+											zlib.inflate(dataAsBuffer, function(err: Error | null, result: Buffer) {
+												if (err) {
+													reject(err);
+												}
+
+												dataAsBuffer = result;
+												handleEncoding();
+											});
+										} else {
+											reject(new Error('Unsupported content encoding, ' + encoding));
 										}
+									} else {
+										data.data = dataAsBuffer;
 
-										dataAsBuffer = result;
-										handleEncoding();
-									});
-								}
-								else if (encoding === 'deflate') {
-									zlib.inflate(dataAsBuffer, function (err: Error | null, result: Buffer) {
-										if (err) {
-											reject(err);
-										}
+										resolve(message);
+									}
+								};
 
-										dataAsBuffer = result;
-										handleEncoding();
-									});
-								}
-								else {
-									reject(new Error('Unsupported content encoding, ' + encoding));
-								}
-							}
-							else {
-								data.data = dataAsBuffer;
+								handleEncoding();
+							});
+						});
+					},
+					() => {
+						request.abort();
+					}
+				);
 
-								resolve(message);
-							}
-						};
+				const data: RequestData = {
+					task,
+					buffer: [],
+					data: Buffer.alloc(0),
+					size: 0,
+					used: false,
+					url: url,
+					requestOptions: options,
+					nativeResponse: message,
+					downloadObservable: new Observable<number>((observer) => downloadSubscriptionPool.add(observer)),
+					dataObservable: new Observable<any>((observer) => dataSubscriptionPool.add(observer))
+				};
 
-						handleEncoding();
-					});
+				dataMap.set(response, data);
+
+				resolve(response);
+			});
+
+			request.once('error', reject);
+
+			if (options.bodyStream) {
+				options.bodyStream.pipe(request);
+				let uploadedSize = 0;
+
+				options.bodyStream.on('data', (chunk: any) => {
+					uploadedSize += chunk.length;
+					uploadObserverPool.next(uploadedSize);
 				});
-			}, () => {
-				request.abort();
-			});
 
-			const data: RequestData = {
-				task,
-				buffer: [],
-				data: Buffer.alloc(0),
-				size: 0,
-				used: false,
-				url: url,
-				requestOptions: options,
-				nativeResponse: message,
-				downloadObservable: new Observable<number>(observer => downloadSubscriptionPool.add(observer)),
-				dataObservable: new Observable<any>(observer => dataSubscriptionPool.add(observer))
-			};
+				options.bodyStream.on('end', () => {
+					uploadObserverPool.complete();
+					request.end();
+				});
+			} else if (options.body) {
+				const body = options.body.toString();
 
-			dataMap.set(response, data);
+				request.on('response', () => {
+					uploadObserverPool.next(body.length);
+				});
 
-			resolve(response);
-		});
-
-		request.once('error', reject);
-
-		if (options.bodyStream) {
-			options.bodyStream.pipe(request);
-			let uploadedSize = 0;
-
-			options.bodyStream.on('data', (chunk: any) => {
-				uploadedSize += chunk.length;
-				uploadObserverPool.next(uploadedSize);
-			});
-
-			options.bodyStream.on('end', () => {
-				uploadObserverPool.complete();
+				request.end(body);
+			} else {
 				request.end();
-			});
-		}
-		else if (options.body) {
-			const body = options.body.toString();
+			}
 
-			request.on('response', () => {
-				uploadObserverPool.next(body.length);
-			});
-
-			request.end(body);
+			if (options.timeout && options.timeout > 0 && options.timeout !== Infinity) {
+				timeoutHandle = createTimer(() => {
+					timeoutReject && timeoutReject(new TimeoutError('The request timed out'));
+				}, options.timeout);
+			}
+		},
+		() => {
+			request.abort();
 		}
-		else {
-			request.end();
-		}
-
-		if (options.timeout && options.timeout > 0 && options.timeout !== Infinity) {
-			timeoutHandle = createTimer(() => {
-				timeoutReject && timeoutReject(new TimeoutError('The request timed out'));
-			}, options.timeout);
-		}
-	}, () => {
-		request.abort();
-	}).catch(function (error: Error): any {
+	).catch(function(error: Error): any {
 		const parsedUrl = urlUtil.parse(url);
 
 		if (parsedUrl.auth) {
@@ -649,7 +671,7 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 		throw error;
 	});
 
-	requestTask.upload = new Observable<number>(observer => uploadObserverPool.add(observer));
+	requestTask.upload = new Observable<number>((observer) => uploadObserverPool.add(observer));
 
 	return requestTask;
 }

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -87,7 +87,7 @@ export class XhrResponse extends Response {
 	constructor(request: XMLHttpRequest) {
 		super();
 
-		const headers = this.headers = new Headers();
+		const headers = (this.headers = new Headers());
 
 		const responseHeaders = request.getAllResponseHeaders();
 		if (responseHeaders) {
@@ -119,13 +119,13 @@ export class XhrResponse extends Response {
 	}
 
 	text(): Task<string> {
-		return <any> getDataTask(this).then((request: XMLHttpRequest) => {
+		return <any>getDataTask(this).then((request: XMLHttpRequest) => {
 			return String(request.responseText);
 		});
 	}
 
 	xml(): Task<Document> {
-		return <any> this.text().then((text: string) => {
+		return <any>this.text().then((text: string) => {
 			const parser = new DOMParser();
 			return parser.parseFromString(text, this.headers.get('content-type') || 'text/html');
 		});
@@ -133,45 +133,48 @@ export class XhrResponse extends Response {
 }
 
 if (has('blob')) {
-	XhrResponse.prototype.blob = function (this: XhrResponse): Task<Blob> {
-		return <any> getDataTask(this).then((request: XMLHttpRequest) => request.response);
+	XhrResponse.prototype.blob = function(this: XhrResponse): Task<Blob> {
+		return <any>getDataTask(this).then((request: XMLHttpRequest) => request.response);
 	};
 
-	XhrResponse.prototype.text = function (this: XhrResponse): Task<string> {
-		return <any> this.blob().then(getTextFromBlob);
+	XhrResponse.prototype.text = function(this: XhrResponse): Task<string> {
+		return <any>this.blob().then(getTextFromBlob);
 	};
 
 	if (has('arraybuffer')) {
-		XhrResponse.prototype.arrayBuffer = function (this: XhrResponse): Task<ArrayBuffer> {
-			return <any> this.blob().then(getArrayBufferFromBlob);
+		XhrResponse.prototype.arrayBuffer = function(this: XhrResponse): Task<ArrayBuffer> {
+			return <any>this.blob().then(getArrayBufferFromBlob);
 		};
 	}
 }
 
 if (has('formdata')) {
-	XhrResponse.prototype.formData = function (this: XhrResponse): Task<FormData> {
-		return <any> this.text().then((text: string) => {
+	XhrResponse.prototype.formData = function(this: XhrResponse): Task<FormData> {
+		return <any>this.text().then((text: string) => {
 			const data = new FormData();
 
-			text.trim().split('&').forEach(keyValues => {
-				if (keyValues) {
-					const pairs = keyValues.split('=');
-					const name = (pairs.shift() || '').replace(/\+/, ' ');
-					const value = pairs.join('=').replace(/\+/, ' ');
+			text
+				.trim()
+				.split('&')
+				.forEach((keyValues) => {
+					if (keyValues) {
+						const pairs = keyValues.split('=');
+						const name = (pairs.shift() || '').replace(/\+/, ' ');
+						const value = pairs.join('=').replace(/\+/, ' ');
 
-					data.append(decodeURIComponent(name), decodeURIComponent(value));
-				}
-			});
+						data.append(decodeURIComponent(name), decodeURIComponent(value));
+					}
+				});
 
 			return data;
 		});
 	};
 }
 
-function noop () {}
+function noop() {}
 
 function setOnError(request: XMLHttpRequest, reject: Function) {
-	request.addEventListener('error', function (event) {
+	request.addEventListener('error', function(event) {
 		reject(new TypeError(event.error || 'Network request failed'));
 	});
 }
@@ -199,10 +202,10 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 	let timeoutHandle: Handle;
 	let timeoutReject: Function;
 
-	const task = <UploadObservableTask<XhrResponse>> new Task<XhrResponse>((resolve, reject) => {
+	const task = <UploadObservableTask<XhrResponse>>new Task<XhrResponse>((resolve, reject) => {
 		timeoutReject = reject;
 
-		request.onreadystatechange = function () {
+		request.onreadystatechange = function() {
 			if (isAborted) {
 				return;
 			}
@@ -216,7 +219,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 				const task = new Task<XMLHttpRequest>((resolve, reject) => {
 					timeoutReject = reject;
 
-					request.onprogress = function (event: any) {
+					request.onprogress = function(event: any) {
 						if (isAborted) {
 							return;
 						}
@@ -224,7 +227,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 						downloadSubscriptionPool.next(event.loaded);
 					};
 
-					request.onreadystatechange = function () {
+					request.onreadystatechange = function() {
 						if (isAborted) {
 							return;
 						}
@@ -249,8 +252,8 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 					nativeResponse: request,
 					requestOptions: options,
 					url: requestUrl,
-					downloadObservable: new Observable<number>(observer => downloadSubscriptionPool.add(observer)),
-					dataObservable: new Observable<any>(observer => dataSubscriptionPool.add(observer))
+					downloadObservable: new Observable<number>((observer) => downloadSubscriptionPool.add(observer)),
+					dataObservable: new Observable<any>((observer) => dataSubscriptionPool.add(observer))
 				});
 
 				resolve(response);
@@ -258,7 +261,6 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 		};
 
 		setOnError(request, reject);
-
 	}, abort);
 
 	request.open(options.method, requestUrl, !options.blockMainThread, options.user, options.password);
@@ -310,10 +312,10 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 	});
 
 	const uploadObserverPool = new SubscriptionPool<number>();
-	task.upload = new Observable<number>(observer => uploadObserverPool.add(observer));
+	task.upload = new Observable<number>((observer) => uploadObserverPool.add(observer));
 
 	if (has('host-browser') || has('web-worker-xhr-upload')) {
-		request.upload.addEventListener('progress', event => {
+		request.upload.addEventListener('progress', (event) => {
 			uploadObserverPool.next(event.loaded);
 		});
 	}

--- a/src/stringExtras.ts
+++ b/src/stringExtras.ts
@@ -8,7 +8,7 @@ const escapeXmlMap: Hash<string> = {
 	'<': '&lt;',
 	'>': '&gt;',
 	'"': '&quot;',
-	'\'': '&#39;'
+	"'": '&#39;'
 };
 
 /**
@@ -33,7 +33,7 @@ export function escapeXml(xml: string, forAttribute: boolean = true): string {
 
 	const pattern = forAttribute ? escapeXmlForPattern : escapeXmlPattern;
 
-	return xml.replace(pattern, function (character: string): string {
+	return xml.replace(pattern, function(character: string): string {
 		return escapeXmlMap[character];
 	});
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -30,15 +30,14 @@ let getText: (url: string, callback: (value: string | null) => void) => void;
 
 if (has('host-browser')) {
 	getText = function(url: string, callback: (value: string | null) => void): void {
-		request(url).then(response => {
-			response.text().then(data => {
+		request(url).then((response) => {
+			response.text().then((data) => {
 				callback(data);
 			});
 		});
 	};
-}
-else if (has('host-node')) {
-	let fs = isAmdRequire(require) && require.nodeRequire ? require.nodeRequire('fs') : (<NodeRequire> require)('fs');
+} else if (has('host-node')) {
+	let fs = isAmdRequire(require) && require.nodeRequire ? require.nodeRequire('fs') : (<NodeRequire>require)('fs');
 	getText = function(url: string, callback: (value: string) => void): void {
 		fs.readFile(url, { encoding: 'utf8' }, function(error: Error, data: string): void {
 			if (error) {
@@ -48,8 +47,7 @@ else if (has('host-node')) {
 			callback(data);
 		});
 	};
-}
-else {
+} else {
 	getText = function(): void {
 		throw new Error('dojo/text not supported on this platform');
 	};
@@ -58,16 +56,16 @@ else {
 /*
  * Cache of previously-loaded text resources
  */
-let textCache: { [key: string]: any; } = {};
+let textCache: { [key: string]: any } = {};
 
 /*
  * Cache of pending text resources
  */
-let pending: { [key: string]: any; } = {};
+let pending: { [key: string]: any } = {};
 
-export function get(url: string): Promise <string | null> {
-	let promise = new Promise<string | null>(function (resolve, reject) {
-		getText(url, function (text) {
+export function get(url: string): Promise<string | null> {
+	let promise = new Promise<string | null>(function(resolve, reject) {
+		getText(url, function(text) {
 			resolve(text);
 		});
 	});
@@ -95,8 +93,7 @@ export function load(id: string, require: AmdRequire, load: (value?: any) => voi
 
 	if (mid in textCache) {
 		text = textCache[mid];
-	}
-	else if (url in textCache) {
+	} else if (url in textCache) {
 		text = textCache[url];
 	}
 
@@ -104,7 +101,7 @@ export function load(id: string, require: AmdRequire, load: (value?: any) => voi
 		if (pending[url]) {
 			pending[url].push(finish);
 		} else {
-			let pendingList = pending[url] = [finish];
+			let pendingList = (pending[url] = [finish]);
 			getText(url, function(value) {
 				textCache[mid] = textCache[url] = value;
 				for (let i = 0; i < pendingList.length; ) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,7 +11,7 @@ import { createHandle } from './lang';
 export function createTimer(callback: (...args: any[]) => void, delay?: number): Handle {
 	let timerId: number | null = setTimeout(callback, delay);
 
-	return createHandle(function () {
+	return createHandle(function() {
 		if (timerId) {
 			clearTimeout(timerId);
 			timerId = null;
@@ -31,13 +31,13 @@ export function debounce<T extends (this: any, ...args: any[]) => void>(callback
 	// but browsers return/receive a number
 	let timer: Handle | null;
 
-	return <T> function () {
+	return <T>function() {
 		timer && timer.destroy();
 
 		let context = this;
 		let args: IArguments | null = arguments;
 
-		timer = guaranteeMinimumTimeout(function () {
+		timer = guaranteeMinimumTimeout(function() {
 			callback.apply(context, args);
 			args = context = timer = null;
 		}, delay);
@@ -54,7 +54,7 @@ export function debounce<T extends (this: any, ...args: any[]) => void>(callback
 export function throttle<T extends (this: any, ...args: any[]) => void>(callback: T, delay: number): T {
 	let ran: boolean | null;
 
-	return <T> function () {
+	return <T>function() {
 		if (ran) {
 			return;
 		}
@@ -62,7 +62,7 @@ export function throttle<T extends (this: any, ...args: any[]) => void>(callback
 		ran = true;
 
 		callback.apply(this, arguments);
-		guaranteeMinimumTimeout(function () {
+		guaranteeMinimumTimeout(function() {
 			ran = null;
 		}, delay);
 	};
@@ -79,7 +79,7 @@ export function throttle<T extends (this: any, ...args: any[]) => void>(callback
 export function throttleAfter<T extends (this: any, ...args: any[]) => void>(callback: T, delay: number): T {
 	let ran: boolean | null;
 
-	return <T> function () {
+	return <T>function() {
 		if (ran) {
 			return;
 		}
@@ -89,7 +89,7 @@ export function throttleAfter<T extends (this: any, ...args: any[]) => void>(cal
 		let context = this;
 		let args: IArguments | null = arguments;
 
-		guaranteeMinimumTimeout(function () {
+		guaranteeMinimumTimeout(function() {
 			callback.apply(context, args);
 			args = context = ran = null;
 		}, delay);
@@ -109,7 +109,7 @@ export function guaranteeMinimumTimeout(callback: (...args: any[]) => void, dela
 			// it thinks we are using the Node version of setTimeout.
 			// Revisit this with the next TypeScript update.
 			// Set another timer for the mount of time that we came up short.
-			timerId = <any> setTimeout(timeoutHandler, delay - delta);
+			timerId = <any>setTimeout(timeoutHandler, delay - delta);
 		}
 	}
 	timerId = setTimeout(timeoutHandler, delay);

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -4,8 +4,9 @@
  * @returns {string}
  */
 export default function uuid(): string {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-		const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+		const r = (Math.random() * 16) | 0,
+			v = c === 'x' ? r : (r & 0x3) | 0x8;
 		return v.toString(16);
 	});
 }

--- a/tests/benchmark/lang.ts
+++ b/tests/benchmark/lang.ts
@@ -7,31 +7,33 @@ function onComplete(this: any) {
 
 const simpleSource = { a: 1, b: 'Lorem ipsum', c: 4 };
 const simpleSourceWithArray = {
-		a: 1,
-		b: 'Dolor sit amet.',
-		c: [ 1, 2, 3 ],
-		d: 5
-	};
-const sourceFromConstructor = (function () {
-		function Answers(this: any, kwArgs: { [key: string]: any }) {
-			Object.keys(kwArgs).forEach(function (this: any, key: string): void {
-				(<any> this)[key] = kwArgs[key];
-			}, this);
-		}
+	a: 1,
+	b: 'Dolor sit amet.',
+	c: [1, 2, 3],
+	d: 5
+};
+const sourceFromConstructor = (function() {
+	function Answers(this: any, kwArgs: { [key: string]: any }) {
+		Object.keys(kwArgs).forEach(function(this: any, key: string): void {
+			(<any>this)[key] = kwArgs[key];
+		}, this);
+	}
 
-		return new (<any> Answers)({
-			universe: 42
-		});
-	})();
-const sourceWithInherited = Object.create(Object.create(null, {
+	return new (<any>Answers)({
+		universe: 42
+	});
+})();
+const sourceWithInherited = Object.create(
+	Object.create(null, {
 		x: {
-			value: ('1234567890').split('')
+			value: '1234567890'.split('')
 		},
 		y: {
 			enumerable: true,
 			value: /\s/
 		}
-	}), {
+	}),
+	{
 		a: {
 			value: 1,
 			enumerable: true,
@@ -56,133 +58,212 @@ const sourceWithInherited = Object.create(Object.create(null, {
 			configurable: true,
 			writable: true
 		}
-	});
+	}
+);
 
 let benchmarks: Benchmark[] = [];
 
-benchmarks.push(new Benchmark('lang.assign (single source)', function () {
-		lang.assign(Object.create(null), simpleSource);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.assign (single source)',
+		function() {
+			lang.assign(Object.create(null), simpleSource);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.assign (multiple sources)', function () {
-		lang.assign(
-			Object.create(null),
-			simpleSource,
-			simpleSourceWithArray,
-			sourceWithInherited,
-			sourceFromConstructor
-		);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.assign (multiple sources)',
+		function() {
+			lang.assign(
+				Object.create(null),
+				simpleSource,
+				simpleSourceWithArray,
+				sourceWithInherited,
+				sourceFromConstructor
+			);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.deepAssign (single source)', function () {
-		lang.deepAssign(Object.create(null), simpleSource);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.deepAssign (single source)',
+		function() {
+			lang.deepAssign(Object.create(null), simpleSource);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.deepAssign (multiple sources)', function () {
-		lang.deepAssign(
-			Object.create(null),
-			simpleSource,
-			simpleSourceWithArray,
-			sourceWithInherited,
-			sourceFromConstructor
-		);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.deepAssign (multiple sources)',
+		function() {
+			lang.deepAssign(
+				Object.create(null),
+				simpleSource,
+				simpleSourceWithArray,
+				sourceWithInherited,
+				sourceFromConstructor
+			);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.mixin (single source)', function () {
-		lang.mixin(Object.create(null), simpleSource);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.mixin (single source)',
+		function() {
+			lang.mixin(Object.create(null), simpleSource);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.mixin (multiple sources)', function () {
-		lang.mixin(
-			Object.create(null),
-			simpleSource,
-			simpleSourceWithArray,
-			sourceWithInherited,
-			sourceFromConstructor
-		);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.mixin (multiple sources)',
+		function() {
+			lang.mixin(
+				Object.create(null),
+				simpleSource,
+				simpleSourceWithArray,
+				sourceWithInherited,
+				sourceFromConstructor
+			);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.deepMixin (single source)', function () {
-		lang.deepMixin(Object.create(null), simpleSource);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.deepMixin (single source)',
+		function() {
+			lang.deepMixin(Object.create(null), simpleSource);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.deepMixin (multiple sources)', function () {
-		lang.deepMixin(
-			Object.create(null),
-			simpleSource,
-			simpleSourceWithArray,
-			sourceWithInherited,
-			sourceFromConstructor
-		);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.deepMixin (multiple sources)',
+		function() {
+			lang.deepMixin(
+				Object.create(null),
+				simpleSource,
+				simpleSourceWithArray,
+				sourceWithInherited,
+				sourceFromConstructor
+			);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.create', function () {
-		lang.create(simpleSource, simpleSource, simpleSource, simpleSource);
-	}, {
-		onComplete: onComplete
-	}));
+benchmarks.push(
+	new Benchmark(
+		'lang.create',
+		function() {
+			lang.create(simpleSource, simpleSource, simpleSource, simpleSource);
+		},
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.isIdentical', (function () {
-	let a = Number('asdfx{}');
-	let b = Number('xkcd');
+benchmarks.push(
+	new Benchmark(
+		'lang.isIdentical',
+		(function() {
+			let a = Number('asdfx{}');
+			let b = Number('xkcd');
 
-	return function () {
-		lang.isIdentical(a, b);
-	};
-})(), {
-	onComplete: onComplete
-}));
+			return function() {
+				lang.isIdentical(a, b);
+			};
+		})(),
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.lateBind', (function () {
-	let object: any = {
-		method: function () {}
-	};
+benchmarks.push(
+	new Benchmark(
+		'lang.lateBind',
+		(function() {
+			let object: any = {
+				method: function() {}
+			};
 
-	return function () {
-		lang.lateBind(object, 'method');
-	};
-})(), {
-	onComplete: onComplete
-}));
+			return function() {
+				lang.lateBind(object, 'method');
+			};
+		})(),
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.lateBind (partial application)', (function () {
-	let object: any = {
-		method: function () {}
-	};
+benchmarks.push(
+	new Benchmark(
+		'lang.lateBind (partial application)',
+		(function() {
+			let object: any = {
+				method: function() {}
+			};
 
-	return function () {
-		lang.lateBind(object, 'method', 1, 2, 3);
-	};
-})(), {
-	onComplete: onComplete
-}));
+			return function() {
+				lang.lateBind(object, 'method', 1, 2, 3);
+			};
+		})(),
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.push(new Benchmark('lang.partial', (function () {
-	function f() {}
+benchmarks.push(
+	new Benchmark(
+		'lang.partial',
+		(function() {
+			function f() {}
 
-	return function () {
-		lang.partial(f, 1, 2, 3);
-	};
-})(), {
-	onComplete: onComplete
-}));
+			return function() {
+				lang.partial(f, 1, 2, 3);
+			};
+		})(),
+		{
+			onComplete: onComplete
+		}
+	)
+);
 
-benchmarks.forEach(function (benchmark: Benchmark): void {
+benchmarks.forEach(function(benchmark: Benchmark): void {
 	benchmark.run();
 });

--- a/tests/benchmark/stringExtras.ts
+++ b/tests/benchmark/stringExtras.ts
@@ -2,9 +2,9 @@ import Benchmark = require('benchmark');
 
 let benchmarks: any[] = [];
 
-benchmarks.forEach(function (benchmark: any): void {
+benchmarks.forEach(function(benchmark: any): void {
 	new Benchmark(benchmark.name, benchmark.fn, {
-		onComplete: function (this: any) {
+		onComplete: function(this: any) {
 			console.log(this.name + ': ' + this.hz + ' with a margin of error of ' + this.stats.moe);
 		}
 	}).run();

--- a/tests/functional/text/textPlugin.ts
+++ b/tests/functional/text/textPlugin.ts
@@ -8,11 +8,16 @@ declare const require: Require;
 
 async function executeTest(test: Test, htmlTestPath: string, timeout = 10000) {
 	try {
-		return await test.remote.get(htmlTestPath).then(pollUntil<{ text: string; }>(function () {
-			return (<any> window).loaderTestResults || null;
-		}, undefined, timeout));
-	}
-	catch (e) {
+		return await test.remote.get(htmlTestPath).then(
+			pollUntil<{ text: string }>(
+				function() {
+					return (<any>window).loaderTestResults || null;
+				},
+				undefined,
+				timeout
+			)
+		);
+	} catch (e) {
 		throw new Error('loaderTestResult was not set.');
 	}
 }

--- a/tests/functional/text/textPlugin.ts
+++ b/tests/functional/text/textPlugin.ts
@@ -1,10 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import Test from 'intern/lib/Test';
-import { Require } from '../../../src/load';
 import pollUntil from '@theintern/leadfoot/helpers/pollUntil';
-
-declare const require: Require;
 
 async function executeTest(test: Test, htmlTestPath: string, timeout = 10000) {
 	try {

--- a/tests/plugins/echo-service.ts
+++ b/tests/plugins/echo-service.ts
@@ -3,8 +3,8 @@ import * as multer from 'multer';
 import * as path from 'path';
 
 intern.registerPlugin('echo-service', () => {
-	intern.on('serverStart', server => {
-		const app: express.Express = (<any> server)._app;
+	intern.on('serverStart', (server) => {
+		const app: express.Express = (<any>server)._app;
 		const echo = express();
 		const upload = multer();
 
@@ -18,30 +18,29 @@ intern.registerPlugin('echo-service', () => {
 
 		echo.post('/post', upload.any());
 
-		echo.use(
-			(request, response, next) => {
-				const responseType: string | undefined = request.query.responseType;
-				if (!responseType || responseType.localeCompare('json') === 0) {
-					response.status(200).type('json').send({
+		echo.use((request, response, next) => {
+			const responseType: string | undefined = request.query.responseType;
+			if (!responseType || responseType.localeCompare('json') === 0) {
+				response
+					.status(200)
+					.type('json')
+					.send({
 						method: request.method,
 						query: request.query,
 						headers: request.headers,
 						payload: request.files || request.body
 					});
+			} else {
+				if (responseType.localeCompare('xml') === 0) {
+					response.sendFile(path.resolve(__dirname, '..', 'support', 'data', 'foo.xml'));
+					return;
 				}
-				else {
-					if (responseType.localeCompare('xml') === 0) {
-						response.sendFile(path.resolve(__dirname, '..', 'support', 'data', 'foo.xml'));
-						return;
-					}
-					next();
-				}
-			},
-			express.static(path.resolve(__dirname, '..', 'support', 'data'), { fallthrough: false })
-		);
+				next();
+			}
+		}, express.static(path.resolve(__dirname, '..', 'support', 'data'), { fallthrough: false }));
 
 		// A hack until Intern allows custom middleware
-		const stack: any[] = (<any> app)._router.stack;
+		const stack: any[] = (<any>app)._router.stack;
 		const layers = stack.splice(stack.length - 3);
 
 		app.use('/__echo', echo);

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -1,9 +1,12 @@
 export function isEventuallyRejected<T>(promise: PromiseLike<T>): PromiseLike<boolean> {
-	return promise.then(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {
@@ -20,5 +23,5 @@ export function hasClassName(): boolean {
 		return _hasClassName;
 	}
 	class Foo {}
-	return _hasClassName = Boolean((<any> Foo.constructor).name);
+	return (_hasClassName = Boolean((<any>Foo.constructor).name));
 }

--- a/tests/unit/DateObject.ts
+++ b/tests/unit/DateObject.ts
@@ -19,7 +19,7 @@ function assertPropertiesEqual(left: DateProperties, right: DateProperties): voi
 }
 
 registerSuite('DateObject', {
-	'creation': function () {
+	creation: function() {
 		const date = new Date();
 		let object = new DateObject();
 
@@ -43,16 +43,16 @@ registerSuite('DateObject', {
 		assert.strictEqual(object.valueOf(), +date);
 	},
 
-	'properties': {
-		beforeEach: function () {
+	properties: {
+		beforeEach: function() {
 			date = new Date();
 			object = new DateObject(date);
 		},
 
 		tests: {
-			'year': function () {
+			year: function() {
 				assert.strictEqual(object.year, date.getFullYear());
-				date.setFullYear(object.year = 1);
+				date.setFullYear((object.year = 1));
 				assert.strictEqual(object.year, date.getFullYear());
 
 				object = new DateObject({ year: 2005, month: 12, dayOfMonth: 27 });
@@ -80,7 +80,7 @@ registerSuite('DateObject', {
 				assert.strictEqual(+object, +new Date(2030, 11, 31));
 			},
 
-			'month': function () {
+			month: function() {
 				assert.strictEqual(object.month, date.getMonth() + 1);
 				date.setMonth((object.month = 1) - 1);
 				assert.strictEqual(object.month, date.getMonth() + 1);
@@ -98,52 +98,52 @@ registerSuite('DateObject', {
 				assert.strictEqual(+object, +new Date(2001, 1, 28));
 			},
 
-			'dayOfMonth': function () {
+			dayOfMonth: function() {
 				assert.strictEqual(object.dayOfMonth, date.getDate());
-				date.setDate(object.dayOfMonth = 1);
+				date.setDate((object.dayOfMonth = 1));
 				assert.strictEqual(object.dayOfMonth, date.getDate());
 			},
 
-			'hours': function () {
+			hours: function() {
 				assert.strictEqual(object.hours, date.getHours());
-				date.setHours(object.hours = 12);
+				date.setHours((object.hours = 12));
 				assert.strictEqual(object.hours, date.getHours());
 			},
 
-			'minutes': function () {
+			minutes: function() {
 				assert.strictEqual(object.minutes, date.getMinutes());
-				date.setMinutes(object.minutes = 12);
+				date.setMinutes((object.minutes = 12));
 				assert.strictEqual(object.minutes, date.getMinutes());
 			},
 
-			'seconds': function () {
+			seconds: function() {
 				assert.strictEqual(object.seconds, date.getSeconds());
-				date.setSeconds(object.seconds = 12);
+				date.setSeconds((object.seconds = 12));
 				assert.strictEqual(object.seconds, date.getSeconds());
 			},
 
-			'milliseconds': function () {
+			milliseconds: function() {
 				assert.strictEqual(object.milliseconds, date.getMilliseconds());
-				date.setMilliseconds(object.milliseconds = 12);
+				date.setMilliseconds((object.milliseconds = 12));
 				assert.strictEqual(object.milliseconds, date.getMilliseconds());
 			},
 
-			'time': function () {
+			time: function() {
 				assert.strictEqual(object.time, +date);
-				date.setTime(object.time = 0);
+				date.setTime((object.time = 0));
 				assert.strictEqual(object.time, +date);
 			},
 
-			'dayOfWeek': function () {
+			dayOfWeek: function() {
 				assert.strictEqual(object.dayOfWeek, date.getDay());
 			},
 
-			'timezoneOffset': function () {
+			timezoneOffset: function() {
 				assert.strictEqual(object.timezoneOffset, date.getTimezoneOffset());
 			},
 
 			utc: {
-				'basic': function () {
+				basic: function() {
 					const date = new Date(1979, 2, 20, 7, 20, 12, 123);
 					const obj = new DateObject(date);
 					const utc = obj.utc;
@@ -151,7 +151,7 @@ registerSuite('DateObject', {
 					assertPropertiesEqual(obj.add(60000 * date.getTimezoneOffset()), utc);
 				},
 
-				'leap year': function () {
+				'leap year': function() {
 					const date = new Date(2012, 1, 29, 7, 20, 12, 123);
 					const obj = new DateObject(date);
 					const utc = obj.utc;
@@ -159,7 +159,7 @@ registerSuite('DateObject', {
 					assertPropertiesEqual(obj.add(60000 * date.getTimezoneOffset()), utc);
 				},
 
-				'setters': (function () {
+				setters: (function() {
 					function assertChange(property: string, dateProperty: string, value: number = 2) {
 						const date = new DateObject();
 						const time = date.time;
@@ -171,44 +171,44 @@ registerSuite('DateObject', {
 							// Months are 0-indexed in Date and 1-indexed in DateObject
 							expected += 1;
 						}
-						(<any> date.utc)[property] += value;
+						(<any>date.utc)[property] += value;
 
-						assert.strictEqual((<any> date.utc)[property], expected);
+						assert.strictEqual((<any>date.utc)[property], expected);
 						assert.notEqual(date.time, time);
 					}
 
 					return {
-						'year': function () {
+						year: function() {
 							assertChange('year', 'FullYear');
 						},
 
-						'month': function () {
+						month: function() {
 							assertChange('month', 'Month');
 						},
 
-						'dayOfMonth': function () {
+						dayOfMonth: function() {
 							assertChange('dayOfMonth', 'Date');
 						},
 
-						'hours': function () {
+						hours: function() {
 							assertChange('hours', 'Hours');
 						},
 
-						'minutes': function () {
+						minutes: function() {
 							assertChange('minutes', 'Minutes');
 						},
 
-						'seconds': function () {
+						seconds: function() {
 							assertChange('seconds', 'Seconds');
 						},
 
-						'milliseconds': function () {
+						milliseconds: function() {
 							assertChange('milliseconds', 'Milliseconds');
 						}
 					};
 				})(),
 
-				'toString': function () {
+				toString: function() {
 					const milliseconds = Date.UTC(1979, 2, 20);
 					const expected = new Date(milliseconds);
 					const date = new DateObject(milliseconds);
@@ -218,16 +218,16 @@ registerSuite('DateObject', {
 		}
 	},
 
-	'parse': function () {
+	parse: function() {
 		const date = DateObject.parse('Tue, 20 Mar 1979 00:00:00');
 		assertPropertiesEqual(date, new DateObject(new Date(1979, 2, 20)));
 	},
 
-	'now': function () {
+	now: function() {
 		assert.closeTo(DateObject.now().time, Date.now(), 100);
 	},
 
-	'.to* methods': function () {
+	'.to* methods': function() {
 		const date = new Date();
 		const object = new DateObject(date);
 
@@ -241,118 +241,46 @@ registerSuite('DateObject', {
 		assert.strictEqual(object.toJSON(), date.toJSON());
 	},
 
-	'.add': (function () {
+	'.add': (function() {
 		function addAndAssertEqual(kwArgs: KwArgs, addArgs: OperationKwArgs, expected: Date) {
 			const object = new DateObject(kwArgs);
 			assert.strictEqual(+object.add(addArgs), +expected);
 		}
 		return {
-			'returns new object': function () {
+			'returns new object': function() {
 				const object: DateObject = new DateObject();
 
 				assert.notStrictEqual(object, object.add(1));
 			},
 
-			'years': function () {
-				addAndAssertEqual(
-					{ year: 2005, month: 12, dayOfMonth: 27 },
-					{ years: 1 },
-					new Date(2006, 11, 27)
-				);
-				addAndAssertEqual(
-					{ year: 2005, month: 12, dayOfMonth: 27 },
-					{ years: -1 },
-					new Date(2004, 11, 27)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 2, dayOfMonth: 29 },
-					{ years: 1 },
-					new Date(2001, 1, 28)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 2, dayOfMonth: 29 },
-					{ years: 5 },
-					new Date(2005, 1, 28)
-				);
-				addAndAssertEqual(
-					{ year: 1900, month: 12, dayOfMonth: 31 },
-					{ years: 30 },
-					new Date(1930, 11, 31)
-				);
-				addAndAssertEqual(
-					{ year: 1995, month: 12, dayOfMonth: 31 },
-					{ years: 35 },
-					new Date(2030, 11, 31)
-				);
+			years: function() {
+				addAndAssertEqual({ year: 2005, month: 12, dayOfMonth: 27 }, { years: 1 }, new Date(2006, 11, 27));
+				addAndAssertEqual({ year: 2005, month: 12, dayOfMonth: 27 }, { years: -1 }, new Date(2004, 11, 27));
+				addAndAssertEqual({ year: 2000, month: 2, dayOfMonth: 29 }, { years: 1 }, new Date(2001, 1, 28));
+				addAndAssertEqual({ year: 2000, month: 2, dayOfMonth: 29 }, { years: 5 }, new Date(2005, 1, 28));
+				addAndAssertEqual({ year: 1900, month: 12, dayOfMonth: 31 }, { years: 30 }, new Date(1930, 11, 31));
+				addAndAssertEqual({ year: 1995, month: 12, dayOfMonth: 31 }, { years: 35 }, new Date(2030, 11, 31));
 			},
 
-			'months': function () {
-				addAndAssertEqual(
-					{ year: 2000, month: 1, dayOfMonth: 1 },
-					{ months: 1 },
-					new Date(2000, 1, 1)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 1, dayOfMonth: 31 },
-					{ months: 1 },
-					new Date(2000, 1, 29)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 3, dayOfMonth: 31 },
-					{ months: -1 },
-					new Date(2000, 1, 29)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 2, dayOfMonth: 29 },
-					{ months: 12 },
-					new Date(2001, 1, 28)
-				);
+			months: function() {
+				addAndAssertEqual({ year: 2000, month: 1, dayOfMonth: 1 }, { months: 1 }, new Date(2000, 1, 1));
+				addAndAssertEqual({ year: 2000, month: 1, dayOfMonth: 31 }, { months: 1 }, new Date(2000, 1, 29));
+				addAndAssertEqual({ year: 2000, month: 3, dayOfMonth: 31 }, { months: -1 }, new Date(2000, 1, 29));
+				addAndAssertEqual({ year: 2000, month: 2, dayOfMonth: 29 }, { months: 12 }, new Date(2001, 1, 28));
 			},
 
-			'days': function () {
-				addAndAssertEqual(
-					{ year: 2000, month: 1, dayOfMonth: 1 },
-					{ days: 1 },
-					new Date(2000, 0, 2)
-				);
-				addAndAssertEqual(
-					{ year: 2001, month: 1, dayOfMonth: 1 },
-					{ days: 365 },
-					new Date(2002, 0, 1)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 1, dayOfMonth: 1 },
-					{ days: 366 },
-					new Date(2001, 0, 1)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 2, dayOfMonth: 28 },
-					{ days: 1 },
-					new Date(2000, 1, 29)
-				);
-				addAndAssertEqual(
-					{ year: 2001, month: 2, dayOfMonth: 28 },
-					{ days: 1 },
-					new Date(2001, 2, 1)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 3, dayOfMonth: 1 },
-					{ days: -1 },
-					new Date(2000, 1, 29)
-				);
-				addAndAssertEqual(
-					{ year: 2001, month: 3, dayOfMonth: 1 },
-					{ days: -1 },
-					new Date(2001, 1, 28)
-				);
-				addAndAssertEqual(
-					{ year: 2000, month: 1, dayOfMonth: 1 },
-					{ days: -1 },
-					new Date(1999, 11, 31)
-				);
+			days: function() {
+				addAndAssertEqual({ year: 2000, month: 1, dayOfMonth: 1 }, { days: 1 }, new Date(2000, 0, 2));
+				addAndAssertEqual({ year: 2001, month: 1, dayOfMonth: 1 }, { days: 365 }, new Date(2002, 0, 1));
+				addAndAssertEqual({ year: 2000, month: 1, dayOfMonth: 1 }, { days: 366 }, new Date(2001, 0, 1));
+				addAndAssertEqual({ year: 2000, month: 2, dayOfMonth: 28 }, { days: 1 }, new Date(2000, 1, 29));
+				addAndAssertEqual({ year: 2001, month: 2, dayOfMonth: 28 }, { days: 1 }, new Date(2001, 2, 1));
+				addAndAssertEqual({ year: 2000, month: 3, dayOfMonth: 1 }, { days: -1 }, new Date(2000, 1, 29));
+				addAndAssertEqual({ year: 2001, month: 3, dayOfMonth: 1 }, { days: -1 }, new Date(2001, 1, 28));
+				addAndAssertEqual({ year: 2000, month: 1, dayOfMonth: 1 }, { days: -1 }, new Date(1999, 11, 31));
 			},
 
-			'hours': function () {
+			hours: function() {
 				addAndAssertEqual(
 					{ year: 2000, month: 1, dayOfMonth: 1, hours: 11 },
 					{ hours: 1 },
@@ -361,7 +289,7 @@ registerSuite('DateObject', {
 				addAndAssertEqual(
 					{ year: 2001, month: 10, dayOfMonth: 28, hours: 0 },
 					{ hours: 1 },
-					new Date((+new Date(2001, 9, 28, 0)) + (60 * 60 * 1000))
+					new Date(+new Date(2001, 9, 28, 0) + 60 * 60 * 1000)
 				);
 				addAndAssertEqual(
 					{ year: 2001, month: 10, dayOfMonth: 28, hours: 23 },
@@ -375,7 +303,7 @@ registerSuite('DateObject', {
 				);
 			},
 
-			'minutes': function () {
+			minutes: function() {
 				addAndAssertEqual(
 					{ year: 2000, month: 12, dayOfMonth: 31, hours: 23, minutes: 59 },
 					{ minutes: 1 },
@@ -388,7 +316,7 @@ registerSuite('DateObject', {
 				);
 			},
 
-			'seconds': function () {
+			seconds: function() {
 				addAndAssertEqual(
 					{ year: 2000, month: 12, dayOfMonth: 31, hours: 23, minutes: 59, seconds: 59 },
 					{ seconds: 1 },
@@ -401,7 +329,7 @@ registerSuite('DateObject', {
 				);
 			},
 
-			'number': function () {
+			number: function() {
 				const date = new DateObject({ year: 2000, month: 2, dayOfMonth: 29 });
 
 				assert.strictEqual(date.add(100).time, date.time + 100);
@@ -409,7 +337,7 @@ registerSuite('DateObject', {
 		};
 	})(),
 
-	'isLeapYear': function () {
+	isLeapYear: function() {
 		const date = new DateObject({
 			year: 2006,
 			month: 1,
@@ -431,7 +359,7 @@ registerSuite('DateObject', {
 		assert.isTrue(date.isLeapYear);
 	},
 
-	'daysInMonth': function () {
+	daysInMonth: function() {
 		const date = new DateObject({
 			year: 2006,
 			month: 1,
@@ -478,33 +406,33 @@ registerSuite('DateObject', {
 		assert.strictEqual(date.daysInMonth, 29);
 	},
 
-	comparisons: (function () {
+	comparisons: (function() {
 		const younger = new DateObject(new Date(2012, 0, 31, 23, 55));
-		const older = new DateObject(new Date(2010, 7, 26, 4 , 15));
+		const older = new DateObject(new Date(2010, 7, 26, 4, 15));
 
 		return {
 			compare: {
-				'if date is newer than comparison: return positive': function () {
+				'if date is newer than comparison: return positive': function() {
 					assert.isTrue(younger.compare(older) > 0);
 				},
 
-				'if date is less recent than comparison: return negative': function () {
+				'if date is less recent than comparison: return negative': function() {
 					assert.isTrue(older.compare(younger) < 0);
 				},
 
-				'if dates are identical: return 0': function () {
+				'if dates are identical: return 0': function() {
 					assert.strictEqual(younger.compare(younger), 0);
 				}
 			},
 
-			compareDate: function () {
+			compareDate: function() {
 				const similarDate1 = new DateObject(new Date(1979, 2, 20, 2, 4, 6));
 				const similarDate2 = new DateObject(new Date(1979, 2, 20, 1, 3, 5));
 
 				assert.strictEqual(similarDate1.compareDate(similarDate2), 0);
 			},
 
-			compareTime:  function () {
+			compareTime: function() {
 				const similarTime1 = new DateObject(new Date(2015, 1, 1, 2, 4, 6));
 				const similarTime2 = new DateObject(new Date(1977, 3, 20, 2, 4, 6));
 

--- a/tests/unit/Destroyable.ts
+++ b/tests/unit/Destroyable.ts
@@ -24,10 +24,7 @@ registerSuite('Destroyable', {
 			const destroy2 = sinon.spy();
 
 			const destroyable = new Destroyable();
-			destroyable.own([
-				{ destroy: destroy1 },
-				{ destroy: destroy2 }
-			]);
+			destroyable.own([{ destroy: destroy1 }, { destroy: destroy2 }]);
 
 			assert.strictEqual(destroy1.callCount, 0, 'first handle should not be called yet');
 			assert.strictEqual(destroy2.callCount, 0, 'second handle should not be called yet');
@@ -69,10 +66,7 @@ registerSuite('Destroyable', {
 			const destroy1 = sinon.spy();
 			const destroy2 = sinon.spy();
 			const destroyable = new Destroyable();
-			const handle = destroyable.own([
-				{ destroy: destroy1 },
-				{ destroy: destroy2 }
-			]);
+			const handle = destroyable.own([{ destroy: destroy1 }, { destroy: destroy2 }]);
 			assert.strictEqual(destroy1.callCount, 0, 'first destroy not called yet');
 			assert.strictEqual(destroy2.callCount, 0, 'second destroy not called yet');
 			handle.destroy();

--- a/tests/unit/Evented.ts
+++ b/tests/unit/Evented.ts
@@ -3,8 +3,8 @@ const { assert } = intern.getPlugin('chai');
 import { Evented } from '../../src/Evented';
 
 interface FooBarEvents {
-	foo: { type: 'foo'; };
-	bar: { type: 'bar'; };
+	foo: { type: 'foo' };
+	bar: { type: 'bar' };
 }
 
 registerSuite('Evented', {
@@ -14,7 +14,7 @@ registerSuite('Evented', {
 		assert.isFunction(evented.on);
 		assert.isFunction(evented.emit);
 	},
-	'on': {
+	on: {
 		'on()'() {
 			const eventStack: string[] = [];
 			const evented = new Evented<FooBarEvents>();
@@ -30,7 +30,7 @@ registerSuite('Evented', {
 			evented.emit({ type: 'foo' });
 			evented.emit({ type: 'bar' });
 
-			assert.deepEqual(eventStack, [ 'foo' ]);
+			assert.deepEqual(eventStack, ['foo']);
 		},
 		'on() with Symbol type'() {
 			const foo = Symbol();
@@ -50,7 +50,7 @@ registerSuite('Evented', {
 			evented.emit({ type: foo });
 			evented.emit({ type: 'bar' });
 
-			assert.deepEqual(eventStack, [ foo ]);
+			assert.deepEqual(eventStack, [foo]);
 		},
 		'multiple listeners, same event'() {
 			const eventStack: string[] = [];
@@ -69,17 +69,17 @@ registerSuite('Evented', {
 			handle2.destroy();
 			evented.emit({ type: 'foo' });
 
-			assert.deepEqual(eventStack, [ 'one', 'two', 'two' ]);
+			assert.deepEqual(eventStack, ['one', 'two', 'two']);
 		},
 		'on(type, listener[])'() {
 			const eventStack: string[] = [];
 			const evented = new Evented<FooBarEvents>();
 
 			const handle = evented.on('foo', [
-				function (event) {
+				function(event) {
 					eventStack.push('foo1');
 				},
-				function (event) {
+				function(event) {
 					eventStack.push('foo2');
 				}
 			]);
@@ -88,7 +88,7 @@ registerSuite('Evented', {
 			handle.destroy();
 			evented.emit({ type: 'foo' });
 
-			assert.deepEqual(eventStack, [ 'foo1', 'foo2' ]);
+			assert.deepEqual(eventStack, ['foo1', 'foo2']);
 		}
 	},
 	'wildcards in event type name': {
@@ -103,7 +103,7 @@ registerSuite('Evented', {
 			evented.emit({ type: 'bar' });
 			evented.emit({ type: 'foo:bar' });
 
-			assert.deepEqual(eventStack, [ 'foo', 'bar', 'foo:bar' ]);
+			assert.deepEqual(eventStack, ['foo', 'bar', 'foo:bar']);
 		},
 		'event types starting with a pattern'() {
 			const eventStack: string[] = [];
@@ -116,7 +116,7 @@ registerSuite('Evented', {
 			evented.emit({ type: 'foo:' });
 			evented.emit({ type: 'foo:bar' });
 
-			assert.deepEqual(eventStack, [ 'foo:', 'foo:bar' ]);
+			assert.deepEqual(eventStack, ['foo:', 'foo:bar']);
 		},
 		'event types ending with a pattern'() {
 			const eventStack: string[] = [];
@@ -129,7 +129,7 @@ registerSuite('Evented', {
 			evented.emit({ type: ':bar' });
 			evented.emit({ type: 'foo:bar' });
 
-			assert.deepEqual(eventStack, [ ':bar', 'foo:bar' ]);
+			assert.deepEqual(eventStack, [':bar', 'foo:bar']);
 		},
 		'event types contains a pattern'() {
 			const eventStack: string[] = [];
@@ -143,7 +143,7 @@ registerSuite('Evented', {
 			evented.emit({ type: 'barfoo' });
 			evented.emit({ type: 'barfoobiz' });
 
-			assert.deepEqual(eventStack, [ 'foo', 'foobar', 'barfoo', 'barfoobiz' ]);
+			assert.deepEqual(eventStack, ['foo', 'foobar', 'barfoo', 'barfoobiz']);
 		},
 		'multiple matches'() {
 			const eventStack: string[] = [];
@@ -159,7 +159,7 @@ registerSuite('Evented', {
 			evented.emit({ type: 'foobar' });
 			evented.emit({ type: 'barfoo' });
 
-			assert.deepEqual(eventStack, [ 'foo->foo', '*foo->foo', '*foo->barfoo' ]);
+			assert.deepEqual(eventStack, ['foo->foo', '*foo->foo', '*foo->barfoo']);
 		}
 	}
 });

--- a/tests/unit/IdentityRegistry.ts
+++ b/tests/unit/IdentityRegistry.ts
@@ -15,11 +15,7 @@ registerSuite('IdentityRegistry', {
 	'#get': {
 		'string id was not registered'() {
 			const registry = new IdentityRegistry<Value>();
-			assert.throws(
-				() => registry.get('id'),
-				Error,
-				'Could not find a value for identity \'id\''
-			);
+			assert.throws(() => registry.get('id'), Error, "Could not find a value for identity 'id'");
 		},
 
 		'symbol id was not registered'() {
@@ -27,7 +23,7 @@ registerSuite('IdentityRegistry', {
 			assert.throws(
 				() => registry.get(idSymbol),
 				Error,
-				'Could not find a value for identity \'' + idSymbolString + '\''
+				"Could not find a value for identity '" + idSymbolString + "'"
 			);
 		},
 
@@ -84,11 +80,7 @@ registerSuite('IdentityRegistry', {
 	'#identify': {
 		'not registered'() {
 			const registry = new IdentityRegistry<Value>();
-			assert.throws(
-				() => registry.identify(new Value()),
-				Error,
-				'Could not identify non-registered value'
-			);
+			assert.throws(() => registry.identify(new Value()), Error, 'Could not identify non-registered value');
 		},
 
 		registered() {
@@ -111,27 +103,39 @@ registerSuite('IdentityRegistry', {
 		'string id is already used'() {
 			const registry = new IdentityRegistry<Value>();
 			registry.register('id', new Value());
-			assert.throws(() => {
-				registry.register('id', new Value());
-			}, Error, 'A value has already been registered for the given identity (id)');
+			assert.throws(
+				() => {
+					registry.register('id', new Value());
+				},
+				Error,
+				'A value has already been registered for the given identity (id)'
+			);
 		},
 
 		'symbol id is already used'() {
 			const registry = new IdentityRegistry<Value>();
 			const id = idSymbol;
 			registry.register(id, new Value());
-			assert.throws(() => {
-				registry.register(id, new Value());
-			}, Error, 'A value has already been registered for the given identity (' + idSymbolString + ')');
+			assert.throws(
+				() => {
+					registry.register(id, new Value());
+				},
+				Error,
+				'A value has already been registered for the given identity (' + idSymbolString + ')'
+			);
 		},
 
 		'value has already been registered with a different (string) id'() {
 			const registry = new IdentityRegistry<Value>();
 			const value = new Value();
 			registry.register('id1', value);
-			assert.throws(() => {
-				registry.register(Symbol('id2'), value);
-			}, Error, 'The value has already been registered with a different identity (id1)');
+			assert.throws(
+				() => {
+					registry.register(Symbol('id2'), value);
+				},
+				Error,
+				'The value has already been registered with a different identity (id1)'
+			);
 		},
 
 		'value has already been registered with a different (symbol) id'() {
@@ -139,9 +143,13 @@ registerSuite('IdentityRegistry', {
 			const value = new Value();
 			const id1Symbol = Symbol('id1');
 			registry.register(id1Symbol, value);
-			assert.throws(() => {
-				registry.register('id2', value);
-			}, Error, 'The value has already been registered with a different identity (' + id1Symbol.toString() + ')');
+			assert.throws(
+				() => {
+					registry.register('id2', value);
+				},
+				Error,
+				'The value has already been registered with a different identity (' + id1Symbol.toString() + ')'
+			);
 		},
 
 		'value has already been registered with the same id'() {
@@ -180,7 +188,7 @@ registerSuite('IdentityRegistry', {
 		registry.register('id2', value2);
 		registry.register('id3', value3);
 
-		assert.deepEqual(arrayFrom(registry.values()), [ value1, value2, value3 ]);
+		assert.deepEqual(arrayFrom(registry.values()), [value1, value2, value3]);
 	},
 
 	'#ids'() {
@@ -193,7 +201,7 @@ registerSuite('IdentityRegistry', {
 		registry.register('id2', value2);
 		registry.register('id3', value3);
 
-		assert.deepEqual(arrayFrom(registry.ids()), [ 'id1', 'id2', 'id3' ]);
+		assert.deepEqual(arrayFrom(registry.ids()), ['id1', 'id2', 'id3']);
 	},
 
 	'#entries'() {
@@ -206,10 +214,10 @@ registerSuite('IdentityRegistry', {
 		registry.register('id2', value2);
 		registry.register('id3', value3);
 
-		assert.deepEqual(arrayFrom(registry.entries()), [ [ 'id1', value1 ], [ 'id2', value2 ], [ 'id3', value3 ] ]);
+		assert.deepEqual(arrayFrom(registry.entries()), [['id1', value1], ['id2', value2], ['id3', value3]]);
 	},
 
-	'iterator'() {
+	iterator() {
 		const value1 = new Value();
 		const value2 = new Value();
 		const value3 = new Value();
@@ -219,6 +227,6 @@ registerSuite('IdentityRegistry', {
 		registry.register('id2', value2);
 		registry.register('id3', value3);
 
-		assert.deepEqual(arrayFrom(registry), [ [ 'id1', value1 ], [ 'id2', value2 ], [ 'id3', value3 ] ]);
+		assert.deepEqual(arrayFrom(registry), [['id1', value1], ['id2', value2], ['id3', value3]]);
 	}
 });

--- a/tests/unit/List.ts
+++ b/tests/unit/List.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import Set from '@dojo/shim/Set';
 import List from '../../src/List';
 
-registerSuite('List', function () {
+registerSuite('List', function() {
 	function listWith<T>(...items: T[]): List<T> {
 		const list = new List<T>();
 
@@ -15,7 +15,7 @@ registerSuite('List', function () {
 	}
 
 	return {
-		'add'() {
+		add() {
 			const list = new List<number>();
 
 			list.add(1);
@@ -25,7 +25,7 @@ registerSuite('List', function () {
 			assert.equal(list.size, 2);
 		},
 
-		'clear'() {
+		clear() {
 			const list = new List<number>();
 
 			list.add(1);
@@ -33,7 +33,7 @@ registerSuite('List', function () {
 			assert.equal(list.size, 0);
 		},
 
-		'delete'() {
+		delete() {
 			const list = listWith(1, 2, 3);
 
 			assert.strictEqual(list.delete(1), true);
@@ -43,7 +43,7 @@ registerSuite('List', function () {
 
 			assert.strictEqual(list.delete(2), false);
 		},
-		'entries'() {
+		entries() {
 			const list = listWith('one', 'two', 'three');
 
 			let entries: [number, string][] = [];
@@ -52,14 +52,10 @@ registerSuite('List', function () {
 				entries.push(value);
 			}
 
-			assert.deepEqual(entries, [
-				[ 0, 'one' ],
-				[ 1, 'two' ],
-				[ 2, 'three' ]
-			]);
+			assert.deepEqual(entries, [[0, 'one'], [1, 'two'], [2, 'three']]);
 		},
 
-		'forEach'() {
+		forEach() {
 			const list = listWith('one', 'two', 'three');
 
 			let items: string[] = [];
@@ -68,22 +64,22 @@ registerSuite('List', function () {
 				myValue: 'test'
 			};
 
-			list.forEach(function (this: any, value: string, index: number) {
+			list.forEach(function(this: any, value: string, index: number) {
 				assert(this.myValue, 'test');
 
 				items.push(value);
 				indicies.push(index);
 			}, obj);
 
-			assert.deepEqual(items, [ 'one', 'two', 'three' ]);
-			assert.deepEqual(indicies, [ 0, 1, 2 ]);
+			assert.deepEqual(items, ['one', 'two', 'three']);
+			assert.deepEqual(indicies, [0, 1, 2]);
 
-			list.forEach(function (this: any) {
+			list.forEach(function(this: any) {
 				assert.equal(this, list);
 			});
 		},
 
-		'has'() {
+		has() {
 			const list = listWith('one', 'two', 'three');
 
 			assert.isFalse(list.has(3));
@@ -91,7 +87,7 @@ registerSuite('List', function () {
 			assert.isTrue(list.has(0));
 		},
 
-		'keys'() {
+		keys() {
 			const list = listWith('one', 'two', 'three');
 
 			let keys: number[] = [];
@@ -100,10 +96,10 @@ registerSuite('List', function () {
 				keys.push(key);
 			}
 
-			assert.deepEqual(keys, [ 0, 1, 2 ]);
+			assert.deepEqual(keys, [0, 1, 2]);
 		},
 
-		'values'() {
+		values() {
 			const list = listWith('one', 'two', 'three');
 
 			let values: string[] = [];
@@ -112,10 +108,10 @@ registerSuite('List', function () {
 				values.push(value);
 			}
 
-			assert.deepEqual(values, [ 'one', 'two', 'three' ]);
+			assert.deepEqual(values, ['one', 'two', 'three']);
 		},
 
-		'includes'() {
+		includes() {
 			const list = listWith('one', 'two', 'three');
 
 			assert.isTrue(list.includes('two'));
@@ -123,21 +119,21 @@ registerSuite('List', function () {
 			assert.isTrue(list.includes('one'));
 		},
 
-		'indexOf'() {
+		indexOf() {
 			const list = listWith('one', 'two', 'three', 'two');
 
 			assert.equal(list.indexOf('two'), 1);
 			assert.equal(list.indexOf('test'), -1);
 		},
 
-		'lastIndexOf'() {
+		lastIndexOf() {
 			const list = listWith('one', 'two', 'three', 'two');
 
 			assert.equal(list.lastIndexOf('two'), 3);
 			assert.equal(list.lastIndexOf('test'), -1);
 		},
 
-		'push'() {
+		push() {
 			const list = new List();
 
 			list.push('one');
@@ -146,7 +142,7 @@ registerSuite('List', function () {
 			assert.equal(list.indexOf('one'), 0);
 		},
 
-		'pop'() {
+		pop() {
 			const list = listWith(1, 2, 3);
 
 			assert.equal(list.pop(), 3);
@@ -155,22 +151,22 @@ registerSuite('List', function () {
 			assert.equal(list.indexOf(2), 1);
 		},
 
-		'splice'() {
+		splice() {
 			const list = listWith(1, 2, 3);
 
-			assert.deepEqual(list.splice(0, 1), [ 1 ]);
+			assert.deepEqual(list.splice(0, 1), [1]);
 			assert.deepEqual(list.splice(1, 0, 1), []);
 
 			assert.equal(list.indexOf(1), 1);
 			assert.equal(list.indexOf(2), 0);
 			assert.equal(list.indexOf(3), 2);
 
-			assert.deepEqual(list.splice(1), [ 1, 3 ]);
+			assert.deepEqual(list.splice(1), [1, 3]);
 			assert.equal(list.size, 1);
 			assert.equal(list.indexOf(2), 0);
 		},
 
-		'join'() {
+		join() {
 			let list = listWith('the', 'quick', 'brown', 'fox');
 
 			assert.equal(list.join(), 'the,quick,brown,fox');
@@ -193,16 +189,16 @@ registerSuite('List', function () {
 				values.push(value);
 			}
 
-			assert.deepEqual(values, [ 'the', 'quick', 'brown', 'fox' ]);
+			assert.deepEqual(values, ['the', 'quick', 'brown', 'fox']);
 		},
 
-		'constructor'() {
+		constructor() {
 			// empty list
 			let list = new List();
 			assert.equal(list.size, 0);
 
 			// array like
-			list = new List([ 1, 2, 3 ]);
+			list = new List([1, 2, 3]);
 			assert.equal(list.size, 3);
 			assert.strictEqual(list.indexOf(1), 0);
 			assert.strictEqual(list.indexOf(2), 1);

--- a/tests/unit/MultiMap.ts
+++ b/tests/unit/MultiMap.ts
@@ -8,40 +8,42 @@ function foo() {}
 const object = Object.create(null);
 const array: any[] = [];
 const mapArgs: any[] = [
-	[ [ 0 ], 0 ],
-	[ [ 0, 1, 2 ], '1' ],
-	[ [ 2, 3, 4, 5, 6 ], object ],
-	[ [ 3 ], array ],
-	[ [ 4, 3, 2, 1 ], foo ],
-	[ [ 5 ], undefined ]
+	[[0], 0],
+	[[0, 1, 2], '1'],
+	[[2, 3, 4, 5, 6], object],
+	[[3], array],
+	[[4, 3, 2, 1], foo],
+	[[5], undefined]
 ];
 
 registerSuite('Map', {
 	instantiation: {
 		'null data'() {
-			assert.doesNotThrow(function () {
-				map = new MultiMap<string>(<any> null);
+			assert.doesNotThrow(function() {
+				map = new MultiMap<string>(<any>null);
 			});
 		},
 
 		'undefined data'() {
-			assert.doesNotThrow(function () {
+			assert.doesNotThrow(function() {
 				map = new MultiMap<string>(undefined);
 			});
 		},
 
 		'empty data'() {
-			assert.doesNotThrow(function () {
+			assert.doesNotThrow(function() {
 				map = new MultiMap<string>([]);
 			});
 		},
 
 		'iterator data'() {
-			assert.doesNotThrow(function () {
-				map = new MultiMap(new ShimIterator<[any[], any]>({
-					length: 1,
-					0: [ [ 1 ], 'foo' ]
-				}));
+			assert.doesNotThrow(function() {
+				map = new MultiMap(
+					new ShimIterator<[any[], any]>({
+						length: 1,
+						0: [[1], 'foo']
+					})
+				);
 			});
 		}
 	},
@@ -49,41 +51,35 @@ registerSuite('Map', {
 	clear: {
 		'empty map'() {
 			map = new MultiMap();
-			assert.doesNotThrow(function () {
+			assert.doesNotThrow(function() {
 				map.clear();
 			});
 		},
 
 		'non-empty map'() {
-			map = new MultiMap([
-				[ [ 1 ] , 'foo' ]
-			]);
+			map = new MultiMap([[[1], 'foo']]);
 			assert.isFalse(map.has([3]));
 			map.clear();
 			assert.isFalse(map.has([3]));
 		}
 	},
 
-	'delete': {
+	delete: {
 		before() {
-			map = new MultiMap([
-				[ [ 1 ], 'foo' ],
-				[ [ 1, 2 ], 'bar' ],
-				[ [ 2 ], 'baz' ]
-			]);
+			map = new MultiMap([[[1], 'foo'], [[1, 2], 'bar'], [[2], 'baz']]);
 		},
 
 		tests: {
 			'key found'() {
-				assert.strictEqual(map.get([ 1, 2 ]), 'bar');
-				assert.isTrue(map.delete([ 1, 2 ]));
-				assert.isUndefined(map.get([ 1, 2 ]));
-				assert.strictEqual(map.get([ 1 ] ), 'foo');
-				assert.strictEqual(map.get([ 2 ] ), 'baz');
+				assert.strictEqual(map.get([1, 2]), 'bar');
+				assert.isTrue(map.delete([1, 2]));
+				assert.isUndefined(map.get([1, 2]));
+				assert.strictEqual(map.get([1]), 'foo');
+				assert.strictEqual(map.get([2]), 'baz');
 			},
 
 			'key not found'() {
-				assert.isFalse(map.delete([ 'foo' ]));
+				assert.isFalse(map.delete(['foo']));
 			}
 		}
 	},
@@ -91,7 +87,7 @@ registerSuite('Map', {
 	size() {
 		map = new MultiMap<any>(mapArgs);
 		assert.strictEqual(map.size, 6);
-		map.delete([ 2, 3, 4, 5, 6 ]);
+		map.delete([2, 3, 4, 5, 6]);
 		assert.strictEqual(map.size, 5);
 		map.clear();
 		assert.strictEqual(map.size, 0);
@@ -136,7 +132,7 @@ registerSuite('Map', {
 
 		tests: {
 			'callback arguments'() {
-				map.forEach(function (value, key, mapInstance) {
+				map.forEach(function(value, key, mapInstance) {
 					assert.lengthOf(arguments, 3);
 					assert.strictEqual(map.get(key), value);
 					assert.strictEqual(map, mapInstance);
@@ -145,7 +141,7 @@ registerSuite('Map', {
 
 			'times executed'() {
 				let counter = 0;
-				map.forEach(function (key, value, mapInstance) {
+				map.forEach(function(key, value, mapInstance) {
 					counter++;
 				});
 				assert.strictEqual(counter, mapArgs.length);
@@ -160,12 +156,12 @@ registerSuite('Map', {
 
 		tests: {
 			'key found'() {
-				assert.strictEqual(map.get([ 0 ]), 0);
-				assert.strictEqual(map.get([ 4, 3, 2, 1 ]), foo);
+				assert.strictEqual(map.get([0]), 0);
+				assert.strictEqual(map.get([4, 3, 2, 1]), foo);
 			},
 
 			'key not found'() {
-				assert.isUndefined(map.get([ 2, 3, 4, 5, 7 ]));
+				assert.isUndefined(map.get([2, 3, 4, 5, 7]));
 			}
 		}
 	},
@@ -177,11 +173,11 @@ registerSuite('Map', {
 
 		tests: {
 			'key found'() {
-				assert.isTrue(map.has([ 4, 3, 2, 1 ]));
+				assert.isTrue(map.has([4, 3, 2, 1]));
 			},
 
 			'key not found'() {
-				assert.isFalse(map.has([ 'key', 'not', 'exist' ]));
+				assert.isFalse(map.has(['key', 'not', 'exist']));
 			}
 		}
 	},
@@ -209,26 +205,26 @@ registerSuite('Map', {
 		tests: {
 			'single key'() {
 				map = new MultiMap<any>();
-				map.set( [ 1 ], 'foo');
-				assert.strictEqual(map.get([ 1 ]), 'foo');
+				map.set([1], 'foo');
+				assert.strictEqual(map.get([1]), 'foo');
 			},
 
 			'multiple keys'() {
 				map = new MultiMap<string>();
-				map.set([ 'foo', 'bar', 'baz', foo, object, array ], 'qux');
-				assert.strictEqual(map.get([ 'foo', 'bar', 'baz', foo, object, array ]), 'qux');
+				map.set(['foo', 'bar', 'baz', foo, object, array], 'qux');
+				assert.strictEqual(map.get(['foo', 'bar', 'baz', foo, object, array]), 'qux');
 			},
 
 			'returns instance'() {
 				map = new MultiMap<string>();
-				assert.instanceOf(map.set([ 'foo' ], 'bar'), MultiMap);
-				assert.strictEqual(map.set([ 'foo' ], 'bar'), map);
+				assert.instanceOf(map.set(['foo'], 'bar'), MultiMap);
+				assert.strictEqual(map.set(['foo'], 'bar'), map);
 			},
 
 			'key exists'() {
-				map = new MultiMap<string>([ [ [ 3 ], 'abc' ] ]);
-				map.set([ 3 ], 'def');
-				assert.strictEqual(map.get([ 3 ]), 'def');
+				map = new MultiMap<string>([[[3], 'abc']]);
+				map.set([3], 'def');
+				assert.strictEqual(map.get([3]), 'def');
 			}
 		}
 	},

--- a/tests/unit/Observable.ts
+++ b/tests/unit/Observable.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import Observable from '../../src/Observable';
 
 function asyncRange(start: number, end: number) {
-	return new Observable(observer => {
+	return new Observable((observer) => {
 		let i = start;
 
 		function handler() {
@@ -12,7 +12,6 @@ function asyncRange(start: number, end: number) {
 				observer.complete();
 			} else {
 				setTimeout(handler, 0);
-
 			}
 		}
 
@@ -21,47 +20,58 @@ function asyncRange(start: number, end: number) {
 }
 
 registerSuite('Observable', {
-	'toPromise': {
+	toPromise: {
 		'resolution with single'() {
-			return Observable.of(42).toPromise().then((value: number) => {
-				assert.strictEqual(value, 42);
-			});
+			return Observable.of(42)
+				.toPromise()
+				.then((value: number) => {
+					assert.strictEqual(value, 42);
+				});
 		},
 		'resolution with multiple'() {
-			return Observable.from([ 1, 2, 3 ]).toPromise().then((value: number) => {
-				assert.strictEqual(value, 1);
-			});
+			return Observable.from([1, 2, 3])
+				.toPromise()
+				.then((value: number) => {
+					assert.strictEqual(value, 1);
+				});
 		},
-		'reject'(this: any) {
+		reject(this: any) {
 			let dfd = this.async();
 
 			new Observable(() => {
 				throw new Error('error');
-			}).toPromise().then(dfd.rejectOnError(() => {
-				assert.fail('should not have succeeded');
-			}), dfd.callback((error: Error) => {
-				assert.strictEqual(error.message, 'error');
-			}));
+			})
+				.toPromise()
+				.then(
+					dfd.rejectOnError(() => {
+						assert.fail('should not have succeeded');
+					}),
+					dfd.callback((error: Error) => {
+						assert.strictEqual(error.message, 'error');
+					})
+				);
 		}
 	},
-	'map': {
+	map: {
 		'transforms values'() {
 			let values: any[] = [],
 				returns: any[] = [];
 
-			new Observable<number>(observer => {
+			new Observable<number>((observer) => {
 				returns.push(observer.next(1));
 				returns.push(observer.next(2));
 				observer.complete();
-			}).map(x => x * 2).subscribe({
-				next(v) {
-					values.push(v);
-					return -v;
-				}
-			});
+			})
+				.map((x) => x * 2)
+				.subscribe({
+					next(v) {
+						values.push(v);
+						return -v;
+					}
+				});
 
-			assert.deepEqual(values, [ 2, 4 ], 'Mapped values are sent to the observer');
-			assert.deepEqual(returns, [ -2, -4 ], 'Return values from the observer are returned to the caller');
+			assert.deepEqual(values, [2, 4], 'Mapped values are sent to the observer');
+			assert.deepEqual(returns, [-2, -4], 'Return values from the observer are returned to the caller');
 		},
 		'errors during callback get sent to the observer'() {
 			let error = new Error(),
@@ -69,16 +79,18 @@ registerSuite('Observable', {
 				returned = null,
 				token = {};
 
-			new Observable<number>(observer => {
+			new Observable<number>((observer) => {
 				returned = observer.next(1);
-			}).map(() => {
-				throw error;
-			}).subscribe({
-				error(e) {
-					thrown = e;
-					return token;
-				}
-			});
+			})
+				.map(() => {
+					throw error;
+				})
+				.subscribe({
+					error(e) {
+						thrown = e;
+						return token;
+					}
+				});
 
 			assert.equal(thrown, error, 'Exceptions from callback are sent to the observer');
 			assert.equal(returned, token, 'The result of calling error is returned to the caller');
@@ -89,51 +101,53 @@ registerSuite('Observable', {
 				returned = null,
 				token = {};
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				returned = observer.error(error);
-			}).map(x => x).subscribe({
-				error(e) {
-					thrown = e;
-					return token;
-				}
-			});
+			})
+				.map((x) => x)
+				.subscribe({
+					error(e) {
+						thrown = e;
+						return token;
+					}
+				});
 
 			assert.equal(thrown, error, 'Error values are forwarded');
 			assert.equal(returned, token, 'The return value of the error method is returned to the caller');
 		},
 		'invalid argument errors'() {
-			const observable = new Observable(() => {
-			});
+			const observable = new Observable(() => {});
 
-			assert.throws(() => observable.map(<any> undefined), TypeError);
-			assert.throws(() => observable.map(<any> null), TypeError);
-			assert.throws(() => observable.map(<any> {}), TypeError);
-			assert.throws(() => observable.map(<any> 42), TypeError);
+			assert.throws(() => observable.map(<any>undefined), TypeError);
+			assert.throws(() => observable.map(<any>null), TypeError);
+			assert.throws(() => observable.map(<any>{}), TypeError);
+			assert.throws(() => observable.map(<any>42), TypeError);
 		},
 		'complete is forwarded to the observer'() {
 			let arg = {},
 				passed = null;
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				observer.complete(arg);
-			}).map(x => x).subscribe({
-				complete(v) {
-					passed = v;
-				}
-			});
+			})
+				.map((x) => x)
+				.subscribe({
+					complete(v) {
+						passed = v;
+					}
+				});
 
 			assert.equal(passed, arg, 'Complete values are forwarded');
 		}
 	},
 
-	'filter': {
+	filter: {
 		'allowed argument'() {
-
 			let observable = new Observable(() => undefined);
 
-			assert.throws(() => observable.filter(<any> undefined), TypeError);
-			assert.throws(() => observable.filter(<any> null), TypeError);
-			assert.throws(() => observable.filter(<any> {}), TypeError);
+			assert.throws(() => observable.filter(<any>undefined), TypeError);
+			assert.throws(() => observable.filter(<any>null), TypeError);
+			assert.throws(() => observable.filter(<any>{}), TypeError);
 		},
 		'even numbers'() {
 			const source = Observable.of(1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10).filter((x) => {
@@ -153,7 +167,7 @@ registerSuite('Observable', {
 			});
 
 			assert.isTrue(finished);
-			assert.deepEqual(values, [ 2, 4, 6, 8, 10 ]);
+			assert.deepEqual(values, [2, 4, 6, 8, 10]);
 		},
 
 		'errors thrown from callback are returned to observer'() {
@@ -162,16 +176,18 @@ registerSuite('Observable', {
 				returned = null,
 				token = {};
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				returned = observer.next(1);
-			}).filter(x => {
-				throw error;
-			}).subscribe({
-				error(e) {
-					thrown = e;
-					return token;
-				}
-			});
+			})
+				.filter((x) => {
+					throw error;
+				})
+				.subscribe({
+					error(e) {
+						thrown = e;
+						return token;
+					}
+				});
 
 			assert.equal(thrown, error, 'The result of calling error is returned to the caller');
 			assert.equal(returned, token);
@@ -183,14 +199,16 @@ registerSuite('Observable', {
 				returned = null,
 				token = {};
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				returned = observer.error(error);
-			}).filter(x => true).subscribe({
-				error(e) {
-					thrown = e;
-					return token;
-				}
-			});
+			})
+				.filter((x) => true)
+				.subscribe({
+					error(e) {
+						thrown = e;
+						return token;
+					}
+				});
 
 			assert.equal(thrown, error, 'Error values are forwarded');
 			assert.equal(returned, token, 'The return value of the error method is returned to the caller');
@@ -201,25 +219,27 @@ registerSuite('Observable', {
 				passed = null,
 				token = {};
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				observer.complete(arg);
-			}).filter(x => true).subscribe({
-				complete(v) {
-					passed = v;
-					return token;
-				}
-			});
+			})
+				.filter((x) => true)
+				.subscribe({
+					complete(v) {
+						passed = v;
+						return token;
+					}
+				});
 
 			assert.equal(passed, arg, 'Complete values are forwarded');
 		}
 	},
-	'defer': {
+	defer: {
 		'execution is deferred until subscribe'() {
 			let called = false;
 			let values: number[] = [];
 
 			const source = Observable.defer(() => {
-				return new Observable<number>(observer => {
+				return new Observable<number>((observer) => {
 					called = true;
 
 					observer.next(1);
@@ -236,7 +256,7 @@ registerSuite('Observable', {
 			});
 
 			assert.isTrue(called);
-			assert.deepEqual(values, [ 1, 2 ]);
+			assert.deepEqual(values, [1, 2]);
 		},
 
 		'errors thrown during factory call are sent to subscriber'() {
@@ -257,7 +277,7 @@ registerSuite('Observable', {
 
 		'errors created in factory observable get propagated to the observer'() {
 			const source = Observable.defer(() => {
-				return new Observable(observer => {
+				return new Observable((observer) => {
 					observer.error(new Error('error'));
 				});
 			});
@@ -270,55 +290,72 @@ registerSuite('Observable', {
 		}
 	},
 
-	'toArray': {
+	toArray: {
 		'complete list'() {
 			let called = false;
 
-			Observable.from([ 1, 2, 3 ]).toArray().subscribe((values) => {
-				called = true;
-				assert.deepEqual(values, [ 1, 2, 3 ]);
-			});
+			Observable.from([1, 2, 3])
+				.toArray()
+				.subscribe((values) => {
+					called = true;
+					assert.deepEqual(values, [1, 2, 3]);
+				});
 
 			assert.isTrue(called);
 		},
 		'errors thrown during subscription are sent to observer'() {
 			new Observable(() => {
 				throw new Error('test');
-			}).toArray().subscribe(() => {
-				assert.fail('should not have succeeded');
-			}, error => {
-				assert.equal(error.message, 'test');
-			});
+			})
+				.toArray()
+				.subscribe(
+					() => {
+						assert.fail('should not have succeeded');
+					},
+					(error) => {
+						assert.equal(error.message, 'test');
+					}
+				);
 		},
 		'errors called are sent to observer'() {
-			new Observable(observer => {
+			new Observable((observer) => {
 				observer.error(new Error('test'));
-			}).toArray().subscribe(() => {
-				assert.fail('should not have succeeded');
-			}, error => {
-				assert.equal(error.message, 'test');
-			});
+			})
+				.toArray()
+				.subscribe(
+					() => {
+						assert.fail('should not have succeeded');
+					},
+					(error) => {
+						assert.equal(error.message, 'test');
+					}
+				);
 		},
 		'complete calls are sent to observer'() {
 			let completeValue = 0;
 
-			new Observable(observer => {
+			new Observable((observer) => {
 				observer.complete(4);
-			}).toArray().subscribe({
-				complete(value) {
-					completeValue = value;
-				}
-			});
+			})
+				.toArray()
+				.subscribe({
+					complete(value) {
+						completeValue = value;
+					}
+				});
 
 			assert.equal(completeValue, 4);
 		}
 	},
 
-	'mergeAll': {
+	mergeAll: {
 		'synchronous concat'() {
 			let values: any[] = [];
 
-			const source = Observable.of(Observable.defer(() => Observable.of(1, 2, 3)), Observable.defer(() => Observable.of(4, 5, 6)));
+			const source = Observable.of(
+				Observable.defer(() => Observable.of(1, 2, 3)),
+				Observable.defer(() => Observable.of(4, 5, 6))
+			);
 
 			source.mergeAll(1).subscribe({
 				next(value) {
@@ -326,7 +363,7 @@ registerSuite('Observable', {
 				}
 			});
 
-			assert.deepEqual(values, [ 1, 2, 3, 4, 5, 6 ]);
+			assert.deepEqual(values, [1, 2, 3, 4, 5, 6]);
 		},
 
 		'asynchronous concat'(this: any) {
@@ -343,7 +380,7 @@ registerSuite('Observable', {
 					values.push(value);
 				},
 				complete: dfd.callback(() => {
-					assert.deepEqual(values, [ 1, 2, 3, 4 ]);
+					assert.deepEqual(values, [1, 2, 3, 4]);
 				})
 			});
 		},
@@ -351,14 +388,16 @@ registerSuite('Observable', {
 		'non observable values'() {
 			let values: any[] = [];
 
-			Observable.of(1, 2, 3).mergeAll(1).subscribe(value => {
-				values.push(value);
-			});
+			Observable.of(1, 2, 3)
+				.mergeAll(1)
+				.subscribe((value) => {
+					values.push(value);
+				});
 
-			assert.deepEqual(values, [ 1, 2, 3 ]);
+			assert.deepEqual(values, [1, 2, 3]);
 		},
 
-		'concurrency'(this: any) {
+		concurrency(this: any) {
 			const dfd = this.async();
 			let values: any[] = [];
 
@@ -378,7 +417,7 @@ registerSuite('Observable', {
 					values.push(value);
 				},
 				complete: dfd.callback(() => {
-					assert.sameMembers(values, [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]);
+					assert.sameMembers(values, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 				})
 			});
 		},
@@ -394,15 +433,17 @@ registerSuite('Observable', {
 					values.push(value);
 				},
 				complete: dfd.callback(() => {
-					assert.deepEqual(values, [ 1, 2 ]);
+					assert.deepEqual(values, [1, 2]);
 				})
 			});
 		},
 
 		'thrown errors during merge call observer'() {
-			Observable.of(new Observable(() => {
-				throw new Error('error');
-			})).subscribe({
+			Observable.of(
+				new Observable(() => {
+					throw new Error('error');
+				})
+			).subscribe({
 				error(error) {
 					assert.equal(error.message, 'error');
 				}
@@ -410,9 +451,11 @@ registerSuite('Observable', {
 		},
 
 		'called errors during merge call observer'() {
-			Observable.of(new Observable(observer => {
-				observer.error(new Error('error'));
-			})).subscribe({
+			Observable.of(
+				new Observable((observer) => {
+					observer.error(new Error('error'));
+				})
+			).subscribe({
 				error(error) {
 					assert.equal(error.message, 'error');
 				}

--- a/tests/unit/QueuingEvented.ts
+++ b/tests/unit/QueuingEvented.ts
@@ -15,71 +15,70 @@ function isCustomEvent(object: any): object is CustomEvent {
 }
 
 registerSuite('QueuingEvented', {
-		'events are queued for the first subscriber': function () {
-			const evented = new QueuingEvented();
-			let listenerCallCount = 0;
+	'events are queued for the first subscriber': function() {
+		const evented = new QueuingEvented();
+		let listenerCallCount = 0;
 
+		evented.emit({
+			type: 'test',
+			value: 1
+		});
+
+		evented.on('test', function() {
+			listenerCallCount++;
+		});
+
+		assert.strictEqual(listenerCallCount, 1);
+	},
+
+	'events do not get queued over maximum'() {
+		const evented = new QueuingEvented();
+		evented.maxEvents = 5;
+		let expectedValues: number[] = [];
+
+		for (let i = 1; i <= 10; i++) {
 			evented.emit({
 				type: 'test',
-				value: 1
+				value: i
 			});
-
-			evented.on('test', function () {
-				listenerCallCount++;
-			});
-
-			assert.strictEqual(listenerCallCount, 1);
-		},
-
-		'events do not get queued over maximum'() {
-			const evented = new QueuingEvented();
-			evented.maxEvents = 5;
-			let expectedValues: number[] = [];
-
-			for (let i = 1; i <= 10; i++) {
-				evented.emit({
-					type: 'test',
-					value: i
-				});
-			}
-
-			evented.on('test', function (event) {
-				if (isCustomEvent(event)) {
-					expectedValues.push(event.value);
-				}
-			});
-
-			assert.deepEqual(expectedValues, [ 6, 7, 8, 9, 10 ]);
-		},
-
-		'events work fine if used normally'() {
-			const evented = new QueuingEvented();
-			let listenerCallCount = 0;
-
-			evented.on('test', function () {
-				listenerCallCount++;
-			});
-
-			evented.emit({
-				type: 'test'
-			});
-
-			assert.strictEqual(listenerCallCount, 1);
-		},
-
-		'events have glob matching'() {
-			const evented = new QueuingEvented();
-			let listenerCallCount = 0;
-
-			evented.emit({
-				type: 'test'
-			});
-
-			evented.on('t*', function () {
-				listenerCallCount++;
-			});
-
-			assert.strictEqual(listenerCallCount, 1);
 		}
+
+		evented.on('test', function(event) {
+			if (isCustomEvent(event)) {
+				expectedValues.push(event.value);
+			}
+		});
+
+		assert.deepEqual(expectedValues, [6, 7, 8, 9, 10]);
+	},
+
+	'events work fine if used normally'() {
+		const evented = new QueuingEvented();
+		let listenerCallCount = 0;
+
+		evented.on('test', function() {
+			listenerCallCount++;
+		});
+
+		evented.emit({
+			type: 'test'
+		});
+
+		assert.strictEqual(listenerCallCount, 1);
+	},
+
+	'events have glob matching'() {
+		const evented = new QueuingEvented();
+		let listenerCallCount = 0;
+
+		evented.emit({
+			type: 'test'
+		});
+
+		evented.on('t*', function() {
+			listenerCallCount++;
+		});
+
+		assert.strictEqual(listenerCallCount, 1);
 	}
-);
+});

--- a/tests/unit/Scheduler.ts
+++ b/tests/unit/Scheduler.ts
@@ -21,120 +21,153 @@ registerSuite('Scheduler', () => {
 		},
 
 		tests: {
-
-			'callback handling': function (this: any) {
+			'callback handling': function(this: any) {
 				const dfd = this.async(5000);
 
 				function c() {
 					a();
-					scheduler.schedule(function () {
+					scheduler.schedule(function() {
 						parts.push('first');
 					});
-					queueTask(function () {
+					queueTask(function() {
 						parts.push('third');
 					});
-					scheduler.schedule(function () {
+					scheduler.schedule(function() {
 						parts.push('second');
 					});
 					b();
 				}
 
 				c();
-				setTimeout(dfd.callback(function () {
-					assert.equal(parts.join(','), 'a,b,first,second,third',
-						'Callbacks registered with scheduler should be executed as part of the same task.');
-				}), 300);
+				setTimeout(
+					dfd.callback(function() {
+						assert.equal(
+							parts.join(','),
+							'a,b,first,second,third',
+							'Callbacks registered with scheduler should be executed as part of the same task.'
+						);
+					}),
+					300
+				);
 			},
 
-			'scheduler type': function (this: any) {
+			'scheduler type': function(this: any) {
 				const dfd = this.async(5000);
 				const macroScheduler = new Scheduler();
 				scheduler = new Scheduler({ queueFunction: queueMicroTask });
 
 				function test() {
-					macroScheduler.schedule(function () {
+					macroScheduler.schedule(function() {
 						parts.push('second');
 					});
-					scheduler.schedule(function () {
+					scheduler.schedule(function() {
 						parts.push('first');
 					});
 				}
 
 				test();
-				setTimeout(dfd.callback(function () {
-					assert.equal(parts.join(','), 'first,second',
-						'It should be possible to change the type of task being registered.');
-				}), 300);
+				setTimeout(
+					dfd.callback(function() {
+						assert.equal(
+							parts.join(','),
+							'first,second',
+							'It should be possible to change the type of task being registered.'
+						);
+					}),
+					300
+				);
 			},
 
-			'when deferWhileProcessing is true': function (this: any) {
+			'when deferWhileProcessing is true': function(this: any) {
 				const dfd = this.async(5000);
 
 				function test() {
-					scheduler.schedule(function () {
+					scheduler.schedule(function() {
 						parts.push('first');
 
-						scheduler.schedule(function () {
+						scheduler.schedule(function() {
 							parts.push('third');
 						});
 					});
-					queueTask(function () {
+					queueTask(function() {
 						parts.push('second');
 					});
 				}
 
 				test();
-				setTimeout(dfd.callback(function () {
-					assert.equal(parts.join(','), 'first,second,third',
-						'Callbacks registered while the current batch is processing should be deferred.');
-				}), 300);
+				setTimeout(
+					dfd.callback(function() {
+						assert.equal(
+							parts.join(','),
+							'first,second,third',
+							'Callbacks registered while the current batch is processing should be deferred.'
+						);
+					}),
+					300
+				);
 			},
 
-			'when deferWhileProcessing is false': function (this: any) {
+			'when deferWhileProcessing is false': function(this: any) {
 				const dfd = this.async(5000);
 				scheduler = new Scheduler({ deferWhileProcessing: false });
 
 				function test() {
-					scheduler.schedule(function () {
+					scheduler.schedule(function() {
 						parts.push('first');
 
-						scheduler.schedule(function () {
+						scheduler.schedule(function() {
 							parts.push('second');
 						});
 					});
-						queueTask(function () {
+					queueTask(function() {
 						parts.push('third');
 					});
 				}
 
 				test();
-				setTimeout(dfd.callback(function () {
-					assert.equal(parts.join(','), 'first,second,third',
-						'Callbacks registered while the current batch is processing should be queued immediately.');
-				}), 300);
+				setTimeout(
+					dfd.callback(function() {
+						assert.equal(
+							parts.join(','),
+							'first,second,third',
+							'Callbacks registered while the current batch is processing should be queued immediately.'
+						);
+					}),
+					300
+				);
 			},
 
-			'scheduler.schedule() => handle.destroy()': function (this: any) {
+			'scheduler.schedule() => handle.destroy()': function(this: any) {
 				const dfd = this.async(5000);
 
 				function test() {
-					scheduler.schedule(function () {
-						parts.push('first');
-					}).destroy();
-					scheduler.schedule(function () {
+					scheduler
+						.schedule(function() {
+							parts.push('first');
+						})
+						.destroy();
+					scheduler.schedule(function() {
 						parts.push('second');
 
-						scheduler.schedule(function () {
-							parts.push('third');
-						}).destroy();
+						scheduler
+							.schedule(function() {
+								parts.push('third');
+							})
+							.destroy();
 					});
 				}
 
 				test();
-				setTimeout(dfd.callback(function () {
-					assert.equal(parts.join(','), 'second',
-						'Destroying a callback should result in it not being called.');
-				}), 300);
+				setTimeout(
+					dfd.callback(function() {
+						assert.equal(
+							parts.join(','),
+							'second',
+							'Destroying a callback should result in it not being called.'
+						);
+					}),
+					300
+				);
 			}
 		}
 	};

--- a/tests/unit/UrlSearchParams.ts
+++ b/tests/unit/UrlSearchParams.ts
@@ -3,11 +3,11 @@ const { assert } = intern.getPlugin('chai');
 import UrlSearchParams from '../../src/UrlSearchParams';
 
 registerSuite('UrlSearchParams', {
-	construct: (function () {
+	construct: (function() {
 		function checkParams(params: UrlSearchParams) {
-			assert.deepEqual(params.getAll('foo'), [ 'bar', 'baz' ]);
-			assert.deepEqual(params.getAll('bar'), [ 'foo' ]);
-			assert.deepEqual(params.getAll('baz'), [ '' ]);
+			assert.deepEqual(params.getAll('foo'), ['bar', 'baz']);
+			assert.deepEqual(params.getAll('bar'), ['foo']);
+			assert.deepEqual(params.getAll('baz'), ['']);
 		}
 
 		return {
@@ -20,7 +20,7 @@ registerSuite('UrlSearchParams', {
 			// Next three tests should generate 'params' objects with same contents
 
 			object() {
-				const params = new UrlSearchParams({ foo: [ 'bar', 'baz' ], bar: 'foo', baz: <any> null });
+				const params = new UrlSearchParams({ foo: ['bar', 'baz'], bar: 'foo', baz: <any>null });
 				checkParams(params);
 			},
 
@@ -30,15 +30,15 @@ registerSuite('UrlSearchParams', {
 
 				// Equals signs after the first will be included in the value
 				params = new UrlSearchParams('foo=bar=baz');
-				assert.deepEqual(params.getAll('foo'), [ 'bar=baz' ]);
+				assert.deepEqual(params.getAll('foo'), ['bar=baz']);
 
 				// Handle empty keys
 				params = new UrlSearchParams('=foo&');
-				assert.deepEqual(params.getAll(''), [ 'foo', '' ]);
+				assert.deepEqual(params.getAll(''), ['foo', '']);
 			},
 
 			UrlSearchParams() {
-				const params1 = new UrlSearchParams({ foo: [ 'bar', 'baz' ], bar: 'foo', baz: <any> null });
+				const params1 = new UrlSearchParams({ foo: ['bar', 'baz'], bar: 'foo', baz: <any>null });
 				const params = new UrlSearchParams(params1);
 				checkParams(params);
 			}
@@ -50,13 +50,13 @@ registerSuite('UrlSearchParams', {
 			// Appending with a new key is the same as 'set'
 			const params = new UrlSearchParams();
 			params.append('foo', 'bar');
-			assert.deepEqual(params.getAll('foo'), [ 'bar' ]);
+			assert.deepEqual(params.getAll('foo'), ['bar']);
 		},
 
 		'existing key'() {
 			const params = new UrlSearchParams({ foo: 'bar' });
 			params.append('foo', 'baz');
-			assert.deepEqual(params.getAll('foo'), [ 'bar', 'baz' ]);
+			assert.deepEqual(params.getAll('foo'), ['bar', 'baz']);
 		}
 	},
 
@@ -68,21 +68,21 @@ registerSuite('UrlSearchParams', {
 
 	'#get'() {
 		// Get should always return the first entry for a key
-		const params1 = new UrlSearchParams({ foo: [ 'bar', 'baz' ] });
-		const params2 = new UrlSearchParams({ foo: [ 'baz', 'bar' ] });
+		const params1 = new UrlSearchParams({ foo: ['bar', 'baz'] });
+		const params2 = new UrlSearchParams({ foo: ['baz', 'bar'] });
 		assert.strictEqual(params1.get('foo'), 'bar');
 		assert.strictEqual(params2.get('foo'), 'baz');
 		assert.isUndefined(params2.get('bar'));
 	},
 
 	'#getAll'() {
-		const params = new UrlSearchParams({ foo: [ 'bar', 'baz' ] });
-		assert.deepEqual(params.getAll('foo'), [ 'bar', 'baz' ]);
+		const params = new UrlSearchParams({ foo: ['bar', 'baz'] });
+		assert.deepEqual(params.getAll('foo'), ['bar', 'baz']);
 		assert.isUndefined(params.getAll('bar'));
 	},
 
 	'#has'() {
-		const params = new UrlSearchParams({ foo: 'bar', bar: <any> undefined, baz: [] });
+		const params = new UrlSearchParams({ foo: 'bar', bar: <any>undefined, baz: [] });
 		assert.isTrue(params.has('foo'), 'expected string property to be present');
 		assert.isTrue(params.has('bar'), 'expected undefined property to be present');
 		assert.isTrue(params.has('baz'), 'expected empty array property to be present');
@@ -90,43 +90,43 @@ registerSuite('UrlSearchParams', {
 	},
 
 	'#keys'() {
-		const params = new UrlSearchParams({ foo: 'bar', bar: <any> undefined, baz: [] });
-		assert.deepEqual(params.keys(), [ 'foo', 'bar', 'baz' ]);
+		const params = new UrlSearchParams({ foo: 'bar', bar: <any>undefined, baz: [] });
+		assert.deepEqual(params.keys(), ['foo', 'bar', 'baz']);
 		params.delete('foo');
-		assert.deepEqual(params.keys(), [ 'bar', 'baz' ]);
+		assert.deepEqual(params.keys(), ['bar', 'baz']);
 
 		// Re-add to test consistent ordering across all platforms
 		params.append('foo', 'bar');
-		assert.deepEqual(params.keys(), [ 'foo', 'bar', 'baz' ]);
+		assert.deepEqual(params.keys(), ['foo', 'bar', 'baz']);
 	},
 
 	'#set'() {
 		const params = new UrlSearchParams({ foo: 'bar' });
 		params.set('foo', 'baz');
-		assert.deepEqual(params.getAll('foo'), [ 'baz' ]);
+		assert.deepEqual(params.getAll('foo'), ['baz']);
 		params.set('foo', 'qux');
-		assert.deepEqual(params.getAll('foo'), [ 'qux' ]);
+		assert.deepEqual(params.getAll('foo'), ['qux']);
 		params.set('bar', 'foo');
-		assert.deepEqual(params.getAll('foo'), [ 'qux' ]);
-		assert.deepEqual(params.getAll('bar'), [ 'foo' ]);
+		assert.deepEqual(params.getAll('foo'), ['qux']);
+		assert.deepEqual(params.getAll('bar'), ['foo']);
 	},
 
 	'#toString'() {
-		let params = new UrlSearchParams({ foo: [ 'bar', 'baz' ], bar: 'foo' });
+		let params = new UrlSearchParams({ foo: ['bar', 'baz'], bar: 'foo' });
 		assert.strictEqual(params.toString(), 'foo=bar&foo=baz&bar=foo');
 
-		params = new UrlSearchParams({ foo: 'bar', baz: <any> null });
+		params = new UrlSearchParams({ foo: 'bar', baz: <any>null });
 		assert.strictEqual(params.toString(), 'foo=bar&baz');
 
-		params = new UrlSearchParams({ foo: 'bar', bar: <any> null, baz: <any> null });
+		params = new UrlSearchParams({ foo: 'bar', bar: <any>null, baz: <any>null });
 		assert.strictEqual(params.toString(), 'foo=bar&bar&baz');
 
-		params = new UrlSearchParams({ foo: 'bar', bar: <any> undefined, baz: [] });
+		params = new UrlSearchParams({ foo: 'bar', bar: <any>undefined, baz: [] });
 		assert.strictEqual(params.toString(), 'foo=bar&bar&baz');
 		params.delete('foo');
 		assert.strictEqual(params.toString(), 'bar&baz');
 
-		params = new UrlSearchParams({ foo: [ <any> null ] });
+		params = new UrlSearchParams({ foo: [<any>null] });
 		assert.strictEqual(params.toString(), 'foo');
 	},
 
@@ -138,7 +138,7 @@ registerSuite('UrlSearchParams', {
 	},
 
 	'no data sharing'() {
-		const params1 = new UrlSearchParams({ foo: [ 'bar', 'baz' ], bar: 'foo' });
+		const params1 = new UrlSearchParams({ foo: ['bar', 'baz'], bar: 'foo' });
 		const params2 = new UrlSearchParams(params1);
 
 		assert.deepEqual(params1.getAll('foo'), params2.getAll('foo'));

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -31,7 +31,7 @@ import './uuid';
 import './util';
 import './has';
 
-if (typeof (<any> require).toUrl === 'function') {
+if (typeof (<any>require).toUrl === 'function') {
 	// tslint:disable-next-line
 	import('./text');
 }

--- a/tests/unit/aspect.ts
+++ b/tests/unit/aspect.ts
@@ -15,7 +15,7 @@ let methodSpy: any;
 let map: Map<string | symbol, (...args: any[]) => any>;
 
 function createBeforeSpy() {
-	return sinon.spy(function (a: number) {
+	return sinon.spy(function(a: number) {
 		return [a + 1];
 	});
 }
@@ -23,7 +23,7 @@ function createBeforeSpy() {
 function indexableTests(property: string | symbol): ObjectSuiteDescriptor {
 	return {
 		beforeEach() {
-			methodSpy = sinon.spy(function (a: number) {
+			methodSpy = sinon.spy(function(a: number) {
 				return a + 1;
 			});
 			obj = { [property]: methodSpy };
@@ -49,21 +49,23 @@ function indexableTests(property: string | symbol): ObjectSuiteDescriptor {
 					let receivedArgs: string[] = [];
 					let beforeCalled = false;
 					let obj = {
-						[property]: function (...args: string[]) {
+						[property]: function(...args: string[]) {
 							receivedArgs = args;
 						}
 					};
 
-					aspect.before(obj, property, function () {
+					aspect.before(obj, property, function() {
 						beforeCalled = true;
 					});
 
 					obj[property]('foo', 'bar');
 
-					assert.isTrue(beforeCalled,
-						'Before advice should be called before original function');
-					assert.deepEqual(receivedArgs, [ 'foo', 'bar' ],
-						'Arguments passed to original method should be unaltered if before advice returns undefined');
+					assert.isTrue(beforeCalled, 'Before advice should be called before original function');
+					assert.deepEqual(
+						receivedArgs,
+						['foo', 'bar'],
+						'Arguments passed to original method should be unaltered if before advice returns undefined'
+					);
 				},
 
 				'multiple aspect.before()'() {
@@ -85,18 +87,18 @@ function indexableTests(property: string | symbol): ObjectSuiteDescriptor {
 				'multiple aspect.before() with removal inside handler'() {
 					let count = 0;
 
-					const handle1 = aspect.before(obj, property, function () {
+					const handle1 = aspect.before(obj, property, function() {
 						count++;
 					});
 
 					// FIXME: TDZ
-					var handle2 = aspect.before(obj, property, function () {
+					var handle2 = aspect.before(obj, property, function() {
 						handle2.destroy();
 						handle1.destroy();
 						count++;
 					});
 
-					assert.doesNotThrow(function () {
+					assert.doesNotThrow(function() {
 						obj[property]();
 					});
 					assert.strictEqual(count, 1, 'Only one advising function should be called');
@@ -131,17 +133,17 @@ function indexableTests(property: string | symbol): ObjectSuiteDescriptor {
 					let handle2: Handle;
 
 					// FIXME: TDZ
-					var handle1 = aspect.after(obj, property, function () {
+					var handle1 = aspect.after(obj, property, function() {
 						handle1.destroy();
 						handle2.destroy();
 						count++;
 					});
 
-					handle2 = aspect.after(obj, property, function () {
+					handle2 = aspect.after(obj, property, function() {
 						count++;
 					});
 
-					assert.doesNotThrow(function () {
+					assert.doesNotThrow(function() {
 						obj[property]();
 					});
 					assert.strictEqual(count, 1, 'Only one advising function should be called');
@@ -289,10 +291,10 @@ function indexableTests(property: string | symbol): ObjectSuiteDescriptor {
 function mapTests(property: string | symbol): ObjectSuiteDescriptor {
 	return {
 		beforeEach() {
-			methodSpy = sinon.spy(function (a: number) {
+			methodSpy = sinon.spy(function(a: number) {
 				return a + 1;
 			});
-			map = new Map([ [ property, methodSpy ] ]);
+			map = new Map([[property, methodSpy]]);
 		},
 
 		tests: {
@@ -315,21 +317,28 @@ function mapTests(property: string | symbol): ObjectSuiteDescriptor {
 				'no return value from advising function'() {
 					let receivedArgs: string[] = [];
 					let beforeCalled = false;
-					map = new Map([ [ property, function (...args: string[]) {
-							receivedArgs = args;
-						} ] ]);
+					map = new Map([
+						[
+							property,
+							function(...args: string[]) {
+								receivedArgs = args;
+							}
+						]
+					]);
 
-					aspect.before(map, property, function () {
+					aspect.before(map, property, function() {
 						beforeCalled = true;
 					});
 
 					const method = map.get(property);
 					method && method('foo', 'bar');
 
-					assert.isTrue(beforeCalled,
-						'Before advice should be called before original function');
-					assert.deepEqual(receivedArgs, [ 'foo', 'bar' ],
-						'Arguments passed to original method should be unaltered if before advice returns undefined');
+					assert.isTrue(beforeCalled, 'Before advice should be called before original function');
+					assert.deepEqual(
+						receivedArgs,
+						['foo', 'bar'],
+						'Arguments passed to original method should be unaltered if before advice returns undefined'
+					);
 				},
 
 				'multiple aspect.before()'() {
@@ -352,18 +361,18 @@ function mapTests(property: string | symbol): ObjectSuiteDescriptor {
 				'multiple aspect.before() with removal inside handler'() {
 					let count = 0;
 
-					const handle1 = aspect.before(map, property, function () {
+					const handle1 = aspect.before(map, property, function() {
 						count++;
 					});
 
 					// FIXME: TDZ
-					var handle2 = aspect.before(map, property, function () {
+					var handle2 = aspect.before(map, property, function() {
 						handle2.destroy();
 						handle1.destroy();
 						count++;
 					});
 
-					assert.doesNotThrow(function () {
+					assert.doesNotThrow(function() {
 						const method = map.get(property);
 						method && method();
 					});
@@ -401,17 +410,17 @@ function mapTests(property: string | symbol): ObjectSuiteDescriptor {
 					let handle2: Handle;
 
 					// FIXME: TDZ
-					var handle1 = aspect.after(map, property, function () {
+					var handle1 = aspect.after(map, property, function() {
 						handle1.destroy();
 						handle2.destroy();
 						count++;
 					});
 
-					handle2 = aspect.after(map, property, function () {
+					handle2 = aspect.after(map, property, function() {
 						count++;
 					});
 
-					assert.doesNotThrow(function () {
+					assert.doesNotThrow(function() {
 						const method = map.get(property);
 						method && method();
 					});
@@ -579,14 +588,14 @@ registerSuite('aspect', {
 	},
 	'join points': {
 		'before advice': {
-			'adjust arguments': function () {
+			'adjust arguments': function() {
 				let result = 0;
 				function foo(a: number) {
 					result = a;
 				}
 
 				function advice(a: number) {
-					return [ a * a ];
+					return [a * a];
 				}
 
 				const fn = aspect.before(foo, advice);
@@ -595,7 +604,7 @@ registerSuite('aspect', {
 
 				assert.strictEqual(result, 4, '"result" should equal 4');
 			},
-			'passes this': function () {
+			'passes this': function() {
 				let result = 0;
 				function foo(this: any) {
 					result = this.a;
@@ -611,7 +620,7 @@ registerSuite('aspect', {
 				assert.strictEqual(context.a, 2, 'context.a should equal 2');
 				assert.strictEqual(result, 2, 'result should equal 2');
 			},
-			'multiple before advice': function () {
+			'multiple before advice': function() {
 				let result = 0;
 				const calls: string[] = [];
 				function foo(a: number) {
@@ -626,17 +635,17 @@ registerSuite('aspect', {
 
 				function advice2(a: number) {
 					calls.push('2');
-					return [ ++a ];
+					return [++a];
 				}
 
 				const fn = aspect.before(aspect.before(foo, advice1), advice2);
 				fn(2);
 				assert.strictEqual(result, 6, '"result" should equal 5');
-				assert.deepEqual(calls, [ '2', '1' ], 'advice should be called in order');
+				assert.deepEqual(calls, ['2', '1'], 'advice should be called in order');
 			}
 		},
 		'after advice': {
-			'adjust return value': function () {
+			'adjust return value': function() {
 				function foo(a: number) {
 					return a;
 				}
@@ -651,7 +660,7 @@ registerSuite('aspect', {
 
 				assert.strictEqual(result, 4, '"result" should equal 4');
 			},
-			'passes this': function () {
+			'passes this': function() {
 				function foo(this: any) {
 					return this.a;
 				}
@@ -667,7 +676,7 @@ registerSuite('aspect', {
 				assert.strictEqual(result, 4, '"result" should equal 4');
 				assert.strictEqual(context.c, 4, '"context.c" should equal 4');
 			},
-			'multiple after advice': function () {
+			'multiple after advice': function() {
 				const calls: string[] = [];
 				function foo(a: number): number {
 					return a;
@@ -687,11 +696,11 @@ registerSuite('aspect', {
 				fn = aspect.after(fn, advice2);
 				const result = fn(2);
 				assert.strictEqual(result, 7, '"result" should equal 7');
-				assert.deepEqual(calls, [ '1', '2' ], 'call should have been made in order');
+				assert.deepEqual(calls, ['1', '2'], 'call should have been made in order');
 			}
 		},
 		'around advice': {
-			'basic function': function () {
+			'basic function': function() {
 				function foo(a: number): number {
 					return a;
 				}
@@ -708,7 +717,7 @@ registerSuite('aspect', {
 				const result = fn(2);
 				assert.strictEqual(result, 5, '"result" should equal 5');
 			},
-			'preserves this': function () {
+			'preserves this': function() {
 				function foo(this: any, a: number): number {
 					return this.a;
 				}
@@ -725,14 +734,14 @@ registerSuite('aspect', {
 				const result = fn.apply(context);
 				assert.strictEqual(result, 2, '"result" should equal 2');
 			},
-			'multiple around advice': function () {
+			'multiple around advice': function() {
 				const calls: string[] = [];
 				function foo(a: number): number {
 					return a;
 				}
 
 				function advice1(origFn: Function): (...args: any[]) => number {
-					return function (this: any, ...args: any[]): number {
+					return function(this: any, ...args: any[]): number {
 						calls.push('1');
 						args[0]++;
 						return origFn.apply(this, args) + 1;
@@ -740,7 +749,7 @@ registerSuite('aspect', {
 				}
 
 				function advice2(origFn: Function): (...args: any[]) => number {
-					return function (this: any, ...args: any[]): number {
+					return function(this: any, ...args: any[]): number {
 						calls.push('2');
 						args[0] += args[0];
 						return origFn.apply(this, args) + 1;
@@ -750,11 +759,11 @@ registerSuite('aspect', {
 				const fn = aspect.around(aspect.around(foo, advice1), advice2);
 				const result = fn(2);
 				assert.strictEqual(result, 7, '"result" should equal 7');
-				assert.deepEqual(calls, [ '2', '1' ]);
+				assert.deepEqual(calls, ['2', '1']);
 			}
 		},
 		'combined advice': {
-			'before and after': function () {
+			'before and after': function() {
 				function foo(a: number): number {
 					return a + a;
 				}

--- a/tests/unit/async/ExtensiblePromise.ts
+++ b/tests/unit/async/ExtensiblePromise.ts
@@ -3,62 +3,69 @@ const { assert } = intern.getPlugin('chai');
 import ExtensiblePromise from '../../../src/async/ExtensiblePromise';
 
 registerSuite('ExtensiblePromise', {
-	'reject': function (this: any) {
+	reject: function(this: any) {
 		let dfd = this.async();
 		ExtensiblePromise.reject().then(
 			dfd.rejectOnError(() => assert.isTrue(false, 'Should not have called then with a rejected promise')),
-			dfd.callback(() => {
-			})
+			dfd.callback(() => {})
 		);
 	},
 
-	'resolve': function (this: any) {
+	resolve: function(this: any) {
 		let dfd = this.async();
 		ExtensiblePromise.resolve().then(
-			dfd.callback(() => {
-			}),
+			dfd.callback(() => {}),
 			dfd.rejectOnError(() => assert.isTrue(false, 'Promise was rejected but it should have resolved'))
 		);
 	},
 
-	'catch': function (this: any) {
+	catch: function(this: any) {
 		let dfd = this.async();
-		ExtensiblePromise.reject().catch(
-			dfd.callback(() => {
+		ExtensiblePromise.reject().catch(dfd.callback(() => {}));
+	},
+
+	'then resolve w/ no handler': function(this: any) {
+		let dfd = this.async();
+		ExtensiblePromise.resolve().then(
+			undefined,
+			dfd.rejectOnError(() => {
+				assert.isTrue(false, 'Should not have rejected');
 			})
 		);
+		setTimeout(dfd.callback(() => {}), 100);
 	},
 
-	'then resolve w/ no handler': function (this: any) {
-		let dfd = this.async();
-		ExtensiblePromise.resolve().then(undefined, dfd.rejectOnError(() => {
-			assert.isTrue(false, 'Should not have rejected');
-		}));
-		setTimeout(dfd.callback(() => {
-		}), 100);
-	},
-
-	'then reject w/ no handler': function (this: any) {
+	'then reject w/ no handler': function(this: any) {
 		let dfd = this.async();
 
-		ExtensiblePromise.reject().then(dfd.rejectOnError(() => {
-			assert.isTrue(false, 'Should not have resolved');
-		}), undefined).catch(dfd.callback(() => {
-		}));
+		ExtensiblePromise.reject()
+			.then(
+				dfd.rejectOnError(() => {
+					assert.isTrue(false, 'Should not have resolved');
+				}),
+				undefined
+			)
+			.catch(dfd.callback(() => {}));
 	},
 
 	'.all': {
 		'with array'() {
-			return ExtensiblePromise.all([ 1, ExtensiblePromise.resolve(2), new ExtensiblePromise((resolve) => {
-				setTimeout(() => resolve(3), 100);
-			}) ]).then((results: any) => {
-				assert.deepEqual(results, [ 1, 2, 3 ]);
+			return ExtensiblePromise.all([
+				1,
+				ExtensiblePromise.resolve(2),
+				new ExtensiblePromise((resolve) => {
+					setTimeout(() => resolve(3), 100);
+				})
+			]).then((results: any) => {
+				assert.deepEqual(results, [1, 2, 3]);
 			});
 		},
 
 		'with object'() {
 			return ExtensiblePromise.all({
-				one: 1, two: ExtensiblePromise.resolve(2), three: new ExtensiblePromise((resolve) => {
+				one: 1,
+				two: ExtensiblePromise.resolve(2),
+				three: new ExtensiblePromise((resolve) => {
 					setTimeout(() => resolve(3), 100);
 				})
 			}).then((results: any) => {
@@ -72,11 +79,14 @@ registerSuite('ExtensiblePromise', {
 			ExtensiblePromise.all({
 				one: ExtensiblePromise.resolve(1),
 				two: ExtensiblePromise.reject(new Error('error message'))
-			}).then(dfd.rejectOnError(() => {
-				assert.fail('should have failed');
-			}), dfd.callback((error: Error) => {
-				assert.equal(error.message, 'error message');
-			}));
+			}).then(
+				dfd.rejectOnError(() => {
+					assert.fail('should have failed');
+				}),
+				dfd.callback((error: Error) => {
+					assert.equal(error.message, 'error message');
+				})
+			);
 		}
 	}
 });

--- a/tests/unit/async/Task.ts
+++ b/tests/unit/async/Task.ts
@@ -8,8 +8,7 @@ import Task, { State, isTask } from '../../../src/async/Task';
 
 const suite: Tests = {
 	'isTask()'() {
-		const task = new Task((resolve) => resolve(), () => {
-		});
+		const task = new Task((resolve) => resolve(), () => {});
 
 		assert.isTrue(isTask(task), 'Should return true');
 		assert.isFalse(isTask(Promise.resolve()), 'Should return false');
@@ -25,15 +24,17 @@ const suite: Tests = {
 		let cancelerCalled = false;
 		let resolver: any;
 		let task = new Task(
-			function (resolve) {
+			function(resolve) {
 				resolver = resolve;
 			},
-			function () {
+			function() {
 				cancelerCalled = true;
 			}
-		).then(dfd.rejectOnError(function () {
-			assert(false, 'Task should not have resolved');
-		}));
+		).then(
+			dfd.rejectOnError(function() {
+				assert(false, 'Task should not have resolved');
+			})
+		);
 
 		task.cancel();
 		resolver();
@@ -41,7 +42,7 @@ const suite: Tests = {
 		assert.isTrue(cancelerCalled, 'Canceler should have been called synchronously');
 		assert.strictEqual(task.state, State.Canceled, 'Task should have Canceled state');
 
-		setTimeout(dfd.callback(function () {}), 100);
+		setTimeout(dfd.callback(function() {}), 100);
 	},
 
 	'Task#cancel with no canceler'(this: any) {
@@ -49,37 +50,44 @@ const suite: Tests = {
 		let resolver: any;
 		let task = new Task((resolve) => {
 			resolver = resolve;
-		}).then(dfd.rejectOnError(function () {
-			assert(false, 'Task should not have resolved');
-		}));
+		}).then(
+			dfd.rejectOnError(function() {
+				assert(false, 'Task should not have resolved');
+			})
+		);
 
 		task.cancel();
 		resolver();
 
 		assert.strictEqual(task.state, State.Canceled, 'Task should have canceled state');
-		setTimeout(dfd.callback(() => {
-		}), 100);
+		setTimeout(dfd.callback(() => {}), 100);
 	},
 
-	'Task#cancel resolved/rejected promises don\'t call canceler'(this: any) {
+	"Task#cancel resolved/rejected promises don't call canceler"(this: any) {
 		let dfd = this.async();
 		let cancelCalled = false;
-		let task = new Task((resolve) => {
-			setTimeout(() => {
-				resolve();
-			}, 0);
-		}, () => {
-			cancelCalled = true;
-		});
+		let task = new Task(
+			(resolve) => {
+				setTimeout(() => {
+					resolve();
+				}, 0);
+			},
+			() => {
+				cancelCalled = true;
+			}
+		);
 
 		setTimeout(() => {
 			task.cancel();
 		}, 10);
 
-		setTimeout(dfd.callback(() => {
-			assert.strictEqual(task.state, State.Fulfilled, 'Task should have fulfilled state');
-			assert.isFalse(cancelCalled, 'Cancel should not have been called');
-		}), 100);
+		setTimeout(
+			dfd.callback(() => {
+				assert.strictEqual(task.state, State.Fulfilled, 'Task should have fulfilled state');
+				assert.isFalse(cancelCalled, 'Cancel should not have been called');
+			}),
+			100
+		);
 	},
 
 	'Task#finally': {
@@ -87,18 +95,20 @@ const suite: Tests = {
 			let dfd = this.async();
 			let resolver: any;
 			let task = new Task(
-				function (resolve) {
+				function(resolve) {
 					resolver = resolve;
 				},
-				function () {}
+				function() {}
 			)
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'Task should not have resolved');
-			}), dfd.rejectOnError(function () {
-				assert(false, 'Task should not have rejected');
-			}))
-			.finally(dfd.callback(function () {
-			}));
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'Task should not have resolved');
+					}),
+					dfd.rejectOnError(function() {
+						assert(false, 'Task should not have rejected');
+					})
+				)
+				.finally(dfd.callback(function() {}));
 
 			task.cancel();
 			resolver();
@@ -108,17 +118,20 @@ const suite: Tests = {
 			let dfd = this.async();
 			let resolver: any;
 			let task = new Task(
-				function (resolve, reject) {
+				function(resolve, reject) {
 					resolver = reject;
 				},
-				function () {}
+				function() {}
 			)
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'Task should not have resolved');
-			}), dfd.rejectOnError(function () {
-				assert(false, 'Task should not have rejected');
-			}))
-			.finally(dfd.callback(function () {}));
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'Task should not have resolved');
+					}),
+					dfd.rejectOnError(function() {
+						assert(false, 'Task should not have rejected');
+					})
+				)
+				.finally(dfd.callback(function() {}));
 
 			task.cancel();
 			resolver();
@@ -128,21 +141,21 @@ const suite: Tests = {
 			let dfd = this.async(5000, 4);
 			let resolver: any;
 			let task = new Task(
-				function (resolve, reject) {
+				function(resolve, reject) {
 					resolver = resolve;
 				},
-				function () {}
-			).finally(function () {
+				function() {}
+			).finally(function() {
 				return Task.resolve(5);
 			});
 
-			let taskA = task.finally(function () {
+			let taskA = task.finally(function() {
 				dfd.resolve();
 				throw new Error('foo');
 			});
-			taskA.finally(dfd.callback(function () {}));
-			task.finally(dfd.callback(function () {}));
-			task.finally(dfd.callback(function () {}));
+			taskA.finally(dfd.callback(function() {}));
+			task.finally(dfd.callback(function() {}));
+			task.finally(dfd.callback(function() {}));
 
 			task.cancel();
 			resolver();
@@ -153,23 +166,28 @@ const suite: Tests = {
 			let resolver: any;
 
 			let task = new Task(
-				function (resolve, reject) {
+				function(resolve, reject) {
 					resolver = resolve;
 				},
-				function () {}
-			).then(function () {
-				task.cancel();
-				return new Promise(function (resolve, reject) {
-					setTimeout(resolve);
-				});
-			})
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'should not have run');
-			}))
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'should not have run');
-			}))
-			.finally(dfd.callback(function () {}));
+				function() {}
+			)
+				.then(function() {
+					task.cancel();
+					return new Promise(function(resolve, reject) {
+						setTimeout(resolve);
+					});
+				})
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'should not have run');
+					})
+				)
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'should not have run');
+					})
+				)
+				.finally(dfd.callback(function() {}));
 
 			resolver();
 		},
@@ -179,36 +197,39 @@ const suite: Tests = {
 			let resolver: any;
 
 			let task = new Task(
-				function (resolve, reject) {
+				function(resolve, reject) {
 					resolver = resolve;
 				},
-				function () {}
-			).then(function () {
-				task.cancel();
-				return new Promise(function (resolve, reject) {
-					setTimeout(reject);
-				}).catch(() => {});
-			})
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'should not have run');
-			}))
-			.then(dfd.rejectOnError(function () {
-				assert(false, 'should not have run');
-			}))
-			.catch(() => {})
-			.finally(dfd.callback(function () {}));
+				function() {}
+			)
+				.then(function() {
+					task.cancel();
+					return new Promise(function(resolve, reject) {
+						setTimeout(reject);
+					}).catch(() => {});
+				})
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'should not have run');
+					})
+				)
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'should not have run');
+					})
+				)
+				.catch(() => {})
+				.finally(dfd.callback(function() {}));
 
 			resolver();
 		},
 
 		'invoked if already canceled'(this: any) {
 			const dfd = this.async();
-			const task = new Task(() => {
-			});
+			const task = new Task(() => {});
 			task.cancel();
 
-			task.finally(dfd.callback(() => {
-			}));
+			task.finally(dfd.callback(() => {}));
 		},
 
 		'finally is only called once when called after cancel'(this: any) {
@@ -218,13 +239,18 @@ const suite: Tests = {
 				setTimeout(resolve, 10);
 			});
 			task.cancel();
-			task.finally(dfd.callback(() => {
-				callCount++;
-			}));
+			task.finally(
+				dfd.callback(() => {
+					callCount++;
+				})
+			);
 
-			setTimeout(dfd.callback(() => {
-				assert.equal(callCount, 1);
-			}), 100);
+			setTimeout(
+				dfd.callback(() => {
+					assert.equal(callCount, 1);
+				}),
+				100
+			);
 		},
 
 		'finally is only called once when called before cancel'(this: any) {
@@ -233,14 +259,19 @@ const suite: Tests = {
 			const task = new Task((resolve) => {
 				setTimeout(resolve, 10);
 			});
-			task.finally(dfd.callback(() => {
-				callCount++;
-			}));
+			task.finally(
+				dfd.callback(() => {
+					callCount++;
+				})
+			);
 			task.cancel();
 
-			setTimeout(dfd.callback(() => {
-				assert.equal(callCount, 1);
-			}), 100);
+			setTimeout(
+				dfd.callback(() => {
+					assert.equal(callCount, 1);
+				}),
+				100
+			);
 		},
 
 		'finally does not change the resolve value'(this: any) {
@@ -249,9 +280,11 @@ const suite: Tests = {
 				setTimeout(resolve.bind(null, 'test'), 10);
 			});
 			task = task.finally(() => 'changed');
-			task.then(dfd.callback((value: string) => {
-				assert.strictEqual(value, 'test');
-			}));
+			task.then(
+				dfd.callback((value: string) => {
+					assert.strictEqual(value, 'test');
+				})
+			);
 		}
 	},
 
@@ -272,78 +305,82 @@ const suite: Tests = {
 /* tslint:disable-next-line:variable-name */
 function addPromiseTests(suite: any, Promise: any) {
 	suite['.all'] = {
-		'empty array': function (this: any) {
+		'empty array': function(this: any) {
 			let dfd = this.async();
-			let promise = Promise.all([]).then(dfd.callback(function (value: any[]) {
-				assert.isArray(value);
-				assert.deepEqual(value, []);
-			}));
+			let promise = Promise.all([]).then(
+				dfd.callback(function(value: any[]) {
+					assert.isArray(value);
+					assert.deepEqual(value, []);
+				})
+			);
 			assert.instanceOf(promise, Promise, 'promise should have expected type');
 		},
 
-		'mixed values and resolved': function (this: any) {
+		'mixed values and resolved': function(this: any) {
 			let dfd = this.async();
-			Promise.all([ 0, Promise.resolve(1), Promise.resolve(2) ]).then(
-				dfd.callback(function (value: number[]) {
+			Promise.all([0, Promise.resolve(1), Promise.resolve(2)]).then(
+				dfd.callback(function(value: number[]) {
 					assert.isArray(value);
-					assert.deepEqual(value, [ 0, 1, 2 ]);
+					assert.deepEqual(value, [0, 1, 2]);
 				})
 			);
 		},
 
-		'iterable argument': function (this: any) {
+		'iterable argument': function(this: any) {
 			let dfd = this.async();
 			Promise.all({
 				[Symbol.iterator]() {
-					return new ShimIterator<number | Thenable<number>>([
-						0, Promise.resolve(1), Promise.resolve(2)
-					]);
+					return new ShimIterator<number | Thenable<number>>([0, Promise.resolve(1), Promise.resolve(2)]);
 				}
 			}).then(
-				dfd.callback(function (value: number[]) {
+				dfd.callback(function(value: number[]) {
 					assert.isArray(value);
-					assert.deepEqual(value, [ 0, 1, 2 ]);
+					assert.deepEqual(value, [0, 1, 2]);
 				})
 			);
 		},
 
-		'reject if any rejected': function (this: any) {
+		'reject if any rejected': function(this: any) {
 			let dfd = this.async();
-			let pending = new Promise(function () {});
+			let pending = new Promise(function() {});
 			let rejected = Promise.reject(new Error('rejected'));
 
-			Promise.all([ pending, rejected ]).then(
-				dfd.rejectOnError(function () {
+			Promise.all([pending, rejected]).then(
+				dfd.rejectOnError(function() {
 					assert(false, 'Should not have resolved');
 				}),
-				dfd.callback(function (error: Error) {
+				dfd.callback(function(error: Error) {
 					assert.strictEqual(error.message, 'rejected');
 				})
 			);
 		},
 
-		'foreign thenables': function (this: any) {
+		'foreign thenables': function(this: any) {
 			let dfd = this.async();
 			let normal = Promise.resolve(1);
-			let foreign = <any> {
-				then: function (f: Function) {
+			let foreign = <any>{
+				then: function(f: Function) {
 					f(2);
 				}
 			};
 
-			Promise.all([ normal, foreign ]).then(dfd.callback(function (value: number[]) {
-				assert.deepEqual(value, [ 1, 2 ]);
-			}));
+			Promise.all([normal, foreign]).then(
+				dfd.callback(function(value: number[]) {
+					assert.deepEqual(value, [1, 2]);
+				})
+			);
 		},
 
-		'non-callable thenables': function (this: any) {
+		'non-callable thenables': function(this: any) {
 			let dfd = this.async();
 			let normal = Promise.resolve(1);
-			let foreign = <any> { then: 'foo' };
+			let foreign = <any>{ then: 'foo' };
 
-			Promise.all([ normal, foreign ]).then(dfd.callback(function (value: number[]) {
-				assert.deepEqual(value, [ 1, foreign ]);
-			}));
+			Promise.all([normal, foreign]).then(
+				dfd.callback(function(value: number[]) {
+					assert.deepEqual(value, [1, foreign]);
+				})
+			);
 		},
 
 		'sparse array': {
@@ -354,12 +391,14 @@ function addPromiseTests(suite: any, Promise: any) {
 				iterable[1] = Promise.resolve(1);
 				iterable[3] = Promise.resolve(3);
 
-				Promise.all(iterable).then(dfd.callback(function (value: number[]) {
-					assert.isUndefined(value[0]);
-					assert.strictEqual(value[1], 1);
-					assert.isUndefined(value[2]);
-					assert.strictEqual(value[3], 3);
-				}));
+				Promise.all(iterable).then(
+					dfd.callback(function(value: number[]) {
+						assert.isUndefined(value[0]);
+						assert.strictEqual(value[1], 1);
+						assert.isUndefined(value[2]);
+						assert.strictEqual(value[3], 3);
+					})
+				);
 			},
 
 			race(this: any) {
@@ -369,32 +408,32 @@ function addPromiseTests(suite: any, Promise: any) {
 				iterable[1] = Promise.resolve(1);
 				iterable[3] = Promise.resolve(3);
 
-				Promise.race(iterable).then(dfd.callback(function (value: number) {
-					assert.isUndefined(value);
-				}));
+				Promise.race(iterable).then(
+					dfd.callback(function(value: number) {
+						assert.isUndefined(value);
+					})
+				);
 			}
 		},
 
-		'value not input': function (this: any) {
+		'value not input': function(this: any) {
 			let dfd = this.async();
-			let iterable = [ 0, 1 ];
+			let iterable = [0, 1];
 
-			Promise.all(iterable).then(dfd.callback(function (value: number[]) {
-				assert.notStrictEqual(value, iterable);
-			}));
+			Promise.all(iterable).then(
+				dfd.callback(function(value: number[]) {
+					assert.notStrictEqual(value, iterable);
+				})
+			);
 		},
 
-		'cancelable': (function () {
+		cancelable: (function() {
 			return {
-				'isIterable': function (this: any) {
+				isIterable: function(this: any) {
 					// Make sure it checks whether each PromiseLike is cancelable
 					const promise = Promise.resolve();
 					promise.cancel = null;
-					const pending = [
-						promise,
-						new Task(() => {}),
-						new Task(() => {})
-					];
+					const pending = [promise, new Task(() => {}), new Task(() => {})];
 
 					cancelTasks(pending).then(() => {
 						pending.forEach((task) => {
@@ -404,11 +443,11 @@ function addPromiseTests(suite: any, Promise: any) {
 						});
 					});
 				},
-				'isObject': function (this: any) {
+				isObject: function(this: any) {
 					// Make sure it checks whether each PromiseLike is cancelable
 					const promise = Promise.resolve();
 					promise.cancel = null;
-					const pending: { [ index: string ]: PromiseLike<any> } = {
+					const pending: { [index: string]: PromiseLike<any> } = {
 						foo: new Task(() => {}),
 						bar: new Task(() => {}),
 						promise
@@ -436,62 +475,67 @@ function addPromiseTests(suite: any, Promise: any) {
 	};
 
 	suite['.race'] = {
-		'empty array': function (this: any) {
+		'empty array': function(this: any) {
 			let dfd = this.async();
-			Promise.race([]).then(dfd.rejectOnError(function () {
-				assert.fail(false, true, 'Promise should not have resolved');
-			}));
-			setTimeout(dfd.callback(function () {}), 10);
+			Promise.race([]).then(
+				dfd.rejectOnError(function() {
+					assert.fail(false, true, 'Promise should not have resolved');
+				})
+			);
+			setTimeout(dfd.callback(function() {}), 10);
 		},
 
-		'mixed values and resolved': function (this: any) {
+		'mixed values and resolved': function(this: any) {
 			let dfd = this.async();
-			Promise.race([ 0, Promise.resolve(1), Promise.resolve(2) ])
-				.then(dfd.callback(function (value: any) {
-					assert.strictEqual(value, 0);
-				}));
-		},
-
-		'iterable argument': function (this: any) {
-			let dfd = this.async();
-			Promise.race({
-				[Symbol.iterator]() {
-					return new ShimIterator<number | Thenable<number>>([
-						0, Promise.resolve(1), Promise.resolve(2)
-					]);
-				}
-			}).then(
-				dfd.callback(function (value: any) {
+			Promise.race([0, Promise.resolve(1), Promise.resolve(2)]).then(
+				dfd.callback(function(value: any) {
 					assert.strictEqual(value, 0);
 				})
 			);
 		},
 
-		'reject if any rejected': function (this: any) {
+		'iterable argument': function(this: any) {
 			let dfd = this.async();
-			let pending = new Promise(function () {});
-			let rejected = Promise.reject(new Error('rejected'));
-
-			Promise.race([ pending, rejected ])
-				.then(dfd.rejectOnError(function () {
-					assert(false, 'Should not have resolved');
-				}), dfd.callback(function (error: Error) {
-					assert.strictEqual(error.message, 'rejected');
-				}));
+			Promise.race({
+				[Symbol.iterator]() {
+					return new ShimIterator<number | Thenable<number>>([0, Promise.resolve(1), Promise.resolve(2)]);
+				}
+			}).then(
+				dfd.callback(function(value: any) {
+					assert.strictEqual(value, 0);
+				})
+			);
 		},
 
-		'foreign thenables': function (this: any) {
+		'reject if any rejected': function(this: any) {
+			let dfd = this.async();
+			let pending = new Promise(function() {});
+			let rejected = Promise.reject(new Error('rejected'));
+
+			Promise.race([pending, rejected]).then(
+				dfd.rejectOnError(function() {
+					assert(false, 'Should not have resolved');
+				}),
+				dfd.callback(function(error: Error) {
+					assert.strictEqual(error.message, 'rejected');
+				})
+			);
+		},
+
+		'foreign thenables': function(this: any) {
 			let dfd = this.async();
 			let normal = Promise.resolve(1);
-			let foreign = <any> {
-				then: function (f: Function) {
+			let foreign = <any>{
+				then: function(f: Function) {
 					f(2);
 				}
 			};
 
-			Promise.race([ normal, foreign ]).then(dfd.callback(function (value: any) {
-				assert.strictEqual(value, 1);
-			}));
+			Promise.race([normal, foreign]).then(
+				dfd.callback(function(value: any) {
+					assert.strictEqual(value, 1);
+				})
+			);
 		}
 	};
 
@@ -500,11 +544,11 @@ function addPromiseTests(suite: any, Promise: any) {
 			let dfd = this.async();
 			let resolved = false;
 			let promise = Promise.reject(new Error('foo')).then(
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					resolved = true;
 					assert(false, 'should not have resolved');
 				}),
-				dfd.callback(function (error: Error) {
+				dfd.callback(function(error: Error) {
 					resolved = true;
 					assert.instanceOf(error, Error, 'error value should be an Error');
 					assert.propertyVal(error, 'message', 'foo', 'error value should have expected message');
@@ -518,17 +562,17 @@ function addPromiseTests(suite: any, Promise: any) {
 		'rejected thenable'(this: any) {
 			let dfd = this.async();
 			let resolved = false;
-			let thenable = <any> {
-				then: function (f: Function, r: Function) {
+			let thenable = <any>{
+				then: function(f: Function, r: Function) {
 					r(new Error('foo'));
 				}
 			};
 			Promise.resolve(thenable).then(
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					resolved = true;
 					assert(false, 'should not have rejected');
 				}),
-				dfd.callback(function (error: Error) {
+				dfd.callback(function(error: Error) {
 					resolved = true;
 					// value should be resolved value of thenable
 					assert.instanceOf(error, Error, 'error value should be an Error');
@@ -545,11 +589,11 @@ function addPromiseTests(suite: any, Promise: any) {
 			let dfd = this.async();
 			let resolved = false;
 			let promise = Promise.resolve('foo').then(
-				dfd.callback(function (value: any) {
+				dfd.callback(function(value: any) {
 					resolved = true;
 					assert.equal(value, 'foo', 'unexpected resolution value');
 				}),
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					resolved = true;
 					assert(false, 'should not have rejected');
 				})
@@ -562,18 +606,18 @@ function addPromiseTests(suite: any, Promise: any) {
 		thenable(this: any) {
 			let dfd = this.async();
 			let resolved = false;
-			let thenable = <any> {
-				then: function (f: Function) {
+			let thenable = <any>{
+				then: function(f: Function) {
 					f(2);
 				}
 			};
 			Promise.resolve(thenable).then(
-				dfd.callback(function (value: any) {
+				dfd.callback(function(value: any) {
 					resolved = true;
 					// value should be resolved value of thenable
 					assert.equal(value, 2, 'unexpected resolution value');
 				}),
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					resolved = true;
 					assert(false, 'should not have rejected');
 				})
@@ -584,229 +628,290 @@ function addPromiseTests(suite: any, Promise: any) {
 	};
 
 	suite['#catch'] = {
-		rejection: function (this: any) {
+		rejection: function(this: any) {
 			let dfd = this.async();
 			let error = new Error('foo');
-			Promise.reject(error).catch(dfd.callback(function (err: Error) {
-				assert.strictEqual(err, error);
-			}));
+			Promise.reject(error).catch(
+				dfd.callback(function(err: Error) {
+					assert.strictEqual(err, error);
+				})
+			);
 		},
 
-		identity: function (this: any) {
+		identity: function(this: any) {
 			let dfd = this.async();
 			let error = new Error('foo');
 			Promise.reject(error)
-				.then(dfd.rejectOnError(function () {
-					assert(false, 'Should not be resolved');
-				}))
-				.catch(dfd.callback(function (err: Error) {
-					assert.strictEqual(err, error);
-				}));
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'Should not be resolved');
+					})
+				)
+				.catch(
+					dfd.callback(function(err: Error) {
+						assert.strictEqual(err, error);
+					})
+				);
 		},
 
-		'resolver throws': function (this: any) {
+		'resolver throws': function(this: any) {
 			let dfd = this.async();
 
 			let error = new Error('foo');
-			let promise = new Promise(function () {
+			let promise = new Promise(function() {
 				throw error;
 			});
 
-			promise.catch(dfd.callback((err: Error) => {
-				assert.strictEqual(err, error);
-			}));
+			promise.catch(
+				dfd.callback((err: Error) => {
+					assert.strictEqual(err, error);
+				})
+			);
 		},
 
-		'handler throws': function (this: any) {
+		'handler throws': function(this: any) {
 			let dfd = this.async();
 			let error = new Error('foo');
 			Promise.resolve(5)
-				.then(function () {
+				.then(function() {
 					throw error;
 				})
-				.catch(dfd.callback(function (err: Error) {
-					assert.strictEqual(err, error);
-				}));
+				.catch(
+					dfd.callback(function(err: Error) {
+						assert.strictEqual(err, error);
+					})
+				);
 		},
 
 		'then throws': {
-			'from resolver': function (this: any) {
+			'from resolver': function(this: any) {
 				let dfd = this.async();
 				let error = new Error('foo');
-				let foreign = <any> {
+				let foreign = <any>{
 					then: (f: Function) => {
 						throw error;
 					}
 				};
 
-				let promise = new Promise(function (resolve: Function) {
+				let promise = new Promise(function(resolve: Function) {
 					resolve(foreign);
 				});
-				promise.catch(dfd.callback(function (err: Error) {
-					assert.strictEqual(err, error);
-				}));
+				promise.catch(
+					dfd.callback(function(err: Error) {
+						assert.strictEqual(err, error);
+					})
+				);
 			},
 
-			'from handler': function (this: any) {
+			'from handler': function(this: any) {
 				let dfd = this.async();
 				let error = new Error('foo');
-				let foreign = <any> {
-					then: function (f: Function) {
+				let foreign = <any>{
+					then: function(f: Function) {
 						throw error;
 					}
 				};
 
 				Promise.resolve(5)
-					.then(function () {
+					.then(function() {
 						return foreign;
 					})
-					.catch(dfd.callback(function (err: Error) {
-						assert.strictEqual(err, error);
-					}));
+					.catch(
+						dfd.callback(function(err: Error) {
+							assert.strictEqual(err, error);
+						})
+					);
 			},
 
 			'then throws': {
-				'from resolver': function (this: any) {
+				'from resolver': function(this: any) {
 					let dfd = this.async();
 					let error = new Error('foo');
-					let foreign = <any> {
-						then: function (f: Function) {
+					let foreign = <any>{
+						then: function(f: Function) {
 							throw error;
 						}
 					};
 
-					let promise = new Promise(function (resolve: Function) {
+					let promise = new Promise(function(resolve: Function) {
 						resolve(foreign);
 					});
-					promise.catch(dfd.callback(function (err: Error) {
-						assert.strictEqual(err, error);
-					}));
+					promise.catch(
+						dfd.callback(function(err: Error) {
+							assert.strictEqual(err, error);
+						})
+					);
 				},
 
-				'from handler': function (this: any) {
+				'from handler': function(this: any) {
 					let dfd = this.async();
 					let error = new Error('foo');
-					let foreign = <any> {
-						then: function (f: Function) {
+					let foreign = <any>{
+						then: function(f: Function) {
 							throw error;
 						}
 					};
 
 					Promise.resolve(5)
-						.then(function () {
+						.then(function() {
 							return foreign;
 						})
-						.catch(dfd.callback(function (err: Error) {
-							assert.strictEqual(err, error);
-						}));
+						.catch(
+							dfd.callback(function(err: Error) {
+								assert.strictEqual(err, error);
+							})
+						);
 				}
 			}
 		}
 	};
 
 	suite['#finally'] = {
-		'called for resolved Promise': function (this: any) {
+		'called for resolved Promise': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(dfd.callback(function () {}));
+			Promise.resolve(5).finally(dfd.callback(function() {}));
 		},
 
-		'called for rejected Promise': function (this: any) {
+		'called for rejected Promise': function(this: any) {
 			let dfd = this.async();
-			Promise.reject(new Error('foo')).catch(() => {
-			}).finally(dfd.callback(function () {
-			}));
+			Promise.reject(new Error('foo'))
+				.catch(() => {})
+				.finally(dfd.callback(function() {}));
 		},
 
-		'value passes through': function (this: any) {
+		'value passes through': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(function () {}).then(dfd.callback(function (value: any) {
-				assert.strictEqual(value, 5);
-			}));
+			Promise.resolve(5)
+				.finally(function() {})
+				.then(
+					dfd.callback(function(value: any) {
+						assert.strictEqual(value, 5);
+					})
+				);
 		},
 
-		'rejection passes through': function (this: any) {
+		'rejection passes through': function(this: any) {
 			let dfd = this.async();
-			Promise.reject(new Error('foo')).finally(function () {}).then(dfd.rejectOnError(function () {
-				assert(false, 'Should not have resolved');
-			}), dfd.callback(function (reason: any) {
-				assert.propertyVal(reason, 'message', 'foo');
-			}));
+			Promise.reject(new Error('foo'))
+				.finally(function() {})
+				.then(
+					dfd.rejectOnError(function() {
+						assert(false, 'Should not have resolved');
+					}),
+					dfd.callback(function(reason: any) {
+						assert.propertyVal(reason, 'message', 'foo');
+					})
+				);
 		},
 
-		'returned value is ignored': function (this: any) {
+		'returned value is ignored': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(function (): any {
-				return 4;
-			}).then(dfd.callback(function (value: any) {
-				assert.strictEqual(value, 5);
-			}), dfd.rejectOnError(function () {
-				assert(false, 'Should not have rejected');
-			}));
+			Promise.resolve(5)
+				.finally(function(): any {
+					return 4;
+				})
+				.then(
+					dfd.callback(function(value: any) {
+						assert.strictEqual(value, 5);
+					}),
+					dfd.rejectOnError(function() {
+						assert(false, 'Should not have rejected');
+					})
+				);
 		},
 
-		'returned resolved promise is ignored': function (this: any) {
+		'returned resolved promise is ignored': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(function (): any {
-				return Promise.resolve(4);
-			}).then(dfd.callback(function (value: any) {
-				assert.strictEqual(value, 5);
-			}), dfd.rejectOnError(function () {
-				assert(false, 'Should not have rejected');
-			}));
+			Promise.resolve(5)
+				.finally(function(): any {
+					return Promise.resolve(4);
+				})
+				.then(
+					dfd.callback(function(value: any) {
+						assert.strictEqual(value, 5);
+					}),
+					dfd.rejectOnError(function() {
+						assert(false, 'Should not have rejected');
+					})
+				);
 		},
 
-		'thrown error rejects': function (this: any) {
+		'thrown error rejects': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(function () {
-				throw new Error('foo');
-			}).then(dfd.rejectOnError(function (value: any) {
-				assert(false, 'Should not have rejected');
-			}), dfd.callback(function (reason: any) {
-				assert.propertyVal(reason, 'message', 'foo');
-			}));
+			Promise.resolve(5)
+				.finally(function() {
+					throw new Error('foo');
+				})
+				.then(
+					dfd.rejectOnError(function(value: any) {
+						assert(false, 'Should not have rejected');
+					}),
+					dfd.callback(function(reason: any) {
+						assert.propertyVal(reason, 'message', 'foo');
+					})
+				);
 		},
 
-		'returned rejected promise rejects': function (this: any) {
+		'returned rejected promise rejects': function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).finally(function () {
-				return Promise.reject(new Error('foo'));
-			}).then(dfd.rejectOnError(function (value: any) {
-				assert(false, 'Should not have rejected');
-			}), dfd.callback(function (reason: any) {
-				assert.propertyVal(reason, 'message', 'foo');
-			}));
+			Promise.resolve(5)
+				.finally(function() {
+					return Promise.reject(new Error('foo'));
+				})
+				.then(
+					dfd.rejectOnError(function(value: any) {
+						assert(false, 'Should not have rejected');
+					}),
+					dfd.callback(function(reason: any) {
+						assert.propertyVal(reason, 'message', 'foo');
+					})
+				);
 		},
 
-		'returned resolved promise on rejection rejects': function (this: any) {
+		'returned resolved promise on rejection rejects': function(this: any) {
 			let dfd = this.async();
-			Promise.reject(new Error('foo')).finally(function () {
-				return Promise.resolve(5);
-			}).then(dfd.rejectOnError(function (value: any) {
-				assert(false, 'Should not have rejected');
-			}), dfd.callback(function (reason: any) {
-				assert.propertyVal(reason, 'message', 'foo');
-			}));
+			Promise.reject(new Error('foo'))
+				.finally(function() {
+					return Promise.resolve(5);
+				})
+				.then(
+					dfd.rejectOnError(function(value: any) {
+						assert(false, 'Should not have rejected');
+					}),
+					dfd.callback(function(reason: any) {
+						assert.propertyVal(reason, 'message', 'foo');
+					})
+				);
 		}
 	};
 
 	suite['#then'] = {
-		fulfillment: function (this: any) {
+		fulfillment: function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).then(dfd.callback(function (value: number) {
-				assert.strictEqual(value, 5);
-			}));
+			Promise.resolve(5).then(
+				dfd.callback(function(value: number) {
+					assert.strictEqual(value, 5);
+				})
+			);
 		},
 
-		identity: function (this: any) {
+		identity: function(this: any) {
 			let dfd = this.async();
-			Promise.resolve(5).then(null, dfd.rejectOnError(function (value: Error) {
-				assert(false, 'Should not have resolved');
-			})).then(dfd.callback(function (value: number) {
-				assert.strictEqual(value, 5);
-			}));
+			Promise.resolve(5)
+				.then(
+					null,
+					dfd.rejectOnError(function(value: Error) {
+						assert(false, 'Should not have resolved');
+					})
+				)
+				.then(
+					dfd.callback(function(value: number) {
+						assert.strictEqual(value, 5);
+					})
+				);
 		},
 
-		'resolve once': function (this: any) {
+		'resolve once': function(this: any) {
 			let dfd = this.async();
 			let evilPromise = {
 				then: (f?: Function, r?: Function) => {
@@ -818,11 +923,13 @@ function addPromiseTests(suite: any, Promise: any) {
 			};
 
 			let calledAlready = false;
-			const p = Promise.resolve(evilPromise).then(dfd.rejectOnError(function (value: number) {
-				assert.strictEqual(calledAlready, false, 'resolver should not have been called');
-				calledAlready = true;
-				assert.strictEqual(value, 1, 'resolver called with unexpected value');
-			}));
+			const p = Promise.resolve(evilPromise).then(
+				dfd.rejectOnError(function(value: number) {
+					assert.strictEqual(calledAlready, false, 'resolver should not have been called');
+					calledAlready = true;
+					assert.strictEqual(value, 1, 'resolver called with unexpected value');
+				})
+			);
 
 			p.catch(dfd.reject.bind(dfd));
 
@@ -835,13 +942,13 @@ function addPromiseTests(suite: any, Promise: any) {
 			let dfd = this.async();
 			let resolver: any;
 			let resolved = false;
-			new Promise(function (resolve: any, reject: any) {
+			new Promise(function(resolve: any, reject: any) {
 				resolver = resolve;
 			}).then(
-				dfd.callback(function () {
+				dfd.callback(function() {
 					resolved = true;
 				}),
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					assert(false, 'should not have rejected');
 				})
 			);
@@ -853,13 +960,13 @@ function addPromiseTests(suite: any, Promise: any) {
 			let dfd = this.async();
 			let resolver: any;
 			let resolved = false;
-			new Promise(function (resolve: any, reject: any) {
+			new Promise(function(resolve: any, reject: any) {
 				resolver = reject;
 			}).then(
-				dfd.rejectOnError(function () {
+				dfd.rejectOnError(function() {
 					assert(false, 'should not have resolved');
 				}),
-				dfd.callback(function () {
+				dfd.callback(function() {
 					resolved = true;
 				})
 			);

--- a/tests/unit/async/iteration.ts
+++ b/tests/unit/async/iteration.ts
@@ -24,9 +24,9 @@ interface ControlledPromise<T> extends Promise<T> {
 function createTriggerablePromise<T>(): ControlledPromise<T> {
 	let resolveFunc: any;
 	let rejectFunc: any;
-	const dfd: ControlledPromise<T>  = <ControlledPromise<T>> new Promise<T>(function (resolve, reject) {
-		resolveFunc = <any> resolve;
-		rejectFunc = <any> reject;
+	const dfd: ControlledPromise<T> = <ControlledPromise<T>>new Promise<T>(function(resolve, reject) {
+		resolveFunc = <any>resolve;
+		rejectFunc = <any>reject;
 	});
 	dfd.resolve = resolveFunc;
 	dfd.reject = rejectFunc;
@@ -41,19 +41,19 @@ function createTriggerablePromises<T>(amount: number): ControlledPromise<T>[] {
 	return list;
 }
 
-function helloWorldTest (value: any): boolean {
+function helloWorldTest(value: any): boolean {
 	return value === 'hello' || value === 'world';
 }
 
-function doublerMapper (value: any): any {
+function doublerMapper(value: any): any {
 	return value * 2;
 }
 
-function assertTrue (value: boolean): void {
+function assertTrue(value: boolean): void {
 	assert.isTrue(value);
 }
 
-function assertFalse (value: boolean): void {
+function assertFalse(value: boolean): void {
 	assert.isFalse(value);
 }
 
@@ -65,7 +65,10 @@ function join(current: string, value: string): string {
 	return current + value;
 }
 
-function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>) => Promise<any>, solutions: any): Tests {
+function findTests(
+	findMethod: (items: any[], callback: iteration.Filterer<any>) => Promise<any>,
+	solutions: any
+): Tests {
 	function getExpectedSolution(test: any): any {
 		return solutions[test.parent.name][test.name];
 	}
@@ -73,40 +76,40 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 	function getTests(useIterator: boolean = false): any {
 		return {
 			'synchronous values': {
-				'no matching values; returns undefined': function (this: any) {
+				'no matching values; returns undefined': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ 'non-matching' ];
+					const values = ['non-matching'];
 					const iterable = getIterable(useIterator, values);
-					return findMethod(iterable, helloWorldTest).then(function (result) {
+					return findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 				},
 
-				'one matching value': function (this: any) {
+				'one matching value': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ 'non-matching', 'hello' ];
+					const values = ['non-matching', 'hello'];
 					const iterable = getIterable(useIterator, values);
-					return findMethod(iterable, helloWorldTest).then(function (result) {
+					return findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 				},
 
-				'multiple matching values; only returns the first': function (this: any) {
+				'multiple matching values; only returns the first': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ 'non-matching', 'hello', 'world' ];
+					const values = ['non-matching', 'hello', 'world'];
 					const iterable = getIterable(useIterator, values);
-					return findMethod(iterable, helloWorldTest).then(function (result) {
+					return findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 				}
 			},
 
 			'asynchronous values': {
-				'no matching values; returns undefined': function (this: any) {
+				'no matching values; returns undefined': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ createTriggerablePromise() ];
+					const values = [createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
-					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+					const promise = findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 
@@ -115,11 +118,11 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 					return promise;
 				},
 
-				'one matching value': function (this: any) {
+				'one matching value': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ createTriggerablePromise(), createTriggerablePromise() ];
+					const values = [createTriggerablePromise(), createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
-					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+					const promise = findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 
@@ -129,11 +132,11 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 					return promise;
 				},
 
-				'multiple matching values; only returns the first': function (this: any) {
+				'multiple matching values; only returns the first': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+					const values = [createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
-					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+					const promise = findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 
@@ -144,22 +147,26 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 					return promise;
 				},
 
-				'mixed synchronous and asynchronous values': function (this: any) {
+				'mixed synchronous and asynchronous values': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values: [ ControlledPromise<string>, string, ControlledPromise<string> ] = [ createTriggerablePromise(), 'hello', createTriggerablePromise() ];
+					const values: [ControlledPromise<string>, string, ControlledPromise<string>] = [
+						createTriggerablePromise(),
+						'hello',
+						createTriggerablePromise()
+					];
 					const iterable = getIterable(useIterator, values);
-					const promise = findMethod(iterable, helloWorldTest).then(function (result) {
+					const promise = findMethod(iterable, helloWorldTest).then(function(result) {
 						assert.strictEqual(result, expected);
 					});
 
-					( <ControlledPromise<string>> values[0]).resolve('non-matching');
-					( <ControlledPromise<string>> values[2]).resolve('world');
+					(<ControlledPromise<string>>values[0]).resolve('non-matching');
+					(<ControlledPromise<string>>values[2]).resolve('world');
 
 					return promise;
 				},
 
-				'rejected promise value': function () {
-					const values = [ createTriggerablePromise() ];
+				'rejected promise value': function() {
+					const values = [createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
 					const promise = findMethod(iterable, helloWorldTest);
 
@@ -170,14 +177,14 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 			},
 
 			'asynchronous callback': {
-				'one asynchronous result': function (this: any) {
+				'one asynchronous result': function(this: any) {
 					const expected: any = getExpectedSolution(this);
-					const values = [ 'value1' ];
+					const values = ['value1'];
 					const iterable = getIterable(useIterator, values);
-					const result = [ createTriggerablePromise() ];
-					const promise = findMethod(iterable, function (value, i) {
+					const result = [createTriggerablePromise()];
+					const promise = findMethod(iterable, function(value, i) {
 						return result[i] as Promise<any>;
-					}).then(function (value) {
+					}).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 
@@ -186,11 +193,11 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 					return promise;
 				},
 
-				'asynchronous result with an eventually rejected promise': function () {
-					const values = [ 'value1' ];
+				'asynchronous result with an eventually rejected promise': function() {
+					const values = ['value1'];
 					const iterable = getIterable(useIterator, values);
-					const result = [ createTriggerablePromise() ];
-					const promise = findMethod(iterable, function (value, i) {
+					const result = [createTriggerablePromise()];
+					const promise = findMethod(iterable, function(value, i) {
 						return result[i] as Promise<any>;
 					});
 
@@ -208,7 +215,14 @@ function findTests(findMethod: (items: any[], callback: iteration.Filterer<any>)
 	};
 }
 
-function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: iteration.Reducer<any, any>, initialvalue?: any) => Promise<any>, solutions: any): Tests {
+function reduceTests(
+	reduceMethod: (
+		items: (any | Promise<any>)[],
+		callback: iteration.Reducer<any, any>,
+		initialvalue?: any
+	) => Promise<any>,
+	solutions: any
+): Tests {
 	function getExpectedSolution(test: any): any {
 		return solutions[test.parent.name][test.name];
 	}
@@ -218,51 +232,51 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 
 		return {
 			'synchronous values': {
-				[`reduce an empty ${valueType} without initial value is eventually rejected`]: function () {
+				[`reduce an empty ${valueType} without initial value is eventually rejected`]: function() {
 					const value = getIterable(useIterator, []);
-					const promise = (<any> reduceMethod)(value);
+					const promise = (<any>reduceMethod)(value);
 
 					return isEventuallyRejected(promise);
 				},
 
-				'reduce a single value without an initial value; should not call callback': function (this: any) {
+				'reduce a single value without an initial value; should not call callback': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
-					const values = [ 'h' ];
+					const values = ['h'];
 					const iterable = getIterable(useIterator, values);
-					return reduceMethod(iterable, throwImmediatly).then(function (value) {
+					return reduceMethod(iterable, throwImmediatly).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 				},
 
-				'reduce multiple values': function (this: any) {
+				'reduce multiple values': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
-					const values = [ 'h', 'e', 'l', 'l', 'o' ];
+					const values = ['h', 'e', 'l', 'l', 'o'];
 					const iterable = getIterable(useIterator, values);
-					return reduceMethod(iterable, join).then(function (value) {
+					return reduceMethod(iterable, join).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 				},
 
-				'reduce multiple values with initializer': function (this: any) {
+				'reduce multiple values with initializer': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
-					const values = [ 'w', 'o', 'r', 'l', 'd' ];
+					const values = ['w', 'o', 'r', 'l', 'd'];
 					const iterable = getIterable(useIterator, values);
-					return reduceMethod(iterable, join, 'hello ').then(function (value) {
+					return reduceMethod(iterable, join, 'hello ').then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 				}
 			},
 
 			'asynchronous values': {
-				'reduce a single value without initial value; should not call callback': function (this: any) {
+				'reduce a single value without initial value; should not call callback': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
-					const values = [ createTriggerablePromise() ];
+					const values = [createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
-					const promise = reduceMethod(iterable, throwImmediatly).then(function (value) {
+					const promise = reduceMethod(iterable, throwImmediatly).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 
@@ -271,12 +285,12 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 					return promise;
 				},
 
-				'reduce multiple values': function (this: any) {
+				'reduce multiple values': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
 					const values = createTriggerablePromises(5);
 					const iterable = getIterable(useIterator, values);
-					const promise = reduceMethod(iterable, join).then(function (value) {
+					const promise = reduceMethod(iterable, join).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 
@@ -289,12 +303,12 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 					return promise;
 				},
 
-				'reduce multiple values with initializer': function (this: any) {
+				'reduce multiple values with initializer': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
 					const values = createTriggerablePromises(5);
 					const iterable = getIterable(useIterator, values);
-					const promise = reduceMethod(iterable, join, 'hello ').then(function (value) {
+					const promise = reduceMethod(iterable, join, 'hello ').then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 
@@ -307,21 +321,21 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 					return promise;
 				},
 
-				'reduce multiple mixed values': function (this: any) {
+				'reduce multiple mixed values': function(this: any) {
 					const expected: any = getExpectedSolution(this);
 
-					const values = [ 'h', 'e', 'l', 'l', createTriggerablePromise()];
+					const values = ['h', 'e', 'l', 'l', createTriggerablePromise()];
 					const iterable = getIterable(useIterator, values);
-					const promise = reduceMethod(iterable, join).then(function (value) {
+					const promise = reduceMethod(iterable, join).then(function(value) {
 						assert.strictEqual(value, expected);
 					});
 
-					(<ControlledPromise<{}>> values[4]).resolve('o');
+					(<ControlledPromise<{}>>values[4]).resolve('o');
 
 					return promise;
 				},
 
-				'one promised value is rejected': function () {
+				'one promised value is rejected': function() {
 					const values = createTriggerablePromises(1);
 					const iterable = getIterable(useIterator, values);
 					const promise = reduceMethod(iterable, join);
@@ -333,38 +347,42 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 			},
 
 			'asynchronous callback': {
-				'multiple asynchronous reductions': function (this: any) {
+				'multiple asynchronous reductions': function(this: any) {
 					const { step, initialIndex, callbackValues } = getExpectedSolution(this);
 					const values: string[] = 'hello'.split('');
 					const iterable = getIterable(useIterator, values);
 					const results = createTriggerablePromises<string>(values.length);
 					let previousIndex = initialIndex;
-					const promise = reduceMethod(iterable,
-						function (previous: string, value: string, index: number, array: string[]): Promise<string> {
-							assert.strictEqual(value, values[index]);
-							assert.strictEqual(index, previousIndex + step);
-							previousIndex = index;
-							assert.deepEqual(values, array);
-							if (index !== initialIndex) {
-								return results[index - step].then(function (result) {
-									assert.strictEqual(previous, result);
-									return results[index];
-								});
-							}
-							return results[index];
-						});
+					const promise = reduceMethod(iterable, function(
+						previous: string,
+						value: string,
+						index: number,
+						array: string[]
+					): Promise<string> {
+						assert.strictEqual(value, values[index]);
+						assert.strictEqual(index, previousIndex + step);
+						previousIndex = index;
+						assert.deepEqual(values, array);
+						if (index !== initialIndex) {
+							return results[index - step].then(function(result) {
+								assert.strictEqual(previous, result);
+								return results[index];
+							});
+						}
+						return results[index];
+					});
 
-					results.forEach(function (result, i) {
+					results.forEach(function(result, i) {
 						result.resolve(callbackValues[i]);
 					});
 
 					return promise;
 				},
 
-				'one promised reduction is rejected': function () {
+				'one promised reduction is rejected': function() {
 					const values: string[] = 'hello'.split('');
 					const iterable = getIterable(useIterator, values);
-					const promise = reduceMethod(iterable, function (): Promise<string> {
+					const promise = reduceMethod(iterable, function(): Promise<string> {
 						throw new Error('expected');
 					});
 
@@ -375,7 +393,7 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 	}
 
 	const arrayLikeTests = getTests(false);
-	arrayLikeTests['synchronous values']['reduces a sparse array'] = function (this: any) {
+	arrayLikeTests['synchronous values']['reduces a sparse array'] = function(this: any) {
 		const expected: any = getExpectedSolution(this);
 
 		const values = Array(10);
@@ -384,11 +402,11 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 		values[5] = 'l';
 		values[7] = 'l';
 		values[9] = 'o';
-		return reduceMethod(values, join).then(function (value) {
+		return reduceMethod(values, join).then(function(value) {
 			assert.strictEqual(value, expected);
 		});
 	};
-	arrayLikeTests['asynchronous values']['reduces a sparse array'] = function (this: any) {
+	arrayLikeTests['asynchronous values']['reduces a sparse array'] = function(this: any) {
 		const expected: any = getExpectedSolution(this);
 
 		const values = Array(10);
@@ -398,7 +416,7 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 		values[7] = 'l';
 		values[8] = 'o';
 
-		const promise = reduceMethod(values, join).then(function (value) {
+		const promise = reduceMethod(values, join).then(function(value) {
 			assert.strictEqual(value, expected);
 		});
 
@@ -413,7 +431,10 @@ function reduceTests(reduceMethod: (items: (any | Promise<any>)[], callback: ite
 	};
 }
 
-function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], callback: iteration.Filterer<any>) => Promise<boolean>, solutions: any): Tests {
+function haltImmediatelyTests(
+	haltingMethod: (items: (any | Promise<any>)[], callback: iteration.Filterer<any>) => Promise<boolean>,
+	solutions: any
+): Tests {
 	function getParameters(test: any): any {
 		return solutions[test.parent.name][test.name];
 	}
@@ -425,7 +446,7 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 			const iterable = getIterable(useIterator, values);
 			const promise = haltingMethod(iterable, helloWorldTest).then(assertion);
 
-			values.forEach(function (value, index) {
+			values.forEach(function(value, index) {
 				value.resolve(results[index]);
 			});
 			return promise;
@@ -433,19 +454,19 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 
 		return {
 			'synchronous values': {
-				'one synchronous value': function (this: any) {
+				'one synchronous value': function(this: any) {
 					const { values, assertion } = getParameters(this);
 					const iterable = getIterable(useIterator, values);
 					return haltingMethod(iterable, helloWorldTest).then(assertion);
 				},
 
-				'multiple synchronous values': function (this: any) {
+				'multiple synchronous values': function(this: any) {
 					const { values, assertion } = getParameters(this);
 					const iterable = getIterable(useIterator, values);
 					return haltingMethod(iterable, helloWorldTest).then(assertion);
 				},
 
-				'multiple synchronous values with failure': function (this: any) {
+				'multiple synchronous values with failure': function(this: any) {
 					const { values, assertion } = getParameters(this);
 					const iterable = getIterable(useIterator, values);
 					return haltingMethod(iterable, helloWorldTest).then(assertion);
@@ -453,24 +474,21 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 			},
 
 			'asynchronous values': {
-				'one asynchronous value': function (this: any) {
+				'one asynchronous value': function(this: any) {
 					return testAsynchronousValues.call(this);
 				},
 
-				'multiple asynchronous values': function (this: any) {
+				'multiple asynchronous values': function(this: any) {
 					return testAsynchronousValues.call(this);
 				},
 
-				'multiple asynchronous values with failure': function (this: any) {
+				'multiple asynchronous values with failure': function(this: any) {
 					return testAsynchronousValues.call(this);
 				},
 
-				'mixed synchronous and asynchronous values': function (this: any) {
+				'mixed synchronous and asynchronous values': function(this: any) {
 					const { results, assertion } = getParameters(this);
-					const values: any[] = [
-						results[0],
-						createTriggerablePromise<string>()
-					];
+					const values: any[] = [results[0], createTriggerablePromise<string>()];
 					const iterable = getIterable(useIterator, values);
 					const promise = haltingMethod(iterable, helloWorldTest).then(assertion);
 
@@ -478,11 +496,8 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 					return promise;
 				},
 
-				'rejected promise value': function () {
-					const values: any[] = [
-						'hello',
-						createTriggerablePromise<string>()
-					];
+				'rejected promise value': function() {
+					const values: any[] = ['hello', createTriggerablePromise<string>()];
 					const iterable = getIterable(useIterator, values);
 					const promise = haltingMethod(iterable, helloWorldTest);
 
@@ -493,19 +508,19 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 			},
 
 			'asynchronous callback': {
-				'callback returns asynchronous results': function (this: any) {
+				'callback returns asynchronous results': function(this: any) {
 					const { resolution, assertion } = getParameters(this);
-					const values: any[] = [ 'unimportant', 'values' ];
+					const values: any[] = ['unimportant', 'values'];
 					const iterable = getIterable(useIterator, values);
-					return haltingMethod(iterable, function () {
+					return haltingMethod(iterable, function() {
 						return Promise.resolve(resolution);
 					}).then(assertion);
 				},
 
-				'callback returns asynchronous results with eventually rejected promise': function () {
-					const values: any[] = [ 'unimportant', 'values' ];
+				'callback returns asynchronous results with eventually rejected promise': function() {
+					const values: any[] = ['unimportant', 'values'];
 					const iterable = getIterable(useIterator, values);
-					const promise = haltingMethod(iterable, <any> function () {
+					const promise = haltingMethod(iterable, <any>function() {
 						throw new Error('kablewie!');
 					});
 
@@ -522,79 +537,85 @@ function haltImmediatelyTests(haltingMethod: (items: (any | Promise<any>)[], cal
 }
 
 registerSuite('async/iteration', {
-	'.every<T>()': (function () {
+	'.every<T>()': (function() {
 		const tests: any = haltImmediatelyTests(iteration.every, {
-				'synchronous values': {
-					'one synchronous value': { values: [ 'hello' ], assertion: assertTrue },
-					'multiple synchronous values': { values: [ 'hello', 'world' ], assertion: assertTrue },
-					'multiple synchronous values with failure': { values: [ 'hello', 'world', 'potato' ], assertion: assertFalse }
-				},
-				'asynchronous values': {
-					'one asynchronous value': { results: [ 'hello' ], assertion: assertTrue },
-					'multiple asynchronous values': { results: [ 'hello', 'world' ], assertion: assertTrue },
-					'multiple asynchronous values with failure': { results: [ 'hello', 'world', 'potato' ], assertion: assertFalse },
-					'mixed synchronous and asynchronous values': { results: [ 'hello', 'world' ], assertion: assertTrue }
-				},
-				'asynchronous callback': {
-					'callback returns asynchronous results': { resolution: true, assertion: assertTrue }
+			'synchronous values': {
+				'one synchronous value': { values: ['hello'], assertion: assertTrue },
+				'multiple synchronous values': { values: ['hello', 'world'], assertion: assertTrue },
+				'multiple synchronous values with failure': {
+					values: ['hello', 'world', 'potato'],
+					assertion: assertFalse
 				}
+			},
+			'asynchronous values': {
+				'one asynchronous value': { results: ['hello'], assertion: assertTrue },
+				'multiple asynchronous values': { results: ['hello', 'world'], assertion: assertTrue },
+				'multiple asynchronous values with failure': {
+					results: ['hello', 'world', 'potato'],
+					assertion: assertFalse
+				},
+				'mixed synchronous and asynchronous values': { results: ['hello', 'world'], assertion: assertTrue }
+			},
+			'asynchronous callback': {
+				'callback returns asynchronous results': { resolution: true, assertion: assertTrue }
 			}
-		);
+		});
 		const asyncArrayTests = tests['array-like value']['asynchronous callback'];
 
-		asyncArrayTests['callback returns multiple asynchronous results with a failure and every exits immediately'] = function () {
+		asyncArrayTests[
+			'callback returns multiple asynchronous results with a failure and every exits immediately'
+		] = function() {
 			const values: any[] = ['unimportant', 'values'];
-			const response: Promise<boolean>[] = [
-				createTriggerablePromise(),
-				createTriggerablePromise()
-			];
-			const promise = iteration.every<any>(values, function (value: any, i: number) {
-				return response[i];
-			}).then(assertFalse);
+			const response: Promise<boolean>[] = [createTriggerablePromise(), createTriggerablePromise()];
+			const promise = iteration
+				.every<any>(values, function(value: any, i: number) {
+					return response[i];
+				})
+				.then(assertFalse);
 
-			(<ControlledPromise<boolean>> response[1]).resolve(false);
+			(<ControlledPromise<boolean>>response[1]).resolve(false);
 
-			return <any> promise;
+			return <any>promise;
 		};
 
 		return tests;
 	})(),
 
-	'.filter()': (function () {
+	'.filter()': (function() {
 		function getTests(useIterator: boolean = false): any {
 			return {
 				'synchronous values': {
-					'one passing value': function () {
-						const values = [ 'hello' ];
+					'one passing value': function() {
+						const values = ['hello'];
 						const iterable = getIterable(useIterator, values);
-						return iteration.filter(iterable, helloWorldTest).then(function (results) {
+						return iteration.filter(iterable, helloWorldTest).then(function(results) {
 							assert.deepEqual(results, values);
 						});
 					},
 
-					'one failing value': function () {
-						const values = [ 'failing value' ];
+					'one failing value': function() {
+						const values = ['failing value'];
 						const iterable = getIterable(useIterator, values);
-						return iteration.filter(iterable, helloWorldTest).then(function (results) {
+						return iteration.filter(iterable, helloWorldTest).then(function(results) {
 							assert.deepEqual(results, []);
 						});
 					},
 
-					'mixed passing and failing values': function () {
-						const values = [ 'hello', 'failing value', 'world' ];
+					'mixed passing and failing values': function() {
+						const values = ['hello', 'failing value', 'world'];
 						const iterable = getIterable(useIterator, values);
-						return iteration.filter(iterable, helloWorldTest).then(function (results) {
-							assert.deepEqual(results, [ 'hello', 'world' ]);
+						return iteration.filter(iterable, helloWorldTest).then(function(results) {
+							assert.deepEqual(results, ['hello', 'world']);
 						});
 					}
 				},
 
 				'asynchronous values': {
-					'one passing value': function () {
-						const values = [ createTriggerablePromise() ];
+					'one passing value': function() {
+						const values = [createTriggerablePromise()];
 						const iterable = getIterable(useIterator, values);
-						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
-							assert.deepEqual(results, [ 'hello' ]);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function(results) {
+							assert.deepEqual(results, ['hello']);
 						});
 
 						values[0].resolve('hello');
@@ -602,11 +623,11 @@ registerSuite('async/iteration', {
 						return promise;
 					},
 
-					'one failing value': function () {
-						const values = [ createTriggerablePromise() ];
+					'one failing value': function() {
+						const values = [createTriggerablePromise()];
 						const iterable = getIterable(useIterator, values);
-						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
-							assert.deepEqual(results, [ ]);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function(results) {
+							assert.deepEqual(results, []);
 						});
 
 						values[0].resolve('failing value');
@@ -614,11 +635,15 @@ registerSuite('async/iteration', {
 						return promise;
 					},
 
-					'mixed passing and failing values': function () {
-						const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
+					'mixed passing and failing values': function() {
+						const values = [
+							createTriggerablePromise(),
+							createTriggerablePromise(),
+							createTriggerablePromise()
+						];
 						const iterable = getIterable(useIterator, values);
-						const promise = iteration.filter(iterable, helloWorldTest).then(function (results) {
-							assert.deepEqual(results, [ 'hello', 'world' ]);
+						const promise = iteration.filter(iterable, helloWorldTest).then(function(results) {
+							assert.deepEqual(results, ['hello', 'world']);
 						});
 
 						values[0].resolve('hello');
@@ -628,8 +653,8 @@ registerSuite('async/iteration', {
 						return promise;
 					},
 
-					'rejected value': function () {
-						const values = [ createTriggerablePromise() ];
+					'rejected value': function() {
+						const values = [createTriggerablePromise()];
 						const iterable = getIterable(useIterator, values);
 						const promise = iteration.filter(iterable, helloWorldTest);
 
@@ -640,35 +665,43 @@ registerSuite('async/iteration', {
 				},
 
 				'asynchronous callback': {
-					'one asynchronous result': function () {
-						const values = [ 'unimportant' ];
+					'one asynchronous result': function() {
+						const values = ['unimportant'];
 						const iterable = getIterable(useIterator, values);
-						return iteration.filter(iterable, function () {
-							return Promise.resolve(true);
-						}).then(function (results) {
-							assert.deepEqual(results, values);
-						});
+						return iteration
+							.filter(iterable, function() {
+								return Promise.resolve(true);
+							})
+							.then(function(results) {
+								assert.deepEqual(results, values);
+							});
 					},
 
-					'asynchronous results with an eventually rejected promise': function () {
-						const values = [ 'unimportant' ];
+					'asynchronous results with an eventually rejected promise': function() {
+						const values = ['unimportant'];
 						const iterable = getIterable(useIterator, values);
-						const promise = iteration.filter(iterable, <any> function () {
+						const promise = iteration.filter(iterable, <any>function() {
 							throw new Error('kaboom!');
 						});
 
 						return isEventuallyRejected(promise);
 					},
 
-					'mixed matched/unmatched asynchronous results': function () {
-						const values = [ 'hello', 'world', 'non-matching' ];
+					'mixed matched/unmatched asynchronous results': function() {
+						const values = ['hello', 'world', 'non-matching'];
 						const iterable = getIterable(useIterator, values);
-						const pass = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
-						const promise = iteration.filter(iterable, function (value, i) {
-							return pass[i] as Promise<any>;
-						}).then(function (results) {
-							assert.deepEqual(results, [ 'hello', 'world' ]);
-						});
+						const pass = [
+							createTriggerablePromise(),
+							createTriggerablePromise(),
+							createTriggerablePromise()
+						];
+						const promise = iteration
+							.filter(iterable, function(value, i) {
+								return pass[i] as Promise<any>;
+							})
+							.then(function(results) {
+								assert.deepEqual(results, ['hello', 'world']);
+							});
 
 						pass[0].resolve(true);
 						pass[1].resolve(true);
@@ -686,7 +719,8 @@ registerSuite('async/iteration', {
 		};
 	})(),
 
-	'.find()': findTests(iteration.find, { // solutions
+	'.find()': findTests(iteration.find, {
+		// solutions
 		'synchronous values': {
 			'no matching values; returns undefined': undefined,
 			'one matching value': 'hello',
@@ -703,7 +737,8 @@ registerSuite('async/iteration', {
 		}
 	}),
 
-	'.findIndex()': findTests(iteration.findIndex, { // solutions
+	'.findIndex()': findTests(iteration.findIndex, {
+		// solutions
 		'synchronous values': {
 			'no matching values; returns undefined': -1,
 			'one matching value': 1,
@@ -722,26 +757,26 @@ registerSuite('async/iteration', {
 
 	'.map()': {
 		'synchronous values': {
-			'transform a single value': function () {
-				const values = [ 1 ];
-				return iteration.map(values, doublerMapper).then(function (values) {
-					assert.deepEqual(values, [ 2 ]);
+			'transform a single value': function() {
+				const values = [1];
+				return iteration.map(values, doublerMapper).then(function(values) {
+					assert.deepEqual(values, [2]);
 				});
 			},
 
-			'transform multiple values': function () {
-				const values = [ 1, 2, 3 ];
-				return iteration.map(values, doublerMapper).then(function (values) {
-					assert.deepEqual(values, [ 2, 4, 6 ]);
+			'transform multiple values': function() {
+				const values = [1, 2, 3];
+				return iteration.map(values, doublerMapper).then(function(values) {
+					assert.deepEqual(values, [2, 4, 6]);
 				});
 			}
 		},
 
 		'asynchronous values': {
-			'transform a single value': function () {
-				const values = [ createTriggerablePromise() ];
-				const promise = iteration.map(values, doublerMapper).then(function (values) {
-					assert.deepEqual(values, [ 2 ]);
+			'transform a single value': function() {
+				const values = [createTriggerablePromise()];
+				const promise = iteration.map(values, doublerMapper).then(function(values) {
+					assert.deepEqual(values, [2]);
 				});
 
 				values[0].resolve(1);
@@ -749,10 +784,10 @@ registerSuite('async/iteration', {
 				return promise;
 			},
 
-			'transform multiple values': function () {
-				const values = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				const promise = iteration.map(values, doublerMapper).then(function (values) {
-					assert.deepEqual(values, [ 2, 4, 6 ]);
+			'transform multiple values': function() {
+				const values = [createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
+				const promise = iteration.map(values, doublerMapper).then(function(values) {
+					assert.deepEqual(values, [2, 4, 6]);
 				});
 
 				values[0].resolve(1);
@@ -762,10 +797,10 @@ registerSuite('async/iteration', {
 				return promise;
 			},
 
-			'transform multiple mixed values': function () {
-				const values: any[] = [ createTriggerablePromise(), 2, createTriggerablePromise(), 4 ];
-				const promise = iteration.map(values, doublerMapper).then(function (values) {
-					assert.deepEqual(values, [ 2, 4, 6, 8 ]);
+			'transform multiple mixed values': function() {
+				const values: any[] = [createTriggerablePromise(), 2, createTriggerablePromise(), 4];
+				const promise = iteration.map(values, doublerMapper).then(function(values) {
+					assert.deepEqual(values, [2, 4, 6, 8]);
 				});
 
 				values[0].resolve(1);
@@ -774,8 +809,8 @@ registerSuite('async/iteration', {
 				return promise;
 			},
 
-			'one promised value is rejected': function () {
-				const values = [ createTriggerablePromise() ];
+			'one promised value is rejected': function() {
+				const values = [createTriggerablePromise()];
 				const promise = iteration.map(values, doublerMapper);
 
 				values[0].reject();
@@ -785,28 +820,32 @@ registerSuite('async/iteration', {
 		},
 
 		'asynchronous callback': {
-			'one asynchronous mapping': function () {
-				const values = [ 'unused' ];
-				const results = [ createTriggerablePromise() ];
-				const promise = iteration.map(values, function (value, i) {
-					return results[i];
-				}).then(function (values) {
-					assert.deepEqual(values, [ 2 ]);
-				});
+			'one asynchronous mapping': function() {
+				const values = ['unused'];
+				const results = [createTriggerablePromise()];
+				const promise = iteration
+					.map(values, function(value, i) {
+						return results[i];
+					})
+					.then(function(values) {
+						assert.deepEqual(values, [2]);
+					});
 
 				results[0].resolve(2);
 
 				return promise;
 			},
 
-			'multiple asynchronous mappings': function () {
-				const values = [ 'unused', 'unused', 'unused' ];
-				const results = [ createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise() ];
-				const promise = iteration.map(values, function (value, i) {
-					return results[i];
-				}).then(function (values) {
-					assert.deepEqual(values, [ 2, 4, 6 ]);
-				});
+			'multiple asynchronous mappings': function() {
+				const values = ['unused', 'unused', 'unused'];
+				const results = [createTriggerablePromise(), createTriggerablePromise(), createTriggerablePromise()];
+				const promise = iteration
+					.map(values, function(value, i) {
+						return results[i];
+					})
+					.then(function(values) {
+						assert.deepEqual(values, [2, 4, 6]);
+					});
 
 				results[0].resolve(2);
 				results[1].resolve(4);
@@ -815,10 +854,10 @@ registerSuite('async/iteration', {
 				return promise;
 			},
 
-			'one promised mapping is rejected': function () {
-				const values = [ 'unused' ];
-				const results = [ createTriggerablePromise() ];
-				const promise = iteration.map(values, function (value, i) {
+			'one promised mapping is rejected': function() {
+				const values = ['unused'];
+				const results = [createTriggerablePromise()];
+				const promise = iteration.map(values, function(value, i) {
 					return results[i];
 				});
 
@@ -846,8 +885,11 @@ registerSuite('async/iteration', {
 		},
 
 		'asynchronous callback': {
-			'multiple asynchronous reductions': { step: 1, initialIndex: 0,
-				callbackValues: [ 'h', 'he', 'hel', 'hell', 'hello' ] }
+			'multiple asynchronous reductions': {
+				step: 1,
+				initialIndex: 0,
+				callbackValues: ['h', 'he', 'hel', 'hell', 'hello']
+			}
 		}
 	}),
 
@@ -868,46 +910,53 @@ registerSuite('async/iteration', {
 		},
 
 		'asynchronous callback': {
-			'multiple asynchronous reductions': { step: -1, initialIndex: 4,
-				callbackValues: [ 'olleh', 'olle', 'oll', 'ol', 'o' ]  }
+			'multiple asynchronous reductions': {
+				step: -1,
+				initialIndex: 4,
+				callbackValues: ['olleh', 'olle', 'oll', 'ol', 'o']
+			}
 		}
 	}),
 
 	'.series()': {
-		'no values returns an empty array': function () {
-			return iteration.series([], throwImmediatly).then(function (result) {
+		'no values returns an empty array': function() {
+			return iteration.series([], throwImmediatly).then(function(result) {
 				assert.deepEqual(result, []);
 			});
 		},
 
-		'synchronous values': function () {
+		'synchronous values': function() {
 			const values = 'hello'.split('');
 			const expected = values;
 
 			const composite: number[] = [];
-			return iteration.series(values, function (value, index, array) {
-				composite.push(index);
-				assert.deepEqual(array, expected);
-				return value;
-			}).then(function (results) {
-				assert.deepEqual(composite, [ 0, 1, 2, 3, 4 ]);
-				assert.deepEqual(results, values);
-			});
+			return iteration
+				.series(values, function(value, index, array) {
+					composite.push(index);
+					assert.deepEqual(array, expected);
+					return value;
+				})
+				.then(function(results) {
+					assert.deepEqual(composite, [0, 1, 2, 3, 4]);
+					assert.deepEqual(results, values);
+				});
 		},
 
-		'asynchronous values': function () {
+		'asynchronous values': function() {
 			const values = createTriggerablePromises(5);
 			const expected = 'hello'.split('');
 
 			const composite: number[] = [];
-			const promise = iteration.series(values, function (value, index, array) {
-				composite.push(index);
-				assert.deepEqual(array, expected);
-				return value;
-			}).then(function (results) {
-				assert.deepEqual(composite, [ 0, 1, 2, 3, 4 ]);
-				assert.deepEqual(results, expected);
-			});
+			const promise = iteration
+				.series(values, function(value, index, array) {
+					composite.push(index);
+					assert.deepEqual(array, expected);
+					return value;
+				})
+				.then(function(results) {
+					assert.deepEqual(composite, [0, 1, 2, 3, 4]);
+					assert.deepEqual(results, expected);
+				});
 
 			values[1].resolve('e');
 			values[3].resolve('l');
@@ -918,17 +967,19 @@ registerSuite('async/iteration', {
 			return promise;
 		},
 
-		'asynchronous callback': function () {
+		'asynchronous callback': function() {
 			const values = 'hello'.split('');
 			const results = createTriggerablePromises(5);
-			const promise = iteration.series(values, function (value, index, array) {
-				assert.strictEqual(value, array[index]);
-				return results[index].then(function () {
-					return index;
+			const promise = iteration
+				.series(values, function(value, index, array) {
+					assert.strictEqual(value, array[index]);
+					return results[index].then(function() {
+						return index;
+					});
+				})
+				.then(function(results) {
+					assert.deepEqual(results, [0, 1, 2, 3, 4]);
 				});
-			}).then(function (results) {
-				assert.deepEqual(results, [ 0, 1, 2, 3, 4 ]);
-			});
 
 			results[1].resolve();
 			results[3].resolve();
@@ -940,37 +991,49 @@ registerSuite('async/iteration', {
 		}
 	},
 
-	'.some()': (function () {
+	'.some()': (function() {
 		const tests: any = haltImmediatelyTests(iteration.some, {
-				'synchronous values': {
-					'one synchronous value': { values: [ 'hello' ], assertion: assertTrue },
-					'multiple synchronous values': { values: [ 'non-matching', 'world' ], assertion: assertTrue },
-					'multiple synchronous values with failure': { values: [ 'non-matching', 'non-matching' ], assertion: assertFalse }
-				},
-				'asynchronous values': {
-					'one asynchronous value': { results: [ 'hello' ], assertion: assertTrue },
-					'multiple asynchronous values': { results: [ 'non-matching', 'world' ], assertion: assertTrue },
-					'multiple asynchronous values with failure': { results: [ 'non-matching', 'non-matching' ], assertion: assertFalse },
-					'mixed synchronous and asynchronous values': { results: [ 'non-matching', 'world' ], assertion: assertTrue }
-				},
-				'asynchronous callback': {
-					'callback returns asynchronous results': { resolution: true, assertion: assertTrue }
+			'synchronous values': {
+				'one synchronous value': { values: ['hello'], assertion: assertTrue },
+				'multiple synchronous values': { values: ['non-matching', 'world'], assertion: assertTrue },
+				'multiple synchronous values with failure': {
+					values: ['non-matching', 'non-matching'],
+					assertion: assertFalse
 				}
+			},
+			'asynchronous values': {
+				'one asynchronous value': { results: ['hello'], assertion: assertTrue },
+				'multiple asynchronous values': { results: ['non-matching', 'world'], assertion: assertTrue },
+				'multiple asynchronous values with failure': {
+					results: ['non-matching', 'non-matching'],
+					assertion: assertFalse
+				},
+				'mixed synchronous and asynchronous values': {
+					results: ['non-matching', 'world'],
+					assertion: assertTrue
+				}
+			},
+			'asynchronous callback': {
+				'callback returns asynchronous results': { resolution: true, assertion: assertTrue }
 			}
-		);
+		});
 		const asyncArrayTests = tests['array-like value']['asynchronous callback'];
 
-		asyncArrayTests['callback returns multiple asynchronous results with a match and every exits immediately'] = function (): Promise<any> {
-			const values: any[] = [ 'unused', 'unused' ];
+		asyncArrayTests[
+			'callback returns multiple asynchronous results with a match and every exits immediately'
+		] = function(): Promise<any> {
+			const values: any[] = ['unused', 'unused'];
 			const response: Promise<boolean>[] = createTriggerablePromises(2);
-			const promise = iteration.some<any>(values, function (value: any, i: number) {
-				return response[i];
-			}).then(assertTrue);
+			const promise = iteration
+				.some<any>(values, function(value: any, i: number) {
+					return response[i];
+				})
+				.then(assertTrue);
 
-			(<ControlledPromise<boolean>> response[0]).resolve(false);
-			(<ControlledPromise<boolean>> response[1]).resolve(true);
+			(<ControlledPromise<boolean>>response[0]).resolve(false);
+			(<ControlledPromise<boolean>>response[1]).resolve(true);
 
-			return <any> promise;
+			return <any>promise;
 		};
 
 		return tests;

--- a/tests/unit/async/timing.ts
+++ b/tests/unit/async/timing.ts
@@ -7,38 +7,46 @@ import Promise from '@dojo/shim/Promise';
 
 registerSuite('async/timing', {
 	'delay()': {
-		'delay returning a value after the given timeout': function () {
-			return timing.delay<number>(251)(Date.now()).then(function (start: number) {
-				const diff: number = Date.now() - start;
-				assert.approximately(diff, 251, 100);
-			});
+		'delay returning a value after the given timeout': function() {
+			return timing
+				.delay<number>(251)(Date.now())
+				.then(function(start: number) {
+					const diff: number = Date.now() - start;
+					assert.approximately(diff, 251, 100);
+				});
 		},
-		'delay executing a function that returns a value after the given timeout': function () {
+		'delay executing a function that returns a value after the given timeout': function() {
 			const now = Date.now();
 			const getNow = function() {
 				return Date.now();
 			};
-			return timing.delay<number>(251)( getNow ).then(function (finish: number) {
-				const diff: number = finish - now;
-				assert.approximately(diff, 251, 100);
-			});
+			return timing
+				.delay<number>(251)(getNow)
+				.then(function(finish: number) {
+					const diff: number = finish - now;
+					assert.approximately(diff, 251, 100);
+				});
 		},
-		'delay executing a function that returns another promise after the given timeout': function () {
+		'delay executing a function that returns another promise after the given timeout': function() {
 			const now = Date.now();
 			const getNow = function() {
-				return Promise.resolve( Date.now() );
+				return Promise.resolve(Date.now());
 			};
-			return timing.delay<number>(251)( getNow ).then(function (finish: number) {
-				const diff: number = finish - now;
-				assert.approximately(diff, 251, 150);
-			});
+			return timing
+				.delay<number>(251)(getNow)
+				.then(function(finish: number) {
+					const diff: number = finish - now;
+					assert.approximately(diff, 251, 150);
+				});
 		},
-		'delay should return undefined when the value is not passed in': function () {
-			return timing.delay(251)().then(function (value) {
-				assert.isUndefined(value);
-			});
+		'delay should return undefined when the value is not passed in': function() {
+			return timing
+				.delay(251)()
+				.then(function(value) {
+					assert.isUndefined(value);
+				});
 		},
-		'delay can be reusable': function () {
+		'delay can be reusable': function() {
 			const start = Date.now();
 			const delay = timing.delay(251);
 			const p1 = delay().then(function() {
@@ -57,43 +65,44 @@ registerSuite('async/timing', {
 	},
 
 	'timeout()': {
-		'called before the timeout; resolves the promise': function () {
+		'called before the timeout; resolves the promise': function() {
 			return Promise.resolve('unused').then(timing.timeout(100, new Error('Error')));
 		},
 
-		'called before the timeout; passes function; resolves the promise': function () {
+		'called before the timeout; passes function; resolves the promise': function() {
 			return Promise.resolve((): string => 'unused').then(timing.timeout(100, new Error('Error')));
 		},
 
-		'called after the timeout; rejects the promise': function () {
+		'called after the timeout; rejects the promise': function() {
 			return isEventuallyRejected(
-				timing.delay(100)('unused')
+				timing
+					.delay(100)('unused')
 					.then(timing.timeout(1, new Error('expected')))
 			);
 		}
 	},
 
-	'DelayedRejection': {
-		'is eventually rejected': function () {
+	DelayedRejection: {
+		'is eventually rejected': function() {
 			const start = Date.now();
-			return new timing.DelayedRejection(101).then(throwImmediatly, function (reason) {
+			return new timing.DelayedRejection(101).then(throwImmediatly, function(reason) {
 				assert.isUndefined(reason);
 				assert.isAbove(Date.now(), start + 99);
 				return true;
 			});
 		},
 
-		'is eventually rejected with error': function () {
+		'is eventually rejected with error': function() {
 			const start = Date.now();
 			const expectedError = new Error('boom!');
-			return new timing.DelayedRejection(101, expectedError).then(throwImmediatly, function (reason) {
+			return new timing.DelayedRejection(101, expectedError).then(throwImmediatly, function(reason) {
 				assert.strictEqual(reason, expectedError);
 				assert.isAbove(Date.now(), start + 99);
 				return true;
 			});
 		},
 
-		'works with race': function () {
+		'works with race': function() {
 			return Promise.race([timing.delay(1)('success!'), new timing.DelayedRejection(100)]);
 		}
 	}

--- a/tests/unit/compare.ts
+++ b/tests/unit/compare.ts
@@ -1,19 +1,17 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import {
-	createConstructRecord,
-	CustomDiff,
-	diff,
-	patch
-} from '../../src/compare';
+import { createConstructRecord, CustomDiff, diff, patch } from '../../src/compare';
 
 registerSuite('compare', {
 	diff: {
 		'plain object': {
 			'add property'() {
-				const patchRecords = diff({
-					foo: 'bar'
-				}, {});
+				const patchRecords = diff(
+					{
+						foo: 'bar'
+					},
+					{}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -25,11 +23,14 @@ registerSuite('compare', {
 			},
 
 			'update property'() {
-				const patchRecords = diff({
-					foo: 'bar'
-				}, {
-					foo: 'qat'
-				});
+				const patchRecords = diff(
+					{
+						foo: 'bar'
+					},
+					{
+						foo: 'qat'
+					}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -41,9 +42,12 @@ registerSuite('compare', {
 			},
 
 			'delete property'() {
-				const patchRecords = diff({}, {
-					foo: 'qat'
-				});
+				const patchRecords = diff(
+					{},
+					{
+						foo: 'qat'
+					}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -54,20 +58,28 @@ registerSuite('compare', {
 			},
 
 			'allowFunctionValues - equal'() {
-				const patchRecords = diff({
-					foo() { }
-				}, {
-					foo() { }
-				}, { allowFunctionValues: true });
+				const patchRecords = diff(
+					{
+						foo() {}
+					},
+					{
+						foo() {}
+					},
+					{ allowFunctionValues: true }
+				);
 
 				assert.strictEqual(patchRecords.length, 0, 'should not see a difference');
 			},
 
 			'allowFunctionValues - add property'() {
 				function foo() {}
-				const patchRecords = diff({
-					foo
-				}, { }, { allowFunctionValues: true });
+				const patchRecords = diff(
+					{
+						foo
+					},
+					{},
+					{ allowFunctionValues: true }
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -84,32 +96,39 @@ registerSuite('compare', {
 			},
 
 			'primative values'() {
-				const patchRecords = diff({
-					foo: undefined,
-					bar: null,
-					baz: '',
-					qat: 0,
-					qux: false
-				}, {});
+				const patchRecords = diff(
+					{
+						foo: undefined,
+						bar: null,
+						baz: '',
+						qat: 0,
+						qux: false
+					},
+					{}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
 						descriptor: { configurable: true, enumerable: true, value: undefined, writable: true },
 						name: 'foo',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: null, writable: true },
 						name: 'bar',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: '', writable: true },
 						name: 'baz',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: 0, writable: true },
 						name: 'qat',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: false, writable: true },
 						name: 'qux',
 						type: 'add'
@@ -118,15 +137,18 @@ registerSuite('compare', {
 			},
 
 			'deep add value'() {
-				const patchRecords = diff({
-					foo: {
-						bar: 'baz'
-					}
-				}, {});
+				const patchRecords = diff(
+					{
+						foo: {
+							bar: 'baz'
+						}
+					},
+					{}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+						descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 						name: 'foo',
 						type: 'add',
 						valueRecords: [
@@ -141,15 +163,18 @@ registerSuite('compare', {
 			},
 
 			'deep update value'() {
-				const patchRecords = diff({
-					foo: {
-						bar: 'baz'
+				const patchRecords = diff(
+					{
+						foo: {
+							bar: 'baz'
+						}
+					},
+					{
+						foo: {
+							bar: 1
+						}
 					}
-				}, {
-					foo: {
-						bar: 1
-					}
-				});
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -168,32 +193,40 @@ registerSuite('compare', {
 			},
 
 			'complex diff'() {
-				const patchRecords = diff({
-					foo: {
-						bar: 'qat'
-					},
-					baz: {
-						qat: {
-							qux: true
-						}
-					},
-					qat: 'foo'
-				}, {
-					foo: {
-						bar: {
-							qat: true
+				const patchRecords = diff(
+					{
+						foo: {
+							bar: 'qat'
 						},
-						baz: undefined
+						baz: {
+							qat: {
+								qux: true
+							}
+						},
+						qat: 'foo'
 					},
-					baz: 1,
-					qux: {
-						baz: 2
+					{
+						foo: {
+							bar: {
+								qat: true
+							},
+							baz: undefined
+						},
+						baz: 1,
+						qux: {
+							baz: 2
+						}
 					}
-				});
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: { bar: { qat: true }, baz: undefined }, writable: true },
+						descriptor: {
+							configurable: true,
+							enumerable: true,
+							value: { bar: { qat: true }, baz: undefined },
+							writable: true
+						},
 						name: 'foo',
 						type: 'update',
 						valueRecords: [
@@ -207,29 +240,37 @@ registerSuite('compare', {
 								type: 'delete'
 							}
 						]
-					}, {
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+					},
+					{
+						descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 						name: 'baz',
 						type: 'update',
 						valueRecords: [
 							{
-								descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+								descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 								name: 'qat',
 								type: 'add',
 								valueRecords: [
 									{
-										descriptor: { configurable: true, enumerable: true, value: true, writable: true },
+										descriptor: {
+											configurable: true,
+											enumerable: true,
+											value: true,
+											writable: true
+										},
 										name: 'qux',
 										type: 'add'
 									}
 								]
 							}
 						]
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: 'foo', writable: true },
 						name: 'qat',
 						type: 'add'
-					}, {
+					},
+					{
 						name: 'qux',
 						type: 'delete'
 					}
@@ -237,30 +278,39 @@ registerSuite('compare', {
 			},
 
 			'no differences'() {
-				const patchRecords = diff({
-					foo: 'bar'
-				}, {
-					foo: 'bar'
-				});
+				const patchRecords = diff(
+					{
+						foo: 'bar'
+					},
+					{
+						foo: 'bar'
+					}
+				);
 
 				assert.deepEqual(patchRecords, []);
 			},
 
 			'deep no differences'() {
-				const patchRecords = diff({
-					foo: { bar: 1 }
-				}, {
-					foo: { bar: 1 }
-				});
+				const patchRecords = diff(
+					{
+						foo: { bar: 1 }
+					},
+					{
+						foo: { bar: 1 }
+					}
+				);
 
 				assert.deepEqual(patchRecords, []);
 			},
 
 			'symbols are ignored'() {
-				const patchRecords = diff({
-					foo: 'bar',
-					[Symbol.iterator]() { }
-				}, {});
+				const patchRecords = diff(
+					{
+						foo: 'bar',
+						[Symbol.iterator]() {}
+					},
+					{}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -328,7 +378,7 @@ registerSuite('compare', {
 					assert.deepEqual(patchRecords, [], 'should have found no differences');
 				},
 
-				'difference'() {
+				difference() {
 					const a = {
 						foo: /foo/
 					};
@@ -336,9 +386,11 @@ registerSuite('compare', {
 						return createConstructRecord(RegExp);
 					});
 					const patchRecords = diff(a, { foo: customDiff });
-					assert.deepEqual(patchRecords, [
-						{ Ctor: RegExp, name: 'foo' }
-					], 'should have expected patch records');
+					assert.deepEqual(
+						patchRecords,
+						[{ Ctor: RegExp, name: 'foo' }],
+						'should have expected patch records'
+					);
 				},
 
 				'difference with arguments'() {
@@ -346,12 +398,14 @@ registerSuite('compare', {
 						foo: /foo/
 					};
 					const customDiff = new CustomDiff(() => {
-						return createConstructRecord(RegExp, [ '/bar/' ]);
+						return createConstructRecord(RegExp, ['/bar/']);
 					});
 					const patchRecords = diff(a, { foo: customDiff });
-					assert.deepEqual(patchRecords, [
-						{ args: [ '/bar/' ], Ctor: RegExp, name: 'foo' }
-					], 'should have expected patch records');
+					assert.deepEqual(
+						patchRecords,
+						[{ args: ['/bar/'], Ctor: RegExp, name: 'foo' }],
+						'should have expected patch records'
+					);
 				},
 
 				'difference with descriptor'() {
@@ -362,29 +416,35 @@ registerSuite('compare', {
 						return createConstructRecord(RegExp, undefined, { writable: true });
 					});
 					const patchRecords = diff(a, { foo: customDiff });
-					assert.deepEqual(patchRecords, [
-						{ Ctor: RegExp, descriptor: { writable: true },  name: 'foo' }
-					], 'should have expected patch records');
+					assert.deepEqual(
+						patchRecords,
+						[{ Ctor: RegExp, descriptor: { writable: true }, name: 'foo' }],
+						'should have expected patch records'
+					);
 				},
 
 				'deleted property'() {
 					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp);
 					});
-					const patchRecords = diff({ }, { foo: customDiff });
-					assert.deepEqual(patchRecords, [
-						{ name: 'foo', type: 'delete' }
-					], 'should have expected patch records');
+					const patchRecords = diff({}, { foo: customDiff });
+					assert.deepEqual(
+						patchRecords,
+						[{ name: 'foo', type: 'delete' }],
+						'should have expected patch records'
+					);
 				},
 
 				'added property'() {
 					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp);
 					});
-					const patchRecords = diff({ foo: customDiff }, { });
-					assert.deepEqual(patchRecords, [
-						{ Ctor: RegExp, name: 'foo' }
-					], 'should have expected patch records');
+					const patchRecords = diff({ foo: customDiff }, {});
+					assert.deepEqual(
+						patchRecords,
+						[{ Ctor: RegExp, name: 'foo' }],
+						'should have expected patch records'
+					);
 				}
 			},
 
@@ -395,7 +455,7 @@ registerSuite('compare', {
 						bar: 1
 					};
 
-					const patchRecords = diff(a, {}, { ignoreProperties: [ 'bar' ] });
+					const patchRecords = diff(a, {}, { ignoreProperties: ['bar'] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -412,7 +472,7 @@ registerSuite('compare', {
 						bar: 1
 					};
 
-					const patchRecords = diff({}, b, { ignoreProperties: [ 'bar' ] });
+					const patchRecords = diff({}, b, { ignoreProperties: ['bar'] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -428,7 +488,7 @@ registerSuite('compare', {
 						_bar: 1
 					};
 
-					const patchRecords = diff(a, {}, { ignoreProperties: [ /^_/ ] });
+					const patchRecords = diff(a, {}, { ignoreProperties: [/^_/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -445,7 +505,7 @@ registerSuite('compare', {
 						_bar: 1
 					};
 
-					const patchRecords = diff({}, b, { ignoreProperties: [ /^_/ ] });
+					const patchRecords = diff({}, b, { ignoreProperties: [/^_/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -462,7 +522,7 @@ registerSuite('compare', {
 						_bar: 1
 					};
 
-					const patchRecords = diff(a, {}, { ignoreProperties: [ 'bar', /^_/ ] });
+					const patchRecords = diff(a, {}, { ignoreProperties: ['bar', /^_/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -480,7 +540,7 @@ registerSuite('compare', {
 						_bar: 1
 					};
 
-					const patchRecords = diff({}, b, { ignoreProperties: [ 'bar', /^_/ ] });
+					const patchRecords = diff({}, b, { ignoreProperties: ['bar', /^_/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -523,7 +583,7 @@ registerSuite('compare', {
 					]);
 				},
 
-				'function'() {
+				function() {
 					const propertyStack: string[] = [];
 
 					const a = {
@@ -538,15 +598,17 @@ registerSuite('compare', {
 						baz: false
 					};
 
-					const patchRecords = diff(a, b, { ignoreProperties(name, first, second) {
-						propertyStack.push(name);
-						assert.strictEqual(first, a);
-						assert.strictEqual(second, b);
-						return false;
-					} });
+					const patchRecords = diff(a, b, {
+						ignoreProperties(name, first, second) {
+							propertyStack.push(name);
+							assert.strictEqual(first, a);
+							assert.strictEqual(second, b);
+							return false;
+						}
+					});
 
 					assert.deepEqual(patchRecords, [], 'should be no differences');
-					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz' ]);
+					assert.deepEqual(propertyStack, ['foo', 'bar', 'baz']);
 				},
 
 				'function and ignored'() {
@@ -564,15 +626,17 @@ registerSuite('compare', {
 						baz: false
 					};
 
-					const patchRecords = diff(a, b, { ignoreProperties(name, first, second) {
-						propertyStack.push(name);
-						assert.strictEqual(first, a);
-						assert.strictEqual(second, b);
-						return true;
-					} });
+					const patchRecords = diff(a, b, {
+						ignoreProperties(name, first, second) {
+							propertyStack.push(name);
+							assert.strictEqual(first, a);
+							assert.strictEqual(second, b);
+							return true;
+						}
+					});
 
 					assert.deepEqual(patchRecords, [], 'should be no differences');
-					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz' ]);
+					assert.deepEqual(propertyStack, ['foo', 'bar', 'baz']);
 				}
 			},
 
@@ -586,7 +650,7 @@ registerSuite('compare', {
 						foo: new Error('foo')
 					};
 
-					const patchRecords = diff(a, b, { ignorePropertyValues: [ 'foo' ] });
+					const patchRecords = diff(a, b, { ignorePropertyValues: ['foo'] });
 
 					assert.deepEqual(patchRecords, []);
 				},
@@ -597,7 +661,7 @@ registerSuite('compare', {
 						foo
 					};
 
-					const patchRecords = diff(a, { }, { ignorePropertyValues: [ 'foo' ] });
+					const patchRecords = diff(a, {}, { ignorePropertyValues: ['foo'] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -613,7 +677,7 @@ registerSuite('compare', {
 						foo: new Error('foo')
 					};
 
-					const patchRecords = diff({ }, b, { ignorePropertyValues: [ 'foo' ] });
+					const patchRecords = diff({}, b, { ignorePropertyValues: ['foo'] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -632,7 +696,7 @@ registerSuite('compare', {
 						foo: new Error('foo')
 					};
 
-					const patchRecords = diff(a, b, { ignorePropertyValues: [ /^foo$/ ] });
+					const patchRecords = diff(a, b, { ignorePropertyValues: [/^foo$/] });
 
 					assert.deepEqual(patchRecords, []);
 				},
@@ -643,7 +707,7 @@ registerSuite('compare', {
 						foo
 					};
 
-					const patchRecords = diff(a, { }, { ignorePropertyValues: [ /^foo$/ ] });
+					const patchRecords = diff(a, {}, { ignorePropertyValues: [/^foo$/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -659,7 +723,7 @@ registerSuite('compare', {
 						foo: new Error('foo')
 					};
 
-					const patchRecords = diff({ }, b, { ignorePropertyValues: [ /^foo$/ ] });
+					const patchRecords = diff({}, b, { ignorePropertyValues: [/^foo$/] });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -680,7 +744,7 @@ registerSuite('compare', {
 						bar: new Error('bar')
 					};
 
-					const patchRecords = diff(a, b, { ignorePropertyValues: [ 'bar', /^foo$/ ] });
+					const patchRecords = diff(a, b, { ignorePropertyValues: ['bar', /^foo$/] });
 
 					assert.deepEqual(patchRecords, []);
 				},
@@ -693,14 +757,15 @@ registerSuite('compare', {
 						bar
 					};
 
-					const patchRecords = diff(a, { }, { ignorePropertyValues: [ 'bar', /^foo$/ ] });
+					const patchRecords = diff(a, {}, { ignorePropertyValues: ['bar', /^foo$/] });
 
 					assert.deepEqual(patchRecords, [
 						{
 							descriptor: { configurable: true, enumerable: true, value: foo, writable: true },
 							name: 'foo',
 							type: 'add'
-						}, {
+						},
+						{
 							descriptor: { configurable: true, enumerable: true, value: bar, writable: true },
 							name: 'bar',
 							type: 'add'
@@ -714,13 +779,14 @@ registerSuite('compare', {
 						bar: new Error('bar')
 					};
 
-					const patchRecords = diff({ }, b, { ignorePropertyValues: [ 'bar', /^foo$/ ] });
+					const patchRecords = diff({}, b, { ignorePropertyValues: ['bar', /^foo$/] });
 
 					assert.deepEqual(patchRecords, [
 						{
 							name: 'foo',
 							type: 'delete'
-						}, {
+						},
+						{
 							name: 'bar',
 							type: 'delete'
 						}
@@ -747,7 +813,7 @@ registerSuite('compare', {
 						foo
 					};
 
-					const patchRecords = diff(a, { }, { ignorePropertyValues: (name) => /^foo$/.test(name) });
+					const patchRecords = diff(a, {}, { ignorePropertyValues: (name) => /^foo$/.test(name) });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -763,7 +829,7 @@ registerSuite('compare', {
 						foo: new Error('foo')
 					};
 
-					const patchRecords = diff({ }, b, { ignorePropertyValues: (name) => /^foo$/.test(name) });
+					const patchRecords = diff({}, b, { ignorePropertyValues: (name) => /^foo$/.test(name) });
 
 					assert.deepEqual(patchRecords, [
 						{
@@ -775,15 +841,15 @@ registerSuite('compare', {
 			}
 		},
 
-		'array': {
-			'same'() {
-				const patchRecords = diff([ 1, 2, 3 ], [ 1, 2, 3 ]);
+		array: {
+			same() {
+				const patchRecords = diff([1, 2, 3], [1, 2, 3]);
 
-				assert.deepEqual(patchRecords, [ ]);
+				assert.deepEqual(patchRecords, []);
 			},
 
-			'shorter'() {
-				const patchRecords = diff([ 1, 2, 3 ], [ 1, 2, 3, 4, 5 ]);
+			shorter() {
+				const patchRecords = diff([1, 2, 3], [1, 2, 3, 4, 5]);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -794,12 +860,12 @@ registerSuite('compare', {
 				]);
 			},
 
-			'longer'() {
-				const patchRecords = diff([ 1, 2, 3, 4, 5 ], [ 1, 2, 3 ]);
+			longer() {
+				const patchRecords = diff([1, 2, 3, 4, 5], [1, 2, 3]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 4, 5 ],
+						add: [4, 5],
 						deleteCount: 0,
 						start: 3,
 						type: 'splice'
@@ -808,11 +874,11 @@ registerSuite('compare', {
 			},
 
 			'first element changed'() {
-				const patchRecords = diff([ 1, 2, 3 ], [ false, 2, 3 ]);
+				const patchRecords = diff([1, 2, 3], [false, 2, 3]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 1 ],
+						add: [1],
 						deleteCount: 1,
 						start: 0,
 						type: 'splice'
@@ -821,11 +887,11 @@ registerSuite('compare', {
 			},
 
 			'middle element changed'() {
-				const patchRecords = diff([ 1, 2, 3 ], [ 1, false, 3 ]);
+				const patchRecords = diff([1, 2, 3], [1, false, 3]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 2 ],
+						add: [2],
 						deleteCount: 1,
 						start: 1,
 						type: 'splice'
@@ -833,12 +899,12 @@ registerSuite('compare', {
 				]);
 			},
 
-			'last element changed' () {
-				const patchRecords = diff([ 1, 2, 3 ], [ 1, 2, false ]);
+			'last element changed'() {
+				const patchRecords = diff([1, 2, 3], [1, 2, false]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 3 ],
+						add: [3],
 						deleteCount: 1,
 						start: 2,
 						type: 'splice'
@@ -847,11 +913,11 @@ registerSuite('compare', {
 			},
 
 			'tail changed plus shorter'() {
-				const patchRecords = diff([ 1, 2, 3 ], [ 1, 2, false, 4, 5 ]);
+				const patchRecords = diff([1, 2, 3], [1, 2, false, 4, 5]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 3 ],
+						add: [3],
 						deleteCount: 3,
 						start: 2,
 						type: 'splice'
@@ -860,11 +926,11 @@ registerSuite('compare', {
 			},
 
 			'tail changed plug longer'() {
-				const patchRecords = diff([ 1, 2, 3, 4, 5 ], [ 1, 2, false ]);
+				const patchRecords = diff([1, 2, 3, 4, 5], [1, 2, false]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 3, 4, 5 ],
+						add: [3, 4, 5],
 						deleteCount: 1,
 						start: 2,
 						type: 'splice'
@@ -873,16 +939,17 @@ registerSuite('compare', {
 			},
 
 			'multiple changes'() {
-				const patchRecords = diff([ 1, 2, 3, 4, 5 ], [ 1, false, 3, 4, false, 6, 7 ]);
+				const patchRecords = diff([1, 2, 3, 4, 5], [1, false, 3, 4, false, 6, 7]);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 2 ],
+						add: [2],
 						deleteCount: 1,
 						start: 1,
 						type: 'splice'
-					}, {
-						add: [ 5 ],
+					},
+					{
+						add: [5],
 						deleteCount: 3,
 						start: 4,
 						type: 'splice'
@@ -891,11 +958,11 @@ registerSuite('compare', {
 			},
 
 			'primative values array'() {
-				const patchRecords = diff([ '', 0, false, undefined, null ], []);
+				const patchRecords = diff(['', 0, false, undefined, null], []);
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ '', 0, false, undefined, null ],
+						add: ['', 0, false, undefined, null],
 						deleteCount: 0,
 						start: 0,
 						type: 'splice'
@@ -904,18 +971,18 @@ registerSuite('compare', {
 			},
 
 			'allowFunctionValues - equal'() {
-				const patchRecords = diff([ function foo () { } ], [ () => undefined ], { allowFunctionValues: true });
+				const patchRecords = diff([function foo() {}], [() => undefined], { allowFunctionValues: true });
 
 				assert.lengthOf(patchRecords, 0, 'should have no differences');
 			},
 
 			'allowFunctionValues - add'() {
 				function foo() {}
-				const patchRecords = diff([ foo ], [], { allowFunctionValues: true });
+				const patchRecords = diff([foo], [], { allowFunctionValues: true });
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ foo ],
+						add: [foo],
 						deleteCount: 0,
 						start: 0,
 						type: 'splice'
@@ -925,8 +992,8 @@ registerSuite('compare', {
 
 			'array of arrays'() {
 				const patchRecords = diff(
-					[ [ 1, 2, 3 ], [ 'foo', 'bar', 'baz' ], [ true, false ] ],
-					[ [ 1, false, 3], [ 'bar', 'baz' ] ]
+					[[1, 2, 3], ['foo', 'bar', 'baz'], [true, false]],
+					[[1, false, 3], ['bar', 'baz']]
 				);
 
 				assert.deepEqual(patchRecords, [
@@ -934,21 +1001,23 @@ registerSuite('compare', {
 						add: [
 							[
 								{
-									add: [ 2 ],
+									add: [2],
 									deleteCount: 1,
 									start: 1,
 									type: 'splice'
 								}
-							], [
+							],
+							[
 								{
-									add: [ 'foo', 'bar', 'baz' ],
+									add: ['foo', 'bar', 'baz'],
 									deleteCount: 2,
 									start: 0,
 									type: 'splice'
 								}
-							], [
+							],
+							[
 								{
-									add: [ true, false ],
+									add: [true, false],
 									deleteCount: 0,
 									start: 0,
 									type: 'splice'
@@ -964,30 +1033,33 @@ registerSuite('compare', {
 
 			'deep no changes'() {
 				const patchRecords = diff(
-					[ [ 1, 2, 3 ], [ 'foo', 'bar', 'baz' ], [ true, false ] ],
-					[ [ 1, 2, 3 ], [ 'foo', 'bar', 'baz' ], [ true, false ] ]
+					[[1, 2, 3], ['foo', 'bar', 'baz'], [true, false]],
+					[[1, 2, 3], ['foo', 'bar', 'baz'], [true, false]]
 				);
 
-				assert.deepEqual(patchRecords, [ ]);
+				assert.deepEqual(patchRecords, []);
 			}
 		},
 
 		'mixed object/arrays': {
 			'object with array'() {
-				const patchRecords = diff({
-					foo: [ 1, 2, 3 ]
-				}, {
-					foo: [ 1, false, 3 ]
-				});
+				const patchRecords = diff(
+					{
+						foo: [1, 2, 3]
+					},
+					{
+						foo: [1, false, 3]
+					}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: [ 1, false, 3 ], writable: true },
+						descriptor: { configurable: true, enumerable: true, value: [1, false, 3], writable: true },
 						name: 'foo',
 						type: 'update',
 						valueRecords: [
 							{
-								add: [ 2 ],
+								add: [2],
 								deleteCount: 1,
 								start: 1,
 								type: 'splice'
@@ -999,8 +1071,8 @@ registerSuite('compare', {
 
 			'array with objects'() {
 				const patchRecords = diff(
-					[ { bar: 1 }, { foo: 'bar' }, { baz: 1, qat: false }, { qux: null }, { } ],
-					[ { bar: 1 }, { foo: 'baz' }, { baz: 1 }, { }, { qux: null } ]
+					[{ bar: 1 }, { foo: 'bar' }, { baz: 1, qat: false }, { qux: null }, {}],
+					[{ bar: 1 }, { foo: 'baz' }, { baz: 1 }, {}, { qux: null }]
 				);
 
 				assert.deepEqual(patchRecords, [
@@ -1012,19 +1084,22 @@ registerSuite('compare', {
 									name: 'foo',
 									type: 'update'
 								}
-							], [
+							],
+							[
 								{
 									descriptor: { configurable: true, enumerable: true, value: false, writable: true },
 									name: 'qat',
 									type: 'add'
 								}
-							], [
+							],
+							[
 								{
 									descriptor: { configurable: true, enumerable: true, value: null, writable: true },
 									name: 'qux',
 									type: 'add'
 								}
-							], [
+							],
+							[
 								{
 									name: 'qux',
 									type: 'delete'
@@ -1039,20 +1114,23 @@ registerSuite('compare', {
 			},
 
 			'object array value to object value'() {
-				const patchRecords = diff({
-					foo: [ 1, 2, 3 ]
-				}, {
-					foo: { bar: 1 }
-				});
+				const patchRecords = diff(
+					{
+						foo: [1, 2, 3]
+					},
+					{
+						foo: { bar: 1 }
+					}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: [ ], writable: true },
+						descriptor: { configurable: true, enumerable: true, value: [], writable: true },
 						name: 'foo',
 						type: 'update',
 						valueRecords: [
 							{
-								add: [ 1, 2, 3 ],
+								add: [1, 2, 3],
 								deleteCount: 0,
 								start: 0,
 								type: 'splice'
@@ -1063,15 +1141,18 @@ registerSuite('compare', {
 			},
 
 			'object object value to array value'() {
-				const patchRecords = diff({
-					foo: { bar: 1 }
-				}, {
-					foo: [ 1, 2, 3 ]
-				});
+				const patchRecords = diff(
+					{
+						foo: { bar: 1 }
+					},
+					{
+						foo: [1, 2, 3]
+					}
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+						descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 						name: 'foo',
 						type: 'update',
 						valueRecords: [
@@ -1086,16 +1167,21 @@ registerSuite('compare', {
 			},
 
 			'array array value to object value'() {
-				const patchRecords = diff([ [ 1, 2, 3 ] ], [ {
-					foo: 1
-				} ]);
+				const patchRecords = diff(
+					[[1, 2, 3]],
+					[
+						{
+							foo: 1
+						}
+					]
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
 						add: [
 							[
 								{
-									add: [ 1, 2, 3 ],
+									add: [1, 2, 3],
 									deleteCount: 0,
 									start: 0,
 									type: 'splice'
@@ -1110,9 +1196,14 @@ registerSuite('compare', {
 			},
 
 			'array object value to array value'() {
-				const patchRecords = diff([ {
-					foo: 1
-				} ], [ [ 1, 2, 3 ] ]);
+				const patchRecords = diff(
+					[
+						{
+							foo: 1
+						}
+					],
+					[[1, 2, 3]]
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -1133,13 +1224,13 @@ registerSuite('compare', {
 			},
 
 			'array to object'() {
-				const patchRecords = diff([ 1, 2, 3 ], {
+				const patchRecords = diff([1, 2, 3], {
 					foo: 'bar'
 				});
 
 				assert.deepEqual(patchRecords, [
 					{
-						add: [ 1, 2, 3 ],
+						add: [1, 2, 3],
 						deleteCount: 0,
 						start: 0,
 						type: 'splice'
@@ -1148,9 +1239,12 @@ registerSuite('compare', {
 			},
 
 			'object to array'() {
-				const patchRecords = diff({
-					foo: 'bar'
-				}, [ 1, 2, 3 ]);
+				const patchRecords = diff(
+					{
+						foo: 'bar'
+					},
+					[1, 2, 3]
+				);
 
 				assert.deepEqual(patchRecords, [
 					{
@@ -1163,26 +1257,45 @@ registerSuite('compare', {
 		},
 
 		'negative tests'() {
-			assert.throws(() => {
-				diff({}, 'foo');
-			}, TypeError, 'Arguments are not of type object.');
+			assert.throws(
+				() => {
+					diff({}, 'foo');
+				},
+				TypeError,
+				'Arguments are not of type object.'
+			);
 
-			assert.throws(() => {
-				diff('foo', {});
-			}, TypeError, 'Arguments are not of type object.');
+			assert.throws(
+				() => {
+					diff('foo', {});
+				},
+				TypeError,
+				'Arguments are not of type object.'
+			);
 
-			assert.throws(() => {
-				diff({
-					foo: /bar/
-				}, {});
-			}, TypeError, 'Value of property named "foo" from first argument is not a primative, plain Object, or Array.');
+			assert.throws(
+				() => {
+					diff(
+						{
+							foo: /bar/
+						},
+						{}
+					);
+				},
+				TypeError,
+				'Value of property named "foo" from first argument is not a primative, plain Object, or Array.'
+			);
 
-			assert.throws(() => {
-				diff([ /foo/ ], []);
-			}, TypeError, 'Value of array element "0" from first argument is not a primative, plain Object, or Array.');
+			assert.throws(
+				() => {
+					diff([/foo/], []);
+				},
+				TypeError,
+				'Value of array element "0" from first argument is not a primative, plain Object, or Array.'
+			);
 
 			assert.doesNotThrow(() => {
-				diff([ ], [ /foo/ ]);
+				diff([], [/foo/]);
 			});
 
 			class Foo {
@@ -1191,17 +1304,25 @@ registerSuite('compare', {
 
 			const foo = new Foo();
 
-			assert.throws(() => {
-				diff(foo, {});
-			}, TypeError, 'Arguments are not plain Objects or Arrays.');
+			assert.throws(
+				() => {
+					diff(foo, {});
+				},
+				TypeError,
+				'Arguments are not plain Objects or Arrays.'
+			);
 
-			assert.throws(() => {
-				diff({}, foo);
-			}, TypeError, 'Arguments are not plain Objects or Arrays.');
+			assert.throws(
+				() => {
+					diff({}, foo);
+				},
+				TypeError,
+				'Arguments are not plain Objects or Arrays.'
+			);
 		}
 	},
 
-	'patch': {
+	patch: {
 		'plain object': {
 			'add property'() {
 				const target = {};
@@ -1220,15 +1341,18 @@ registerSuite('compare', {
 			},
 
 			'update property'() {
-				const result = patch({
-					foo: 'qat'
-				}, [
+				const result = patch(
 					{
-						descriptor: { configurable: true, enumerable: true, value: 'bar', writable: true },
-						name: 'foo',
-						type: 'update'
-					}
-				]);
+						foo: 'qat'
+					},
+					[
+						{
+							descriptor: { configurable: true, enumerable: true, value: 'bar', writable: true },
+							name: 'foo',
+							type: 'update'
+						}
+					]
+				);
 
 				assert.deepEqual(result, {
 					foo: 'bar'
@@ -1236,14 +1360,17 @@ registerSuite('compare', {
 			},
 
 			'delete property'() {
-				const result = patch({
-					foo: 'qat'
-				}, [
+				const result = patch(
 					{
-						name: 'foo',
-						type: 'delete'
-					}
-				]);
+						foo: 'qat'
+					},
+					[
+						{
+							name: 'foo',
+							type: 'delete'
+						}
+					]
+				);
 
 				assert.deepEqual(result, {});
 			},
@@ -1254,19 +1381,23 @@ registerSuite('compare', {
 						descriptor: { configurable: true, enumerable: true, value: undefined, writable: true },
 						name: 'foo',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: null, writable: true },
 						name: 'bar',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: '', writable: true },
 						name: 'baz',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: 0, writable: true },
 						name: 'qat',
 						type: 'add'
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: false, writable: true },
 						name: 'qux',
 						type: 'add'
@@ -1285,7 +1416,7 @@ registerSuite('compare', {
 			'deep add value'() {
 				const result = patch({}, [
 					{
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+						descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 						name: 'foo',
 						type: 'add',
 						valueRecords: [
@@ -1365,29 +1496,37 @@ registerSuite('compare', {
 								type: 'delete'
 							}
 						]
-					}, {
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+					},
+					{
+						descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 						name: 'baz',
 						type: 'update',
 						valueRecords: [
 							{
-								descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+								descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
 								name: 'qat',
 								type: 'add',
 								valueRecords: [
 									{
-										descriptor: { configurable: true, enumerable: true, value: true, writable: true },
+										descriptor: {
+											configurable: true,
+											enumerable: true,
+											value: true,
+											writable: true
+										},
 										name: 'qux',
 										type: 'add'
 									}
 								]
 							}
 						]
-					}, {
+					},
+					{
 						descriptor: { configurable: true, enumerable: true, value: 'foo', writable: true },
 						name: 'qat',
 						type: 'add'
-					}, {
+					},
+					{
 						name: 'qux',
 						type: 'delete'
 					}
@@ -1412,25 +1551,25 @@ registerSuite('compare', {
 
 			'empty patch'() {
 				const target = {};
-				const result = patch(target, [ ]);
+				const result = patch(target, []);
 
 				assert.deepEqual(result, {});
 				assert.strictEqual(result, target);
 			}
 		},
 
-		'array': {
-			'same'() {
-				const target = [ 1, 2, 3 ];
-				const result = patch(target, [ ]);
+		array: {
+			same() {
+				const target = [1, 2, 3];
+				const result = patch(target, []);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 				assert.deepEqual(result, target);
 				assert.strictEqual(target, result);
 			},
 
-			'shorter'() {
-				const target = [ 1, 2, 3, 4, 5 ];
+			shorter() {
+				const target = [1, 2, 3, 4, 5];
 				const result = patch(target, [
 					{
 						deleteCount: 2,
@@ -1439,162 +1578,189 @@ registerSuite('compare', {
 					}
 				]);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 				assert.strictEqual(target, result);
 			},
 
-			'longer'() {
-				const target = [ 1, 2, 3 ];
+			longer() {
+				const target = [1, 2, 3];
 				const result = patch(target, [
 					{
-						add: [ 4, 5 ],
+						add: [4, 5],
 						deleteCount: 0,
 						start: 3,
 						type: 'splice'
 					}
 				]);
 
-				assert.deepEqual(result, [ 1, 2, 3, 4, 5 ]);
+				assert.deepEqual(result, [1, 2, 3, 4, 5]);
 				assert.strictEqual(result, target);
 			},
 
 			'first element changed'() {
-				const result = patch([ false, 2, 3 ], [
-					{
-						add: [ 1 ],
-						deleteCount: 1,
-						start: 0,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[false, 2, 3],
+					[
+						{
+							add: [1],
+							deleteCount: 1,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 			},
 
 			'middle element changed'() {
-				const result = patch([ 1, false, 3 ], [
-					{
-						add: [ 2 ],
-						deleteCount: 1,
-						start: 1,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[1, false, 3],
+					[
+						{
+							add: [2],
+							deleteCount: 1,
+							start: 1,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 			},
 
-			'last element changed' () {
-				const result = patch([ 1, 2, false ], [
-					{
-						add: [ 3 ],
-						deleteCount: 1,
-						start: 2,
-						type: 'splice'
-					}
-				]);
+			'last element changed'() {
+				const result = patch(
+					[1, 2, false],
+					[
+						{
+							add: [3],
+							deleteCount: 1,
+							start: 2,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 			},
 
 			'tail changed plus shorter'() {
-				const result = patch([ 1, 2, false, 4, 5 ], [
-					{
-						add: [ 3 ],
-						deleteCount: 3,
-						start: 2,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[1, 2, false, 4, 5],
+					[
+						{
+							add: [3],
+							deleteCount: 3,
+							start: 2,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 			},
 
 			'tail changed plug longer'() {
-				const result = patch([ 1, 2, false ], [
-					{
-						add: [ 3, 4, 5 ],
-						deleteCount: 1,
-						start: 2,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[1, 2, false],
+					[
+						{
+							add: [3, 4, 5],
+							deleteCount: 1,
+							start: 2,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3, 4, 5 ]);
+				assert.deepEqual(result, [1, 2, 3, 4, 5]);
 			},
 
 			'multiple changes'() {
-				const result = patch([ 1, false, 3, 4, false, 6, 7 ], [
-					{
-						add: [ 2 ],
-						deleteCount: 1,
-						start: 1,
-						type: 'splice'
-					}, {
-						add: [ 5 ],
-						deleteCount: 3,
-						start: 4,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[1, false, 3, 4, false, 6, 7],
+					[
+						{
+							add: [2],
+							deleteCount: 1,
+							start: 1,
+							type: 'splice'
+						},
+						{
+							add: [5],
+							deleteCount: 3,
+							start: 4,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3, 4, 5 ]);
+				assert.deepEqual(result, [1, 2, 3, 4, 5]);
 			},
 
 			'primative values array'() {
-				const result = patch([], [
-					{
-						add: [ '', 0, false, undefined, null ],
-						deleteCount: 0,
-						start: 0,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[],
+					[
+						{
+							add: ['', 0, false, undefined, null],
+							deleteCount: 0,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ '', 0, false, undefined, null ]);
+				assert.deepEqual(result, ['', 0, false, undefined, null]);
 			},
 
 			'array of arrays'() {
-				const result = patch([ [ 1, false, 3], [ 'bar', 'baz' ] ], [
-					{
-						add: [
-							[
-								{
-									add: [ 2 ],
-									deleteCount: 1,
-									start: 1,
-									type: 'splice'
-								}
-							], [
-								{
-									add: [ 'foo', 'bar', 'baz' ],
-									deleteCount: 2,
-									start: 0,
-									type: 'splice'
-								}
-							], [
-								{
-									add: [ true, false ],
-									deleteCount: 0,
-									start: 0,
-									type: 'splice'
-								}
-							]
-						],
-						deleteCount: 2,
-						start: 0,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[[1, false, 3], ['bar', 'baz']],
+					[
+						{
+							add: [
+								[
+									{
+										add: [2],
+										deleteCount: 1,
+										start: 1,
+										type: 'splice'
+									}
+								],
+								[
+									{
+										add: ['foo', 'bar', 'baz'],
+										deleteCount: 2,
+										start: 0,
+										type: 'splice'
+									}
+								],
+								[
+									{
+										add: [true, false],
+										deleteCount: 0,
+										start: 0,
+										type: 'splice'
+									}
+								]
+							],
+							deleteCount: 2,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ [ 1, 2, 3 ], [ 'foo', 'bar', 'baz' ], [ true, false ] ]);
+				assert.deepEqual(result, [[1, 2, 3], ['foo', 'bar', 'baz'], [true, false]]);
 			}
 		},
 
 		'mixed object/arrays': {
 			'object with array'() {
 				const target = {
-					foo: [ 1, false, 3 ]
+					foo: [1, false, 3]
 				};
 
 				const result = patch(target, [
@@ -1604,7 +1770,7 @@ registerSuite('compare', {
 						type: 'update',
 						valueRecords: [
 							{
-								add: [ 2 ],
+								add: [2],
 								deleteCount: 1,
 								start: 1,
 								type: 'splice'
@@ -1614,14 +1780,14 @@ registerSuite('compare', {
 				]);
 
 				assert.deepEqual(result, {
-					foo: [ 1, 2, 3 ]
+					foo: [1, 2, 3]
 				});
 				assert.strictEqual(target, result);
 				assert.strictEqual(target.foo, result.foo);
 			},
 
 			'array with objects'() {
-				const target = [ { bar: 1 }, { foo: 'baz' }, { baz: 1 }, { }, { qux: null } ];
+				const target = [{ bar: 1 }, { foo: 'baz' }, { baz: 1 }, {}, { qux: null }];
 
 				const result = patch(target, [
 					{
@@ -1632,19 +1798,22 @@ registerSuite('compare', {
 									name: 'foo',
 									type: 'update'
 								}
-							], [
+							],
+							[
 								{
 									descriptor: { configurable: true, enumerable: true, value: false, writable: true },
 									name: 'qat',
 									type: 'add'
 								}
-							], [
+							],
+							[
 								{
 									descriptor: { configurable: true, enumerable: true, value: null, writable: true },
 									name: 'qux',
 									type: 'add'
 								}
-							], [
+							],
+							[
 								{
 									name: 'qux',
 									type: 'delete'
@@ -1657,7 +1826,7 @@ registerSuite('compare', {
 					}
 				]);
 
-				assert.deepEqual(result, [ { bar: 1 }, { foo: 'bar' }, { baz: 1, qat: false }, { qux: null }, { } ]);
+				assert.deepEqual(result, [{ bar: 1 }, { foo: 'bar' }, { baz: 1, qat: false }, { qux: null }, {}]);
 				assert.strictEqual(target, result);
 				target.forEach((item, index) => {
 					assert.strictEqual(item, result[index]);
@@ -1665,46 +1834,52 @@ registerSuite('compare', {
 			},
 
 			'object array value to object value'() {
-				const result = patch({
-					foo: { bar: 1 }
-				}, [
+				const result = patch(
 					{
-						descriptor: { configurable: true, enumerable: true, value: [ ], writable: true },
-						name: 'foo',
-						type: 'update',
-						valueRecords: [
-							{
-								add: [ 1, 2, 3 ],
-								deleteCount: 0,
-								start: 0,
-								type: 'splice'
-							}
-						]
-					}
-				]);
+						foo: { bar: 1 }
+					},
+					[
+						{
+							descriptor: { configurable: true, enumerable: true, value: [], writable: true },
+							name: 'foo',
+							type: 'update',
+							valueRecords: [
+								{
+									add: [1, 2, 3],
+									deleteCount: 0,
+									start: 0,
+									type: 'splice'
+								}
+							]
+						}
+					]
+				);
 
 				assert.deepEqual(result, {
-					foo: [ 1, 2, 3 ]
+					foo: [1, 2, 3]
 				});
 			},
 
 			'object object value to array value'() {
-				const result = patch({
-					foo: [ 1, 2, 3 ]
-				}, [
+				const result = patch(
 					{
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
-						name: 'foo',
-						type: 'update',
-						valueRecords: [
-							{
-								descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
-								name: 'bar',
-								type: 'add'
-							}
-						]
-					}
-				]);
+						foo: [1, 2, 3]
+					},
+					[
+						{
+							descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
+							name: 'foo',
+							type: 'update',
+							valueRecords: [
+								{
+									descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
+									name: 'bar',
+									type: 'add'
+								}
+							]
+						}
+					]
+				);
 
 				assert.deepEqual(result, {
 					foo: { bar: 1 }
@@ -1712,75 +1887,91 @@ registerSuite('compare', {
 			},
 
 			'array array value to object value'() {
-				const result = patch([ {
-					foo: 1
-				} ], [
-					{
-						add: [
-							[
-								{
-									add: [ 1, 2, 3 ],
-									deleteCount: 0,
-									start: 0,
-									type: 'splice'
-								}
-							]
-						],
-						deleteCount: 1,
-						start: 0,
-						type: 'splice'
-					}
-				]);
+				const result = patch(
+					[
+						{
+							foo: 1
+						}
+					],
+					[
+						{
+							add: [
+								[
+									{
+										add: [1, 2, 3],
+										deleteCount: 0,
+										start: 0,
+										type: 'splice'
+									}
+								]
+							],
+							deleteCount: 1,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ [ 1, 2, 3 ] ]);
+				assert.deepEqual(result, [[1, 2, 3]]);
 			},
 
 			'array object value to array value'() {
-				const result = patch([ [ 1, 2, 3 ] ], [
+				const result = patch(
+					[[1, 2, 3]],
+					[
+						{
+							add: [
+								[
+									{
+										descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
+										name: 'foo',
+										type: 'add'
+									}
+								]
+							],
+							deleteCount: 1,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
+
+				assert.deepEqual(result, [
 					{
-						add: [
-							[
-								{
-									descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
-									name: 'foo',
-									type: 'add'
-								}
-							]
-						],
-						deleteCount: 1,
-						start: 0,
-						type: 'splice'
+						foo: 1
 					}
 				]);
-
-				assert.deepEqual(result, [ {
-					foo: 1
-				} ]);
 			},
 
 			'array to object'() {
-				const result = patch({
-					foo: 'bar'
-				}, [
+				const result = patch(
 					{
-						add: [ 1, 2, 3 ],
-						deleteCount: 0,
-						start: 0,
-						type: 'splice'
-					}
-				]);
+						foo: 'bar'
+					},
+					[
+						{
+							add: [1, 2, 3],
+							deleteCount: 0,
+							start: 0,
+							type: 'splice'
+						}
+					]
+				);
 
-				assert.deepEqual(result, [ 1, 2, 3 ]);
+				assert.deepEqual(result, [1, 2, 3]);
 			},
 
 			'object to array'() {
-				const result = patch([ 1, 2, 3 ], [
-					{
-						descriptor: { configurable: true, enumerable: true, value: 'bar', writable: true },
-						name: 'foo',
-						type: 'add'
-					}
-				]);
+				const result = patch(
+					[1, 2, 3],
+					[
+						{
+							descriptor: { configurable: true, enumerable: true, value: 'bar', writable: true },
+							name: 'foo',
+							type: 'add'
+						}
+					]
+				);
 
 				assert.deepEqual(result, {
 					foo: 'bar'
@@ -1790,9 +1981,7 @@ registerSuite('compare', {
 
 		'plain object with construct records': {
 			'basic property construct'() {
-				const result = patch({}, [
-					{ args: [ 'foo' ], Ctor: RegExp, name: 'foo' }
-				]);
+				const result = patch({}, [{ args: ['foo'], Ctor: RegExp, name: 'foo' }]);
 
 				assert.instanceOf(result.foo, RegExp, 'should be a regular expression');
 				assert.strictEqual(result.foo.toString(), '/foo/', 'should have a pattern of foo');
@@ -1800,8 +1989,13 @@ registerSuite('compare', {
 
 			'property construct with descriptor'() {
 				const result = patch({}, [
-					{ args: [ 'foo' ], Ctor: RegExp, name: 'foo', descriptor: { writable: false, enumerable: false, configurable: false } },
-					{ args: [ 'foo' ], Ctor: RegExp, name: 'bar' }
+					{
+						args: ['foo'],
+						Ctor: RegExp,
+						name: 'foo',
+						descriptor: { writable: false, enumerable: false, configurable: false }
+					},
+					{ args: ['foo'], Ctor: RegExp, name: 'bar' }
 				]);
 
 				const descriptorFoo = Object.getOwnPropertyDescriptor(result, 'foo');
@@ -1823,13 +2017,16 @@ registerSuite('compare', {
 				}
 
 				const result = patch({}, [
-					{ Ctor: Foo, name: 'foo', propertyRecords:
-						[
+					{
+						Ctor: Foo,
+						name: 'foo',
+						propertyRecords: [
 							{
 								descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
 								name: 'foo',
 								type: 'add'
-							}, {
+							},
+							{
 								descriptor: { configurable: true, enumerable: true, value: 'baz', writable: true },
 								name: 'bar',
 								type: 'add'
@@ -1849,7 +2046,10 @@ registerSuite('compare', {
 				}
 
 				const result = patch({}, [
-					{ Ctor: Foo, name: 'foo', propertyRecords: [
+					{
+						Ctor: Foo,
+						name: 'foo',
+						propertyRecords: [
 							{
 								Ctor: Foo,
 								name: 'foo'
@@ -1863,22 +2063,25 @@ registerSuite('compare', {
 			},
 
 			'plain object has complex property'() {
-				const result = patch({
-					foo: []
-				}, [
+				const result = patch(
 					{
-						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
-						name: 'foo',
-						type: 'update',
-						valueRecords: [
-							{
-								args: [ 'foo' ],
-								Ctor: RegExp,
-								name: 'bar'
-							}
-						]
-					}
-				]);
+						foo: []
+					},
+					[
+						{
+							descriptor: { configurable: true, enumerable: true, value: {}, writable: true },
+							name: 'foo',
+							type: 'update',
+							valueRecords: [
+								{
+									args: ['foo'],
+									Ctor: RegExp,
+									name: 'bar'
+								}
+							]
+						}
+					]
+				);
 
 				assert.instanceOf(result.foo.bar, RegExp);
 				assert.strictEqual(result.foo.bar.toString(), '/foo/');
@@ -1886,31 +2089,47 @@ registerSuite('compare', {
 		},
 
 		'negative tests'() {
-			assert.throws(() => {
-				patch(/foo/, [ ]);
-			}, TypeError, 'A target for a patch must be either an array or a plain object.');
+			assert.throws(
+				() => {
+					patch(/foo/, []);
+				},
+				TypeError,
+				'A target for a patch must be either an array or a plain object.'
+			);
 
 			class Foo {
 				bar: 'bar';
 			}
 
-			assert.throws(() => {
-				patch(new Foo(), [ ]);
-			}, TypeError, 'A target for a patch must be either an array or a plain object.');
+			assert.throws(
+				() => {
+					patch(new Foo(), []);
+				},
+				TypeError,
+				'A target for a patch must be either an array or a plain object.'
+			);
 
 			const foo = {};
 			Object.freeze(foo);
 
-			assert.throws(() => {
-				patch(foo, []);
-			}, TypeError, 'Cannot patch sealed or frozen objects.');
+			assert.throws(
+				() => {
+					patch(foo, []);
+				},
+				TypeError,
+				'Cannot patch sealed or frozen objects.'
+			);
 
 			const bar = {};
 			Object.seal(bar);
 
-			assert.throws(() => {
-				patch(bar, []);
-			}, TypeError, 'Cannot patch sealed or frozen objects.');
+			assert.throws(
+				() => {
+					patch(bar, []);
+				},
+				TypeError,
+				'Cannot patch sealed or frozen objects.'
+			);
 		}
 	}
 });

--- a/tests/unit/has.ts
+++ b/tests/unit/has.ts
@@ -7,8 +7,7 @@ registerSuite('has', {
 		const value = has('node-buffer');
 		if (has('host-node')) {
 			assert.ok(value, 'Should be true running under node');
-		}
-		else {
+		} else {
 			assert.notOk(value, 'Should be false running under node');
 		}
 	}

--- a/tests/unit/instrument.ts
+++ b/tests/unit/instrument.ts
@@ -2,12 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { hasClassName } from '../support/util';
 import { spy, SinonSpy } from 'sinon';
-import {
-	deprecated,
-	deprecatedAdvice,
-	deprecatedDecorator,
-	setWarn
-} from '../../src/instrument';
+import { deprecated, deprecatedAdvice, deprecatedDecorator, setWarn } from '../../src/instrument';
 
 let consoleWarnSpy: SinonSpy;
 
@@ -17,7 +12,7 @@ registerSuite('instrument', {
 	},
 
 	afterEach() {
-		(<any> console.warn).restore && (<any> console.warn).restore();
+		(<any>console.warn).restore && (<any>console.warn).restore();
 	},
 
 	tests: {
@@ -26,7 +21,10 @@ registerSuite('instrument', {
 				deprecated();
 				assert.isTrue(consoleWarnSpy.calledOnce);
 				assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
-				assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
+				assert.strictEqual(
+					consoleWarnSpy.lastCall.args[0],
+					'DEPRECATED: This function will be removed in future versions.'
+				);
 			},
 
 			'message in options'(this: any) {
@@ -42,7 +40,10 @@ registerSuite('instrument', {
 				deprecated({ name });
 				assert.isTrue(consoleWarnSpy.calledOnce);
 				assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
-				assert.strictEqual(consoleWarnSpy.lastCall.args[0], `DEPRECATED: ${name}: This function will be removed in future versions.`);
+				assert.strictEqual(
+					consoleWarnSpy.lastCall.args[0],
+					`DEPRECATED: ${name}: This function will be removed in future versions.`
+				);
 			},
 
 			'url in options'(this: any) {
@@ -50,7 +51,10 @@ registerSuite('instrument', {
 				deprecated({ url });
 				assert.isTrue(consoleWarnSpy.calledOnce);
 				assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
-				assert.strictEqual(consoleWarnSpy.lastCall.args[0], `DEPRECATED: This function will be removed in future versions.\n\n    See ${url} for more details.\n\n`);
+				assert.strictEqual(
+					consoleWarnSpy.lastCall.args[0],
+					`DEPRECATED: This function will be removed in future versions.\n\n    See ${url} for more details.\n\n`
+				);
 			},
 
 			'warn in options'() {
@@ -73,12 +77,15 @@ registerSuite('instrument', {
 				const advice = deprecatedAdvice();
 				assert.isTrue(consoleWarnSpy.notCalled);
 
-				const args: any[] = [ 'foo' ];
+				const args: any[] = ['foo'];
 				const result = advice.apply(null, args);
 				assert.deepEqual(args, result);
 				assert.isTrue(consoleWarnSpy.calledOnce);
 				assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
-				assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
+				assert.strictEqual(
+					consoleWarnSpy.lastCall.args[0],
+					'DEPRECATED: This function will be removed in future versions.'
+				);
 			},
 
 			'warn in options'() {
@@ -90,7 +97,7 @@ registerSuite('instrument', {
 
 				const advice = deprecatedAdvice({ warn });
 
-				const args: any[] = [ 'foo' ];
+				const args: any[] = ['foo'];
 				const result = advice.apply(null, args);
 				assert.deepEqual(args, result);
 				assert.isTrue(consoleWarnSpy.notCalled);
@@ -117,10 +124,15 @@ registerSuite('instrument', {
 				assert.isTrue(consoleWarnSpy.calledOnce);
 				assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
 				if (hasClassName()) {
-					assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: Foo#method: This function will be removed in future versions.');
-				}
-				else {
-					assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: method: This function will be removed in future versions.');
+					assert.strictEqual(
+						consoleWarnSpy.lastCall.args[0],
+						'DEPRECATED: Foo#method: This function will be removed in future versions.'
+					);
+				} else {
+					assert.strictEqual(
+						consoleWarnSpy.lastCall.args[0],
+						'DEPRECATED: method: This function will be removed in future versions.'
+					);
 				}
 				assert.strictEqual(callStack[0].length, 1);
 				assert.strictEqual(callStack[0][0], 'foo');
@@ -135,7 +147,7 @@ registerSuite('instrument', {
 
 				class Foo {
 					@deprecatedDecorator({ warn })
-					method() { }
+					method() {}
 				}
 
 				const foo = new Foo();
@@ -144,10 +156,15 @@ registerSuite('instrument', {
 				assert.strictEqual(callStack.length, 1);
 				assert.strictEqual(callStack[0].length, 1);
 				if (hasClassName()) {
-					assert.strictEqual(callStack[0][0], 'DEPRECATED: Foo#method: This function will be removed in future versions.');
-				}
-				else {
-					assert.strictEqual(callStack[0][0], 'DEPRECATED: method: This function will be removed in future versions.');
+					assert.strictEqual(
+						callStack[0][0],
+						'DEPRECATED: Foo#method: This function will be removed in future versions.'
+					);
+				} else {
+					assert.strictEqual(
+						callStack[0][0],
+						'DEPRECATED: method: This function will be removed in future versions.'
+					);
 				}
 			}
 		},
@@ -171,7 +188,10 @@ registerSuite('instrument', {
 			assert.isTrue(consoleWarnSpy.calledOnce);
 			assert.strictEqual(callStack.length, 1);
 			assert.strictEqual(consoleWarnSpy.lastCall.args.length, 1);
-			assert.strictEqual(consoleWarnSpy.lastCall.args[0], 'DEPRECATED: This function will be removed in future versions.');
+			assert.strictEqual(
+				consoleWarnSpy.lastCall.args[0],
+				'DEPRECATED: This function will be removed in future versions.'
+			);
 		}
 	}
 });

--- a/tests/unit/lang.ts
+++ b/tests/unit/lang.ts
@@ -10,29 +10,32 @@ registerSuite('lang functions', {
 
 	'.deepAssign()'() {
 		const source: {
-			a: number,
+			a: number;
 			b: {
-				enumerable: boolean,
-				configurable: boolean,
-				writable: boolean,
-				value: number
-			},
+				enumerable: boolean;
+				configurable: boolean;
+				writable: boolean;
+				value: number;
+			};
 			c: {
-				d: number,
-				e: any[]
+				d: number;
+				e: any[];
+			};
+		} = Object.create(
+			{ a: 1 },
+			{
+				b: {
+					enumerable: false,
+					configurable: true,
+					writable: true,
+					value: 2
+				}
 			}
-		} = Object.create({ a: 1 }, {
-			b: {
-				enumerable: false,
-				configurable: true,
-				writable: true,
-				value: 2
-			}
-		});
+		);
 
 		source.c = {
 			d: 3,
-			e: [ 4, [ 5 ], { f: 6 } ]
+			e: [4, [5], { f: 6 }]
 		};
 
 		const object: {} = Object.create(null);
@@ -55,7 +58,8 @@ registerSuite('lang functions', {
 				weight: 52,
 				price: 100,
 				details: {
-					colour: 'brown', texture: 'soft'
+					colour: 'brown',
+					texture: 'soft'
 				}
 			},
 			cherry: 97
@@ -117,26 +121,30 @@ registerSuite('lang functions', {
 		};
 
 		const assignedObject = lang.deepAssign(target, source);
-		assert.deepEqual(assignedObject, { bar: { foo: 'bar' }, baz: { foo: 'bar' }, qux: { foo: { foo: 'bar' }, bar: { foo: { foo: 'bar' } } } });
+		assert.deepEqual(assignedObject, {
+			bar: { foo: 'bar' },
+			baz: { foo: 'bar' },
+			qux: { foo: { foo: 'bar' }, bar: { foo: { foo: 'bar' } } }
+		});
 	},
 
 	'.mixin()'() {
 		const source: {
-			a: number,
-			c: number,
+			a: number;
+			c: number;
 			nested: {
-				a: number
-			},
-			b: number,
-			hidden: number
-		} = <any> Object.create({
+				a: number;
+			};
+			b: number;
+			hidden: number;
+		} = <any>Object.create({
 			a: 1
 		});
 		source.c = 3;
 		source.nested = { a: 5 };
 		Object.defineProperty(source, 'b', {
 			enumerable: true,
-			get: function () {
+			get: function() {
 				return 2;
 			}
 		});
@@ -175,19 +183,19 @@ registerSuite('lang functions', {
 	'.deepMixin()'() {
 		const source: {
 			nested: {
-				a: number,
-				b: any[]
-			},
-			a: number,
-			b: number,
-			c: number,
-			d: Date,
-			e: RegExp,
-			hidden: number
-		} = <any> Object.create({
+				a: number;
+				b: any[];
+			};
+			a: number;
+			b: number;
+			c: number;
+			d: Date;
+			e: RegExp;
+			hidden: number;
+		} = <any>Object.create({
 			nested: {
 				a: 1,
-				b: [ 2, [ 3 ], { f: 4 } ]
+				b: [2, [3], { f: 4 }]
 			}
 		});
 		source.a = 1;
@@ -196,7 +204,7 @@ registerSuite('lang functions', {
 		source.e = /abc/;
 		Object.defineProperty(source, 'b', {
 			enumerable: true,
-			get: function () {
+			get: function() {
 				return 2;
 			}
 		});
@@ -229,7 +237,8 @@ registerSuite('lang functions', {
 				weight: 52,
 				price: 100,
 				details: {
-					colour: 'brown', texture: 'soft'
+					colour: 'brown',
+					texture: 'soft'
 				}
 			},
 			cherry: 97
@@ -280,41 +289,44 @@ registerSuite('lang functions', {
 			a: 1
 		};
 		const mixin: {
-			lorem: string,
+			lorem: string;
 			b: {
-				enumerable: boolean,
-				configurable: boolean,
-				writable: boolean,
+				enumerable: boolean;
+				configurable: boolean;
+				writable: boolean;
 				value: {
-					c: number
+					c: number;
+				};
+			};
+			d: {
+				enumerable: boolean;
+				configurable: boolean;
+				writable: boolean;
+				value: number;
+			};
+			e: {
+				value: number;
+			};
+		} = Object.create(
+			{ lorem: 'ipsum' },
+			{
+				b: {
+					enumerable: true,
+					configurable: true,
+					writable: true,
+					value: { c: 2 }
+				},
+				d: {
+					enumerable: true,
+					configurable: true,
+					writable: false,
+					value: 3
+				},
+				e: {
+					value: 4
 				}
-			},
-			d: {
-				enumerable: boolean,
-				configurable: boolean,
-				writable: boolean,
-				value: number
-			},
-			e: {
-				value: number
 			}
-		} = Object.create({ lorem: 'ipsum' }, {
-			b: {
-				enumerable: true,
-				configurable: true,
-				writable: true,
-				value: { c: 2 }
-			},
-			d: {
-				enumerable: true,
-				configurable: true,
-				writable: false,
-				value: 3
-			},
-			e: {
-				value: 4
-			}
-		});
+		);
 		const object: typeof prototype & typeof mixin = lang.create(prototype, mixin);
 
 		assert.strictEqual(Object.getPrototypeOf(object), prototype);
@@ -322,7 +334,7 @@ registerSuite('lang functions', {
 		assert.isTrue(Object.getOwnPropertyDescriptor(object, 'd')!.writable);
 		assert.isUndefined(object.e);
 		assert.isUndefined(object.lorem);
-		assert.throw(function () {
+		assert.throw(function() {
 			lang.create({});
 		});
 	},
@@ -332,13 +344,13 @@ registerSuite('lang functions', {
 			a: 1
 		};
 		const source: {
-			a: number,
+			a: number;
 			b: {
-				value: number
-			},
+				value: number;
+			};
 			c: {
-				d: number
-			}
+				d: number;
+			};
 		} = Object.create(prototype, {
 			b: { value: 2 }
 		});
@@ -364,56 +376,77 @@ registerSuite('lang functions', {
 	'.lateBind() context'() {
 		const object: {
 			method?: (...args: string[]) => string;
-		} = <any> {};
+		} = <any>{};
 		const method = lang.lateBind(object, 'method');
-		object.method = function (this: any): any {
+		object.method = function(this: any): any {
 			return this;
 		};
 
-		assert.strictEqual(method(), object, 'lateBind\'s context should be `object`.');
+		assert.strictEqual(method(), object, "lateBind's context should be `object`.");
 	},
 
 	'.lateBind() arguments'() {
 		const object: {
 			method?: (...args: string[]) => string;
-		} = <any> {};
+		} = <any>{};
 		const method = lang.lateBind(object, 'method', 'The', 'quick', 'brown');
 		const methodNoArgs = lang.lateBind(object, 'method');
 		const suffix = 'fox jumped over the lazy dog';
-		object.method = function (...parts: string[]): string {
+		object.method = function(...parts: string[]): string {
 			return parts.join(' ');
 		};
 
-		assert.strictEqual(method(suffix), 'The quick brown ' + suffix,
-			'lateBind\'s additional arguments should be prepended to the wrapped function.');
-		assert.strictEqual(methodNoArgs(suffix), suffix,
-			'lateBind\'s additional arguments should be prepended to the wrapped function.');
-		assert.strictEqual(method(), 'The quick brown',
-			'lateBind\'s additional arguments should be prepended to the wrapped function.');
+		assert.strictEqual(
+			method(suffix),
+			'The quick brown ' + suffix,
+			"lateBind's additional arguments should be prepended to the wrapped function."
+		);
+		assert.strictEqual(
+			methodNoArgs(suffix),
+			suffix,
+			"lateBind's additional arguments should be prepended to the wrapped function."
+		);
+		assert.strictEqual(
+			method(),
+			'The quick brown',
+			"lateBind's additional arguments should be prepended to the wrapped function."
+		);
 	},
 
 	'.partial()'() {
 		const ending = 'jumps over the lazy dog';
-		const finish = lang.partial(function (this: any) {
-			const start = this && this.start ? [ this.start ] : [];
+		const finish = lang.partial(
+			function(this: any) {
+				const start = this && this.start ? [this.start] : [];
 
-			return start.concat(Array.prototype.slice.call(arguments)).join(' ');
-		}, 'jumps', 'over');
+				return start.concat(Array.prototype.slice.call(arguments)).join(' ');
+			},
+			'jumps',
+			'over'
+		);
 
 		function Sentence(this: any, start: string = '') {
 			this.start = start;
 		}
 		Sentence.prototype.finish = finish;
 
-		assert.strictEqual(finish('the lazy dog'), ending,
+		assert.strictEqual(
+			finish('the lazy dog'),
+			ending,
 			'The arguments supplied to `lang.partial` should be prepended to the arguments list of the ' +
-			'original function.');
-		assert.strictEqual(finish(), 'jumps over',
+				'original function.'
+		);
+		assert.strictEqual(
+			finish(),
+			'jumps over',
 			'The arguments supplied to `lang.partial` should still be used even if no arguments are passed to the ' +
-			'wrapped function.');
-		assert.strictEqual(new (<any> Sentence)('The quick brown fox').finish('the lazy dog'),
+				'wrapped function.'
+		);
+		assert.strictEqual(
+			new (<any>Sentence)('The quick brown fox').finish('the lazy dog'),
 			'The quick brown fox ' + ending,
-			'A function passed to `lang.partial` should inherit its context.');
+			'A function passed to `lang.partial` should inherit its context.'
+		);
 	},
 
 	'.createHandle'() {
@@ -434,10 +467,7 @@ registerSuite('lang functions', {
 		function destructor(): void {
 			++count;
 		}
-		const handle = lang.createCompositeHandle(
-			lang.createHandle(destructor),
-			lang.createHandle(destructor)
-		);
+		const handle = lang.createCompositeHandle(lang.createHandle(destructor), lang.createHandle(destructor));
 
 		handle.destroy();
 		assert.strictEqual(count, 2, 'both destructors in the composite handle should have been called');

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -25,107 +25,148 @@ const suite: ObjectSuiteDescriptor = {
 		'global load'(this: any) {
 			const def = this.async(5000);
 
-			load('@dojo/shim/Promise').then(def.callback(function ([ promiseModule ]: [ any, any ]) {
-				assert.strictEqual(promiseModule.default, Promise);
-			}));
+			load('@dojo/shim/Promise').then(
+				def.callback(function([promiseModule]: [any, any]) {
+					assert.strictEqual(promiseModule.default, Promise);
+				})
+			);
 		},
 
 		'contextual load'(this: any) {
 			const def = this.async(5000);
 
-			load(require, '../support/load/a', '../support/load/b').then(def.callback(function ([ a, b ]: [ any, any ]) {
-				assert.deepEqual(a, { 'default': 'A', one: 1, two: 2 });
-				assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
-			}));
+			load(require, '../support/load/a', '../support/load/b').then(
+				def.callback(function([a, b]: [any, any]) {
+					assert.deepEqual(a, { default: 'A', one: 1, two: 2 });
+					assert.deepEqual(b, { default: 'B', three: 3, four: 4 });
+				})
+			);
 		},
 
 		'contextual load - all es 6 modules'() {
-			return load(require, '../support/load/a', '../support/load/b').then(useDefault).then(([ a, b ]: any[]) => {
-				assert.deepEqual(a, 'A');
-				assert.deepEqual(b, 'B');
-			});
+			return load(require, '../support/load/a', '../support/load/b')
+				.then(useDefault)
+				.then(([a, b]: any[]) => {
+					assert.deepEqual(a, 'A');
+					assert.deepEqual(b, 'B');
+				});
 		},
 
 		'contextual load - single es 6 module'() {
-			return load(require, '../support/load/a', '../support/load/b').then(([ a, b ]) => [ useDefault(a), b ]).then(([ a, b ]: any[]) => {
-				assert.deepEqual(a, 'A');
-				assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
-			});
+			return load(require, '../support/load/a', '../support/load/b')
+				.then(([a, b]) => [useDefault(a), b])
+				.then(([a, b]: any[]) => {
+					assert.deepEqual(a, 'A');
+					assert.deepEqual(b, { default: 'B', three: 3, four: 4 });
+				});
 		},
 
 		'load plugin': {
 			'without a resource id'(this: any) {
 				const dfd = this.async(5000);
 
-				load(require, '../support/load/plugin').then(dfd.callback(([ plugin ]: [ any ]) => {
-					assert.isFunction(plugin.load, 'No special behavior without a resource id.');
-				}));
+				load(require, '../support/load/plugin').then(
+					dfd.callback(([plugin]: [any]) => {
+						assert.isFunction(plugin.load, 'No special behavior without a resource id.');
+					})
+				);
 			},
 
 			'with a resource id'(this: any) {
 				const dfd = this.async(5000);
-				const resourceId = require.toUrl ? require.toUrl('@dojo/shim/Promise') : (require as any).resolve('@dojo/shim/Promise');
+				const resourceId = require.toUrl
+					? require.toUrl('@dojo/shim/Promise')
+					: (require as any).resolve('@dojo/shim/Promise');
 
-				load(require, '../support/load/plugin!@dojo/shim/Promise').then(dfd.callback(([ value ]: [ any ]) => {
-					assert.strictEqual(value, resourceId, 'The plugin `load` should receive the resolved resource id.');
-				}));
+				load(require, '../support/load/plugin!@dojo/shim/Promise').then(
+					dfd.callback(([value]: [any]) => {
+						assert.strictEqual(
+							value,
+							resourceId,
+							'The plugin `load` should receive the resolved resource id.'
+						);
+					})
+				);
 			},
 
 			'non-plugin with resource id'(this: any) {
 				const dfd = this.async(5000);
 
-				load(require, '../support/load/a!some/resource').then(dfd.callback(([ a ]: [ any ]) => {
-					assert.deepEqual(a, { one: 1, two: 2, 'default': 'A' }, 'The resource id should be ignored.');
-				}));
+				load(require, '../support/load/a!some/resource').then(
+					dfd.callback(([a]: [any]) => {
+						assert.deepEqual(a, { one: 1, two: 2, default: 'A' }, 'The resource id should be ignored.');
+					})
+				);
 			},
 
 			'default export used'(this: any) {
 				const dfd = this.async(5000);
 				sinon.spy(mockPlugin, 'load');
 
-				load(require, '../support/load/plugin-default!some/resource').then(dfd.callback(([ value ]: [ any ]) => {
-					assert.isTrue((<any> mockPlugin.load).calledWith('some/resource', load),
-						'Plugin `load` called with resource id and core `load`.');
-					assert.strictEqual(value, 'some/resource', 'The `load` on the default export should be used.');
+				load(require, '../support/load/plugin-default!some/resource').then(
+					dfd.callback(([value]: [any]) => {
+						assert.isTrue(
+							(<any>mockPlugin.load).calledWith('some/resource', load),
+							'Plugin `load` called with resource id and core `load`.'
+						);
+						assert.strictEqual(value, 'some/resource', 'The `load` on the default export should be used.');
 
-					(<any> mockPlugin.load).restore();
-				}), dfd.rejectOnError(() => {
-					(<any> mockPlugin.load).restore();
-				}));
+						(<any>mockPlugin.load).restore();
+					}),
+					dfd.rejectOnError(() => {
+						(<any>mockPlugin.load).restore();
+					})
+				);
 			},
 
 			'normalize method'(this: any) {
 				const dfd = this.async(5000);
 				sinon.spy(mockPlugin, 'normalize');
 
-				load(require, '../support/load/plugin-default!normalize').then(dfd.callback(([ value ]: [ any ]) => {
-					assert.strictEqual(value, 'path/to/normalized', 'The path should be passed to the `normalize` method.');
-					assert.isTrue((<any> mockPlugin.normalize).calledWith('normalize'),
-						'`normalize` called with resource id.');
-					assert.isFunction((<any> mockPlugin.normalize).firstCall.args[1],
-						'`normalize` called with resolver function.');
+				load(require, '../support/load/plugin-default!normalize').then(
+					dfd.callback(([value]: [any]) => {
+						assert.strictEqual(
+							value,
+							'path/to/normalized',
+							'The path should be passed to the `normalize` method.'
+						);
+						assert.isTrue(
+							(<any>mockPlugin.normalize).calledWith('normalize'),
+							'`normalize` called with resource id.'
+						);
+						assert.isFunction(
+							(<any>mockPlugin.normalize).firstCall.args[1],
+							'`normalize` called with resolver function.'
+						);
 
-					(<any> mockPlugin.normalize).restore();
-				}), dfd.rejectOnError(() => {
-					(<any> mockPlugin.normalize).restore();
-				}));
+						(<any>mockPlugin.normalize).restore();
+					}),
+					dfd.rejectOnError(() => {
+						(<any>mockPlugin.normalize).restore();
+					})
+				);
 			}
 		},
 
 		'error handling'() {
-			return load('some/bogus/nonexistent/thing').then(() => {
-				throw new Error('Should not resolve.');
-			}, (error: Error) => {
-				assert(error);
-				assert.isTrue(error.message.indexOf('some/bogus/nonexistent/thing') > -1,
-					'The error message should contain the module id.');
-			});
+			return load('some/bogus/nonexistent/thing').then(
+				() => {
+					throw new Error('Should not resolve.');
+				},
+				(error: Error) => {
+					assert(error);
+					assert.isTrue(
+						error.message.indexOf('some/bogus/nonexistent/thing') > -1,
+						'The error message should contain the module id.'
+					);
+				}
+			);
 		}
 	}
 };
 
 if (has('host-node')) {
-	const nodeRequire: any = (<any> require).nodeRequire || require;
+	const nodeRequire: any = (<any>require).nodeRequire || require;
 	const path: any = nodeRequire('path');
 	const buildDir: string = path.join(process.cwd(), '_build');
 
@@ -133,43 +174,57 @@ if (has('host-node')) {
 		'global load succeeds'(this: any) {
 			const def = this.async(5000);
 
-			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).globalSucceed;
-			result().then(def.callback(function ([ fs, path ]: [ any, any ]) {
-				assert.strictEqual(fs, nodeRequire('fs'));
-				assert.strictEqual(path, nodeRequire('path'));
-			}));
+			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node'))
+				.globalSucceed;
+			result().then(
+				def.callback(function([fs, path]: [any, any]) {
+					assert.strictEqual(fs, nodeRequire('fs'));
+					assert.strictEqual(path, nodeRequire('path'));
+				})
+			);
 		},
 
 		'global load with relative path fails'(this: any) {
 			const def = this.async(5000);
 
-			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).globalFail;
-			result().then(function () {
-				def.reject(new Error('load should not have succeeded'));
-			}, def.callback(function (error: Error) {
-				assert.instanceOf(error, Error);
-			}));
+			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node'))
+				.globalFail;
+			result().then(
+				function() {
+					def.reject(new Error('load should not have succeeded'));
+				},
+				def.callback(function(error: Error) {
+					assert.instanceOf(error, Error);
+				})
+			);
 		},
 
 		'contextual load succeeds'(this: any) {
 			const def = this.async(5000);
 
-			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeed;
-			result().then(def.callback(function ([ a, b ]: [ any, any ]) {
-				assert.deepEqual(a, { 'default': 'A', one: 1, two: 2 });
-				assert.deepEqual(b, { 'default': 'B', three: 3, four: 4 });
-			}));
+			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node'))
+				.succeed;
+			result().then(
+				def.callback(function([a, b]: [any, any]) {
+					assert.deepEqual(a, { default: 'A', one: 1, two: 2 });
+					assert.deepEqual(b, { default: 'B', three: 3, four: 4 });
+				})
+			);
 		},
 
 		'contextual load with non-existent module fails'(this: any) {
 			const def = this.async(5000);
 
-			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).fail;
-			result().then(function () {
-				def.reject(new Error('load should not have succeeded'));
-			}, def.callback(function (error: Error) {
-				assert.instanceOf(error, Error);
-			}));
+			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node'))
+				.fail;
+			result().then(
+				function() {
+					def.reject(new Error('load should not have succeeded'));
+				},
+				def.callback(function(error: Error) {
+					assert.instanceOf(error, Error);
+				})
+			);
 		}
 	};
 }

--- a/tests/unit/load/util.ts
+++ b/tests/unit/load/util.ts
@@ -1,4 +1,3 @@
-import Promise from '@dojo/shim/Promise';
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { Tests } from 'intern/lib/interfaces/object';

--- a/tests/unit/load/util.ts
+++ b/tests/unit/load/util.ts
@@ -12,17 +12,23 @@ const suite: Tests = {
 		assert.isFalse(isPlugin([]));
 		assert.isFalse(isPlugin(/\s/));
 		assert.isFalse(isPlugin({}));
-		assert.isTrue(isPlugin({
-			load() {}
-		}));
+		assert.isTrue(
+			isPlugin({
+				load() {}
+			})
+		);
 	},
 
 	useDefault: {
 		'single es6 module'() {
-			assert.strictEqual(useDefault({
-				'__esModule': true,
-				'default': 42
-			}), 42, 'The default export should be returned.');
+			assert.strictEqual(
+				useDefault({
+					__esModule: true,
+					default: 42
+				}),
+				42,
+				'The default export should be returned.'
+			);
 		},
 
 		'single non-es6 module'() {
@@ -31,24 +37,24 @@ const suite: Tests = {
 		},
 
 		'all es6 modules'() {
-			const modules = [ 42, 43 ].map((value: number) => {
-				return { '__esModule': true, 'default': value };
+			const modules = [42, 43].map((value: number) => {
+				return { __esModule: true, default: value };
 			});
-			assert.sameMembers(useDefault(modules), [ 42, 43 ], 'The default export should be returned for all modules.');
+			assert.sameMembers(useDefault(modules), [42, 43], 'The default export should be returned for all modules.');
 		},
 
 		'mixed module types'() {
-			const modules: any[] = [ 42, 43 ].map((value: number) => {
-				return { '__esModule': true, 'default': value };
+			const modules: any[] = [42, 43].map((value: number) => {
+				return { __esModule: true, default: value };
 			});
 			modules.push({ value: 44 });
-			assert.sameDeepMembers(useDefault(modules), [ 42, 43, { value: 44 } ]);
+			assert.sameDeepMembers(useDefault(modules), [42, 43, { value: 44 }]);
 		}
 	}
 };
 
 if (has('host-node')) {
-	const nodeRequire: any = (<any> require).nodeRequire || require;
+	const nodeRequire: any = (<any>require).nodeRequire || require;
 	const path: any = nodeRequire('path');
 	const buildDir: string = path.join(process.cwd(), '_build');
 
@@ -56,11 +62,14 @@ if (has('host-node')) {
 		'useDefault resolves es modules'(this: any) {
 			const def = this.async(5000);
 
-			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node')).succeedDefault;
-			result().then(def.callback(function ([ a, b ]: [ any, any ]) {
-				assert.deepEqual(a, 'A');
-				assert.deepEqual(b, 'B');
-			}));
+			const result: () => Promise<any[]> = nodeRequire(path.join(buildDir, 'tests', 'support', 'load', 'node'))
+				.succeedDefault;
+			result().then(
+				def.callback(function([a, b]: [any, any]) {
+					assert.deepEqual(a, 'A');
+					assert.deepEqual(b, 'B');
+				})
+			);
 		}
 	};
 }

--- a/tests/unit/load/webpack.ts
+++ b/tests/unit/load/webpack.ts
@@ -22,15 +22,14 @@ function setModules(modules?: { [mid: string]: any }) {
 			webpackModules[id] = modules[mid];
 		});
 		global.__modules__ = idMap;
-	}
-	else {
+	} else {
 		global.__modules__ = null;
 	}
 }
 
 registerSuite('load/webpack', {
 	before() {
-		global.__webpack_require__ = function (id: number): any {
+		global.__webpack_require__ = function(id: number): any {
 			return webpackModules[id];
 		};
 	},
@@ -84,31 +83,40 @@ registerSuite('load/webpack', {
 
 		'without __modules__'() {
 			setModules();
-			return load('non-existent/module').then(() => {
-				throw new Error('Should not resolve.');
-			}, (error: Error) => {
-				assert.instanceOf(error, Error);
-				assert.strictEqual(error.message, 'Missing module: non-existent/module');
-			});
+			return load('non-existent/module').then(
+				() => {
+					throw new Error('Should not resolve.');
+				},
+				(error: Error) => {
+					assert.instanceOf(error, Error);
+					assert.strictEqual(error.message, 'Missing module: non-existent/module');
+				}
+			);
 		},
 
 		'contextual require': {
 			'absolute path'() {
-				return load(() => '/path/to/first', '/path/to/second').then((results: any[]) => {
-					assert.strictEqual(results.length, 1);
-					assert.strictEqual(results[0].foo, 'bar');
-				}, (error: Error) => {
-					throw new Error(`Promise should not reject\n${error.message}`);
-				});
+				return load(() => '/path/to/first', '/path/to/second').then(
+					(results: any[]) => {
+						assert.strictEqual(results.length, 1);
+						assert.strictEqual(results[0].foo, 'bar');
+					},
+					(error: Error) => {
+						throw new Error(`Promise should not reject\n${error.message}`);
+					}
+				);
 			},
 
 			'relative path (same directory)'() {
-				return load(() => '/path/to/first', './second').then((results: any[]) => {
-					assert.strictEqual(results.length, 1);
-					assert.strictEqual(results[0].foo, 'bar');
-				}, (error: Error) => {
-					throw new Error(`Promise should not reject\n${error.message}`);
-				});
+				return load(() => '/path/to/first', './second').then(
+					(results: any[]) => {
+						assert.strictEqual(results.length, 1);
+						assert.strictEqual(results[0].foo, 'bar');
+					},
+					(error: Error) => {
+						throw new Error(`Promise should not reject\n${error.message}`);
+					}
+				);
 			},
 
 			'relative path (up one directory)'() {
@@ -126,86 +134,114 @@ registerSuite('load/webpack', {
 			},
 
 			'relative path (beyond root directory)'() {
-				assert.throws(() => {
-					load(() => '/path/to/first', '../../../../../../other');
-				}, Error, 'Path cannot go beyond root directory.');
+				assert.throws(
+					() => {
+						load(() => '/path/to/first', '../../../../../../other');
+					},
+					Error,
+					'Path cannot go beyond root directory.'
+				);
 			}
 		},
 
 		'normal require': {
 			'absolute path'() {
-				return load('/path/to/second').then((results: any[]) => {
-					assert.strictEqual(results.length, 1);
-					assert.strictEqual(results[0].foo, 'bar');
-				}, (error: Error) => {
-					throw new Error(`Promise should not reject\n${error.message}`);
-				});
+				return load('/path/to/second').then(
+					(results: any[]) => {
+						assert.strictEqual(results.length, 1);
+						assert.strictEqual(results[0].foo, 'bar');
+					},
+					(error: Error) => {
+						throw new Error(`Promise should not reject\n${error.message}`);
+					}
+				);
 			},
 
 			'relative path'() {
-				return load('./path/to/second').then((results: any[]) => {
-					assert.strictEqual(results.length, 1);
-					assert.strictEqual(results[0].foo, 'bar');
-				}, (error: Error) => {
-					throw new Error(`Promise should not reject\n${error.message}`);
-				});
+				return load('./path/to/second').then(
+					(results: any[]) => {
+						assert.strictEqual(results.length, 1);
+						assert.strictEqual(results[0].foo, 'bar');
+					},
+					(error: Error) => {
+						throw new Error(`Promise should not reject\n${error.message}`);
+					}
+				);
 			}
 		},
 
 		'bundle loader modules'() {
-			return load('bundle!lazy').then((results: any[]) => {
-				assert.strictEqual(results.length, 1);
-				assert.strictEqual(results[0].value, 'lazy loaded');
-			}, (error: Error) => {
-				throw new Error(`Promise should not reject\n${error.message}`);
-			});
+			return load('bundle!lazy').then(
+				(results: any[]) => {
+					assert.strictEqual(results.length, 1);
+					assert.strictEqual(results[0].value, 'lazy loaded');
+				},
+				(error: Error) => {
+					throw new Error(`Promise should not reject\n${error.message}`);
+				}
+			);
 		},
 
 		'plugin modules': {
 			'with normalize method'() {
 				const mid = 'plugin!normalize';
-				return load(mid).then(() => {
-					const module = webpackModules[global.__modules__[mid].id];
-					assert.isTrue(module.normalize.calledWith('normalize'));
-					assert.strictEqual(module.normalize.args[0][1]('normalize'), 'normalize',
-						'`normalize` should be passed an identity resolver.');
-					assert.isTrue(module.load.calledWith('normalized/path/to/resource', load));
-				}, (error: Error) => {
-					throw new Error(`Promise should not reject\n${error.message}`);
-				});
+				return load(mid).then(
+					() => {
+						const module = webpackModules[global.__modules__[mid].id];
+						assert.isTrue(module.normalize.calledWith('normalize'));
+						assert.strictEqual(
+							module.normalize.args[0][1]('normalize'),
+							'normalize',
+							'`normalize` should be passed an identity resolver.'
+						);
+						assert.isTrue(module.load.calledWith('normalized/path/to/resource', load));
+					},
+					(error: Error) => {
+						throw new Error(`Promise should not reject\n${error.message}`);
+					}
+				);
 			},
 
 			'without normalize method': {
 				'with a context method'() {
 					const mid = 'plugin!./resource/id';
 					const context = () => 'parent/sibling';
-					return load(context, mid).then(() => {
-						const module = webpackModules[global.__modules__[mid].id];
-						assert.isTrue(module.load.calledWith('parent/resource/id'));
-					}, (error: Error) => {
-						throw new Error(`Promise should not reject\n${error.message}`);
-					});
+					return load(context, mid).then(
+						() => {
+							const module = webpackModules[global.__modules__[mid].id];
+							assert.isTrue(module.load.calledWith('parent/resource/id'));
+						},
+						(error: Error) => {
+							throw new Error(`Promise should not reject\n${error.message}`);
+						}
+					);
 				},
 
 				'without a context method': {
 					'with a relative ID'() {
 						const mid = 'plugin!./resource/id';
-						return load(mid).then(() => {
-							const module = webpackModules[global.__modules__[mid].id];
-							assert.isTrue(module.load.calledWith('/resource/id'));
-						}, (error: Error) => {
-							throw new Error(`Promise should not reject\n${error.message}`);
-						});
+						return load(mid).then(
+							() => {
+								const module = webpackModules[global.__modules__[mid].id];
+								assert.isTrue(module.load.calledWith('/resource/id'));
+							},
+							(error: Error) => {
+								throw new Error(`Promise should not reject\n${error.message}`);
+							}
+						);
 					},
 
 					'without a relative ID'() {
 						const mid = 'plugin!resource/id';
-						return load(mid).then(() => {
-							const module = webpackModules[global.__modules__[mid].id];
-							assert.isTrue(module.load.calledWith('resource/id'));
-						}, (error: Error) => {
-							throw new Error(`Promise should not reject\n${error.message}`);
-						});
+						return load(mid).then(
+							() => {
+								const module = webpackModules[global.__modules__[mid].id];
+								assert.isTrue(module.load.calledWith('resource/id'));
+							},
+							(error: Error) => {
+								throw new Error(`Promise should not reject\n${error.message}`);
+							}
+						);
 					}
 				}
 			}

--- a/tests/unit/on/all.ts
+++ b/tests/unit/on/all.ts
@@ -6,15 +6,15 @@ import on, { emit } from '../../../src/on';
 import Evented from '../../../src/Evented';
 
 registerSuite('events - Evented', {
-	'cannot target non-emitter': function () {
-		assert.throws(function () {
-			on(<any> {}, 'test', function () {});
+	'cannot target non-emitter': function() {
+		assert.throws(function() {
+			on(<any>{}, 'test', function() {});
 		});
 	},
 
 	'common cases': common({
 		eventName: 'test',
-		createTarget: function () {
+		createTarget: function() {
 			return new Evented();
 		}
 	}),
@@ -23,7 +23,7 @@ registerSuite('events - Evented', {
 		const target = new Evented();
 		assert.isFalse(emit(target, { type: 'test' }));
 
-		const handle = on(target, 'test', function () {});
+		const handle = on(target, 'test', function() {});
 		assert.isFalse(emit(target, { type: 'test' }));
 
 		handle.destroy();

--- a/tests/unit/on/browserOnly.ts
+++ b/tests/unit/on/browserOnly.ts
@@ -35,7 +35,7 @@ registerSuite('events - EventTarget', {
 		const target = createTarget();
 		assert.isTrue(emit(target, { type: 'test' }));
 
-		const handle = on(target, 'test', function (evt: EventObject) {
+		const handle = on(target, 'test', function(evt: EventObject) {
 			if (isDOMEvent(evt)) {
 				evt.preventDefault();
 			}

--- a/tests/unit/on/common.ts
+++ b/tests/unit/on/common.ts
@@ -26,7 +26,7 @@ interface CustomEvent {
 	preventDefault?: () => void;
 }
 
-export default function (args: any): ObjectSuiteDescriptor {
+export default function(args: any): ObjectSuiteDescriptor {
 	let target: any;
 	const testEventName: string = args.eventName;
 
@@ -45,7 +45,7 @@ export default function (args: any): ObjectSuiteDescriptor {
 				let listenerCallCount = 0;
 				let emittedEvent: CustomEvent;
 
-				testOn(target, testEventName, function (actualEvent: CustomEvent) {
+				testOn(target, testEventName, function(actualEvent: CustomEvent) {
 					listenerCallCount++;
 					assert.strictEqual(actualEvent.value, emittedEvent.value);
 				});
@@ -64,7 +64,7 @@ export default function (args: any): ObjectSuiteDescriptor {
 				let emittedEventType: string;
 				let emittedEvent: CustomEvent;
 
-				testOn(target, ['test1', 'test2'], function (actualEvent: CustomEvent) {
+				testOn(target, ['test1', 'test2'], function(actualEvent: CustomEvent) {
 					listenerCallCount++;
 					if (emittedEventType in actualEvent) {
 						assert.strictEqual(actualEvent.type, emittedEventType);
@@ -85,26 +85,28 @@ export default function (args: any): ObjectSuiteDescriptor {
 
 			'on - multiple handlers'() {
 				const order: any[] = [];
-				testOn(target, ['a', 'b'], function (event: CustomEvent) {
+				testOn(target, ['a', 'b'], function(event: CustomEvent) {
 					order.push(`1${event.type}`);
 				});
-				testOn(target, [ 'a', 'c' ], function (event: CustomEvent) {
+				testOn(target, ['a', 'c'], function(event: CustomEvent) {
 					order.push(`2${event.type}`);
 				});
 				emit(target, { type: 'a' });
 				emit(target, { type: 'b' });
 				emit(target, { type: 'c' });
-				assert.deepEqual(order, [ '1a', '2a', '1b', '2c' ]);
+				assert.deepEqual(order, ['1a', '2a', '1b', '2c']);
 			},
 
-			'once'() {
+			once() {
 				let listenerCallCount = 0;
 				let emittedEvent: CustomEvent;
 
-				handles.push(once(target, testEventName, function (actualEvent: CustomEvent) {
-					listenerCallCount++;
-					assert.strictEqual(actualEvent.value, emittedEvent.value);
-				}));
+				handles.push(
+					once(target, testEventName, function(actualEvent: CustomEvent) {
+						listenerCallCount++;
+						assert.strictEqual(actualEvent.value, emittedEvent.value);
+					})
+				);
 
 				emittedEvent = { value: 'foo', type: testEventName };
 
@@ -115,11 +117,11 @@ export default function (args: any): ObjectSuiteDescriptor {
 				assert.strictEqual(listenerCallCount, 1);
 			},
 
-			'pausable'() {
+			pausable() {
 				let listenerCallCount = 0;
 				let emittedEvent: CustomEvent;
 
-				let handle = pausable(target, testEventName, function (actualEvent: CustomEvent) {
+				let handle = pausable(target, testEventName, function(actualEvent: CustomEvent) {
 					listenerCallCount++;
 					assert.strictEqual(actualEvent.value, emittedEvent.value);
 				});

--- a/tests/unit/on/nodeOnly.ts
+++ b/tests/unit/on/nodeOnly.ts
@@ -18,7 +18,7 @@ registerSuite('events - EventEmitter', {
 		const target = createTarget();
 		assert.isFalse(emit(target, { type: 'test' }));
 
-		const handle = on(target, 'test', function () {});
+		const handle = on(target, 'test', function() {});
 		assert.isFalse(emit(target, { type: 'test' }));
 
 		handle.destroy();

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -9,37 +9,38 @@ const mockData = '{ "foo": "bar" }';
 let handle: any;
 
 function mockProvider(url: string, options?: RequestOptions): UploadObservableTask<Response> {
-	const task: UploadObservableTask<Response> = <any> Task.resolve(new class extends ResponseClass {
-		bodyUsed = false;
-		headers: Headers = new Headers();
-		ok = true;
-		status = 200;
-		statusText = 'OK';
-		url: string = url;
-		requestOptions = options || {};
+	const task: UploadObservableTask<Response> = <any>Task.resolve(
+		new class extends ResponseClass {
+			bodyUsed = false;
+			headers: Headers = new Headers();
+			ok = true;
+			status = 200;
+			statusText = 'OK';
+			url: string = url;
+			requestOptions = options || {};
 
-		download = new Observable<number>(() => {});
-		data = new Observable<number>(() => {});
+			download = new Observable<number>(() => {});
+			data = new Observable<number>(() => {});
 
-		arrayBuffer(): Task<ArrayBuffer> {
-			return Task.resolve(<any> null);
-		}
+			arrayBuffer(): Task<ArrayBuffer> {
+				return Task.resolve(<any>null);
+			}
 
-		blob(): Task<Blob> {
-			return Task.resolve(<any> null);
-		}
+			blob(): Task<Blob> {
+				return Task.resolve(<any>null);
+			}
 
-		formData(): Task<FormData> {
-			return Task.resolve(<any> null);
-		}
+			formData(): Task<FormData> {
+				return Task.resolve(<any>null);
+			}
 
-		text(): Task<string> {
-			return Task.resolve(mockData);
-		}
-	});
+			text(): Task<string> {
+				return Task.resolve(mockData);
+			}
+		}()
+	);
 
-	task.upload = new Observable<number>(() => {
-	});
+	task.upload = new Observable<number>(() => {});
 
 	return task;
 }
@@ -59,36 +60,38 @@ registerSuite('request', {
 			},
 
 			tests: {
-				'get'() {
-					return request.get('test.html').then(response => {
+				get() {
+					return request.get('test.html').then((response) => {
 						assert.equal(response.requestOptions.method, 'GET');
 					});
 				},
-				'delete'() {
-					return request.delete('test.html').then(response => {
+				delete() {
+					return request.delete('test.html').then((response) => {
 						assert.equal(response.requestOptions.method, 'DELETE');
 					});
 				},
-				'head'() {
-					return request.head('test.html').then(response => {
+				head() {
+					return request.head('test.html').then((response) => {
 						assert.equal(response.requestOptions.method, 'HEAD');
 					});
 				},
-				'options'() {
-					return request.options('test.html').then(response => {
+				options() {
+					return request.options('test.html').then((response) => {
 						assert.equal(response.requestOptions.method, 'OPTIONS');
 					});
 				},
-				'post'() {
-					return request.post('test.html', {
-						body: 'some body'
-					}).then(response => {
-						assert.equal(response.requestOptions.method, 'POST');
-						assert.equal(response.requestOptions.body, 'some body');
-					});
+				post() {
+					return request
+						.post('test.html', {
+							body: 'some body'
+						})
+						.then((response) => {
+							assert.equal(response.requestOptions.method, 'POST');
+							assert.equal(response.requestOptions.body, 'some body');
+						});
 				},
-				'put'() {
-					return request.put('test.html').then(response => {
+				put() {
+					return request.put('test.html').then((response) => {
 						assert.equal(response.requestOptions.method, 'PUT');
 					});
 				}
@@ -99,10 +102,12 @@ registerSuite('request', {
 			'String matching'() {
 				handle = providerRegistry.register('arbitrary.html', mockProvider);
 
-				return request.get('arbitrary.html')
-					.then(function (response) {
+				return request
+					.get('arbitrary.html')
+					.then(function(response) {
 						return response.text();
-					}).then(data => {
+					})
+					.then((data) => {
 						assert.equal(data, mockData);
 					});
 			},
@@ -110,26 +115,27 @@ registerSuite('request', {
 			'RegExp matching'() {
 				handle = providerRegistry.register(/arbitrary\.html$/, mockProvider);
 
-				return request.get('arbitrary.html')
-					.then(function (response) {
+				return request
+					.get('arbitrary.html')
+					.then(function(response) {
 						return response.text();
-					}).then(text => {
+					})
+					.then((text) => {
 						assert.equal(text, mockData);
 					});
 			},
 
 			'Default matching'() {
-				handle = providerRegistry.register(
-					function (url: string): boolean {
-						return url === 'arbitrary.html';
-					},
-					mockProvider
-				);
+				handle = providerRegistry.register(function(url: string): boolean {
+					return url === 'arbitrary.html';
+				}, mockProvider);
 
-				return request.get('arbitrary.html')
-					.then(function (response) {
+				return request
+					.get('arbitrary.html')
+					.then(function(response) {
 						return response.text();
-					}).then(text => {
+					})
+					.then((text) => {
 						assert.equal(text, mockData);
 					});
 			}
@@ -142,11 +148,14 @@ registerSuite('request', {
 
 			tests: {
 				'JSON matching'() {
-					return request.get('arbitrary.html').then(function (response) {
-						return response.json<{ foo: string; }>();
-					}).then((json) => {
-						assert.deepEqual(json, { foo: 'bar' }, 'JSON parsing should be automatically provided.');
-					});
+					return request
+						.get('arbitrary.html')
+						.then(function(response) {
+							return response.json<{ foo: string }>();
+						})
+						.then((json) => {
+							assert.deepEqual(json, { foo: 'bar' }, 'JSON parsing should be automatically provided.');
+						});
 				}
 			}
 		}

--- a/tests/unit/request/SubscriptionPool.ts
+++ b/tests/unit/request/SubscriptionPool.ts
@@ -8,9 +8,9 @@ registerSuite('SubscriptionPool', {
 		const dfd = this.async();
 
 		const pool = new SubscriptionPool<any>();
-		const obs = new Observable<any>(observer => pool.add(observer));
+		const obs = new Observable<any>((observer) => pool.add(observer));
 
-		obs.subscribe(value => {
+		obs.subscribe((value) => {
 			assert.deepEqual(value, 1);
 			dfd.resolve();
 		});
@@ -22,11 +22,11 @@ registerSuite('SubscriptionPool', {
 		const dfd = this.async();
 
 		const pool = new SubscriptionPool<any>();
-		const obs = new Observable<any>(observer => pool.add(observer));
+		const obs = new Observable<any>((observer) => pool.add(observer));
 
 		pool.next(1);
 
-		obs.subscribe(value => {
+		obs.subscribe((value) => {
 			assert.strictEqual(value, 1);
 			dfd.resolve();
 		});
@@ -36,12 +36,12 @@ registerSuite('SubscriptionPool', {
 		const dfd = this.async();
 
 		const pool = new SubscriptionPool<any>(1);
-		const obs = new Observable<any>(observer => pool.add(observer));
+		const obs = new Observable<any>((observer) => pool.add(observer));
 
 		pool.next(1);
 		pool.next(2);
 
-		obs.subscribe(value => {
+		obs.subscribe((value) => {
 			assert.strictEqual(value, 2);
 			dfd.resolve();
 		});

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -40,7 +40,7 @@ const responseData: { [url: string]: DummyResponse } = {
 	'foo.json': {
 		body: JSON.stringify({ foo: 'bar' })
 	},
-	'cookies': {
+	cookies: {
 		body: JSON.stringify({ foo: 'bar' }),
 		headers: {
 			'Set-cookie': 'one'
@@ -56,42 +56,42 @@ const responseData: { [url: string]: DummyResponse } = {
 		statusCode: 300,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'301-redirect': {
 		statusCode: 301,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'302-redirect': {
 		statusCode: 302,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'303-redirect': {
 		statusCode: 303,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'304-redirect': {
 		statusCode: 304,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'305-redirect': {
 		statusCode: 305,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': 'http://localhost:1337'
+			Location: 'http://localhost:1337'
 		}
 	},
 	'305-redirect-broken': {
@@ -102,21 +102,21 @@ const responseData: { [url: string]: DummyResponse } = {
 		statusCode: 306,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'307-redirect': {
 		statusCode: 307,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success')
+			Location: getRequestUrl('redirect-success')
 		}
 	},
 	'infinite-redirect': {
 		statusCode: 301,
 		body: JSON.stringify('beginning to redirect'),
 		headers: {
-			'Location': getRequestUrl('infinite-redirect')
+			Location: getRequestUrl('infinite-redirect')
 		}
 	},
 	'broken-redirect': {
@@ -128,20 +128,20 @@ const responseData: { [url: string]: DummyResponse } = {
 		statusCode: 301,
 		body: JSON.stringify('beginning redirect'),
 		headers: {
-			'Location': '/redirect-success'
+			Location: '/redirect-success'
 		}
 	},
 	'protocolless-redirect': {
 		statusCode: 301,
 		body: JSON.stringify('beginning redirect'),
 		headers: {
-			'Location': getRequestUrl('redirect-success').replace('http:', '')
+			Location: getRequestUrl('redirect-success').replace('http:', '')
 		}
 	},
 	'gzip-compressed': {
 		statusCode: 200,
-		body: function (callback: any) {
-			zlib.gzip(new Buffer(JSON.stringify({ 'test': true }), 'utf8'), function (err: any, result: any) {
+		body: function(callback: any) {
+			zlib.gzip(new Buffer(JSON.stringify({ test: true }), 'utf8'), function(err: any, result: any) {
 				callback(result);
 			});
 		},
@@ -151,8 +151,8 @@ const responseData: { [url: string]: DummyResponse } = {
 	},
 	'deflate-compressed': {
 		statusCode: 200,
-		body: function (callback: any) {
-			zlib.deflate(new Buffer(JSON.stringify({ 'test': true }), 'utf8'), function (err: any, result: any) {
+		body: function(callback: any) {
+			zlib.deflate(new Buffer(JSON.stringify({ test: true }), 'utf8'), function(err: any, result: any) {
 				callback(result);
 			});
 		},
@@ -162,9 +162,9 @@ const responseData: { [url: string]: DummyResponse } = {
 	},
 	'gzip-deflate-compressed': {
 		statusCode: 200,
-		body: function (callback: any) {
-			zlib.gzip(new Buffer(JSON.stringify({ 'test': true }), 'utf8'), (err: any, result: any) => {
-				zlib.deflate(result, function (err: any, result: any) {
+		body: function(callback: any) {
+			zlib.gzip(new Buffer(JSON.stringify({ test: true }), 'utf8'), (err: any, result: any) => {
+				zlib.deflate(result, function(err: any, result: any) {
 					callback(result);
 				});
 			});
@@ -196,7 +196,7 @@ const responseData: { [url: string]: DummyResponse } = {
 	},
 	'blob.gif': {
 		statusCode: 200,
-		body: function (callback: any) {
+		body: function(callback: any) {
 			callback(fs.readFileSync('tests/support/data/blob.gif'));
 		}
 	}
@@ -211,12 +211,11 @@ function buildRedirectTests(methods: RedirectTestData[]) {
 		const url = getRequestUrl(details.url);
 		const expectedMethod = details.expectedMethod || method;
 		const expectedPage = details.expectedPage ? getRequestUrl(details.expectedPage) : url;
-		const followRedirects = (details.followRedirects === undefined) ? true : details.followRedirects;
+		const followRedirects = details.followRedirects === undefined ? true : details.followRedirects;
 
-		let title = details.title || (method + ' ' + (keepOriginalMethod ? 'w/' : 'w/o') + ' keepOriginalMethod');
+		let title = details.title || method + ' ' + (keepOriginalMethod ? 'w/' : 'w/o') + ' keepOriginalMethod';
 
-		tests[ title ] = () => {
-
+		tests[title] = () => {
 			let error: any = null;
 
 			return nodeRequest(getRequestUrl(details.url), {
@@ -225,48 +224,51 @@ function buildRedirectTests(methods: RedirectTestData[]) {
 				redirectOptions: {
 					keepOriginalMethod
 				}
-			}).then((response?: Response) => {
-				if (response) {
-					return response.text().then((text: string) => {
-						if (details.callback) {
-							details.callback(response);
-						}
-
-						(assert as any).nestedPropertyVal(response, 'requestOptions.method', expectedMethod);
-						assert.equal(response.url, expectedPage);
-
-						if (details.expectedCount !== undefined) {
-							const { redirectOptions: { count: redirectCount = 0 } = {} } = (<NodeResponse> response).requestOptions;
-
-							assert.equal(redirectCount, details.expectedCount);
-						}
-
-						if (details.expectedData !== undefined) {
-							if (text === null) {
-								assert.isNull(details.expectedData);
+			})
+				.then((response?: Response) => {
+					if (response) {
+						return response.text().then((text: string) => {
+							if (details.callback) {
+								details.callback(response);
 							}
-							else {
-								let data = JSON.parse(text);
-								assert.deepEqual(data, details.expectedData);
+
+							(assert as any).nestedPropertyVal(response, 'requestOptions.method', expectedMethod);
+							assert.equal(response.url, expectedPage);
+
+							if (details.expectedCount !== undefined) {
+								const {
+									redirectOptions: { count: redirectCount = 0 } = {}
+								} = (<NodeResponse>response).requestOptions;
+
+								assert.equal(redirectCount, details.expectedCount);
 							}
-						}
-					});
-				}
-			}).catch((e: Error) => {
-				error = e;
-			}).finally(() => {
-				if (details.expectedToError) {
-					assert.isNotNull(error, 'Expected an error to occur but none did');
-				}
-				else if (error) {
-					throw error;
-				}
-			});
+
+							if (details.expectedData !== undefined) {
+								if (text === null) {
+									assert.isNull(details.expectedData);
+								} else {
+									let data = JSON.parse(text);
+									assert.deepEqual(data, details.expectedData);
+								}
+							}
+						});
+					}
+				})
+				.catch((e: Error) => {
+					error = e;
+				})
+				.finally(() => {
+					if (details.expectedToError) {
+						assert.isNotNull(error, 'Expected an error to occur but none did');
+					} else if (error) {
+						throw error;
+					}
+				});
 		};
 	});
 
 	return tests;
-};
+}
 
 function getResponseData(request: any): DummyResponse {
 	const urlInfo = parse(request.url, true);
@@ -279,7 +281,7 @@ function getResponseData(request: any): DummyResponse {
 		};
 	}
 
-	return responseData[ urlInfo.query.dataKey ] || {};
+	return responseData[urlInfo.query.dataKey] || {};
 }
 
 function getRequestUrl(dataKey: string): string {
@@ -291,11 +293,11 @@ function getAuthRequestUrl(dataKey: string, user: string = 'user', password: str
 	return requestUrl.slice(0, 7) + user + ':' + password + '@' + requestUrl.slice(7);
 }
 
-function assertBasicAuthentication(options: { user?: string, password?: string }, expectedAuth: string, dfd: any) {
+function assertBasicAuthentication(options: { user?: string; password?: string }, expectedAuth: string, dfd: any) {
 	nodeRequest(getRequestUrl('foo.json'), options).then(
-		dfd.callback(function (response: any) {
+		dfd.callback(function(response: any) {
 			const actual: string = response.nativeResponse.req._headers.authorization;
-			const expected = `Basic ${ new Buffer(expectedAuth).toString('base64') }`;
+			const expected = `Basic ${new Buffer(expectedAuth).toString('base64')}`;
 
 			assert.strictEqual(actual, expected);
 		}),
@@ -307,30 +309,29 @@ registerSuite('request/node', {
 	before(this: any) {
 		const dfd = this.async();
 
-		server = createServer(function (request, response) {
+		server = createServer(function(request, response) {
 			const { statusCode = 200, headers = {}, body = '{}' } = getResponseData(request);
 
 			const data: string[] = [];
-			request.on('data', function (chunk: any) {
+			request.on('data', function(chunk: any) {
 				data.push(chunk.toString('utf8'));
 			});
 
-			request.on('end', function () {
+			request.on('end', function() {
 				requestData = data.length ? JSON.parse(data.join()) : null;
 
 				if (!('Content-Type' in headers)) {
-					headers[ 'Content-Type' ] = 'application/json';
+					headers['Content-Type'] = 'application/json';
 				}
 
 				response.writeHead(statusCode, headers);
 
 				if (typeof body === 'function') {
-					body(function (result: Buffer) {
+					body(function(result: Buffer) {
 						response.write(result);
 						response.end();
 					});
-				}
-				else {
+				} else {
 					response.write(new Buffer(body, 'utf8'));
 					response.end();
 				}
@@ -348,10 +349,10 @@ registerSuite('request/node', {
 			requestData = '';
 
 			if (!('Content-Type' in headers)) {
-				headers[ 'Content-Type' ] = 'application/json';
+				headers['Content-Type'] = 'application/json';
 			}
 
-			headers[ 'Proxy-agent' ] = 'nodejs';
+			headers['Proxy-agent'] = 'nodejs';
 
 			response.writeHead(statusCode, headers);
 
@@ -373,19 +374,19 @@ registerSuite('request/node', {
 	tests: {
 		'request options': {
 			body: {
-				'string'(this: any): void {
+				string(this: any): void {
 					const dfd = this.async();
 					nodeRequest(getRequestUrl('foo.json'), {
 						body: '{ "foo": "bar" }',
 						method: 'POST'
 					}).then(
-						dfd.callback(function () {
+						dfd.callback(function() {
 							assert.deepEqual(requestData, { foo: 'bar' } as any);
 						}),
 						dfd.reject.bind(dfd)
 					);
 				},
-				'buffer'() {
+				buffer() {
 					return nodeRequest(getRequestUrl('foo.json'), {
 						body: Buffer.from('{ "foo": "bar" }', 'utf8'),
 						method: 'POST'
@@ -400,38 +401,47 @@ registerSuite('request/node', {
 					return nodeRequest(getRequestUrl('echo'), {
 						method: 'POST',
 						bodyStream: fs.createReadStream('tests/support/data/foo.json')
-					}).then(res => res.json()).then(json => {
-						assert.deepEqual(requestData, { foo: 'bar' } as any);
-					});
+					})
+						.then((res) => res.json())
+						.then((json) => {
+							assert.deepEqual(requestData, { foo: 'bar' } as any);
+						});
 				}
 			},
 
-			'content encoding': (function (compressionTypes) {
+			'content encoding': (function(compressionTypes) {
 				const suites: { [key: string]: any } = {};
 
-				compressionTypes.map(type => {
-					suites[ type ] = {
+				compressionTypes.map((type) => {
+					suites[type] = {
 						'gets decoded'() {
-							return nodeRequest(getRequestUrl(`${type}-compressed`)).then(response => {
-								return response.json();
-							}).then(obj => {
-								assert.deepEqual(obj, { test: true });
-							});
+							return nodeRequest(getRequestUrl(`${type}-compressed`))
+								.then((response) => {
+									return response.json();
+								})
+								.then((obj) => {
+									assert.deepEqual(obj, { test: true });
+								});
 						},
 						'errors are caught'() {
-							return nodeRequest(getRequestUrl(`${type}-invalid`)).then(response => {
-								return response.json();
-							}).then(() => {
-								assert.fail('Should not have succeeded');
-							}, (error) => {
-								assert.isNotNull(error);
-							});
+							return nodeRequest(getRequestUrl(`${type}-invalid`))
+								.then((response) => {
+									return response.json();
+								})
+								.then(
+									() => {
+										assert.fail('Should not have succeeded');
+									},
+									(error) => {
+										assert.isNotNull(error);
+									}
+								);
 						}
 					};
 				});
 
 				return suites;
-			})([ 'gzip', 'deflate', 'gzip-deflate' ]),
+			})(['gzip', 'deflate', 'gzip-deflate']),
 
 			proxy(this: any): void {
 				const dfd = this.async();
@@ -439,12 +449,14 @@ registerSuite('request/node', {
 				nodeRequest(url, {
 					proxy: url.slice(0, 7) + 'username:password@' + url.slice(7)
 				}).then(
-					dfd.callback(function (response: any) {
+					dfd.callback(function(response: any) {
 						const request = response.nativeResponse.req;
 
 						assert.strictEqual(request.path, url);
-						assert.strictEqual(request._headers[ 'proxy-authorization' ],
-							'Basic ' + new Buffer('username:password').toString('base64'));
+						assert.strictEqual(
+							request._headers['proxy-authorization'],
+							'Basic ' + new Buffer('username:password').toString('base64')
+						);
 						assert.strictEqual(request._headers.host, serverUrl.slice(7));
 					}),
 					dfd.reject.bind(dfd)
@@ -455,45 +467,60 @@ registerSuite('request/node', {
 				both(this: any): void {
 					const user = 'user name';
 					const password = 'pass word';
-					assertBasicAuthentication({
-						user,
-						password
-					}, `${ user }:${ password }`, this.async());
+					assertBasicAuthentication(
+						{
+							user,
+							password
+						},
+						`${user}:${password}`,
+						this.async()
+					);
 				},
 
 				'user only'(this: any): void {
 					const user = 'user name';
-					assertBasicAuthentication({
-						user
-					}, `${ user }:`, this.async());
+					assertBasicAuthentication(
+						{
+							user
+						},
+						`${user}:`,
+						this.async()
+					);
 				},
 
 				'password only'(this: any): void {
 					const password = 'pass word';
-					assertBasicAuthentication({
-						password
-					}, `:${ password }`, this.async());
+					assertBasicAuthentication(
+						{
+							password
+						},
+						`:${password}`,
+						this.async()
+					);
 				},
 
 				'special characters'(this: any): void {
 					const user = '$pecialUser';
 					const password = '__!passW@rd';
-					assertBasicAuthentication({
-						user,
-						password
-					}, `${ user }:${ password }`, this.async());
+					assertBasicAuthentication(
+						{
+							user,
+							password
+						},
+						`${user}:${password}`,
+						this.async()
+					);
 				},
 
 				error(this: any): void {
 					const dfd = this.async();
-					nodeRequest(getAuthRequestUrl('foo.json'), { timeout: 1 })
-						.then(
-							dfd.resolve.bind(dfd),
-							dfd.callback(function (error: TimeoutError): void {
-								assert.notInclude(error.message, 'user:password');
-								assert.include(error.message, '(redacted)');
-							})
-						);
+					nodeRequest(getAuthRequestUrl('foo.json'), { timeout: 1 }).then(
+						dfd.resolve.bind(dfd),
+						dfd.callback(function(error: TimeoutError): void {
+							assert.notInclude(error.message, 'user:password');
+							assert.include(error.message, '(redacted)');
+						})
+					);
 				}
 			},
 
@@ -506,7 +533,7 @@ registerSuite('request/node', {
 						timeout: 100
 					}
 				}).then(
-					dfd.callback(function (response: NodeResponse) {
+					dfd.callback(function(response: NodeResponse) {
 						// TODO: Is it even possible to test this?
 						const socketOptions = response.requestOptions.socketOptions || {};
 						assert.strictEqual(socketOptions.keepAlive, 100);
@@ -522,24 +549,22 @@ registerSuite('request/node', {
 				nodeRequest(getRequestUrl('foo.json'), {
 					streamEncoding: 'utf8'
 				}).then((response: NodeResponse) => {
-						response.json().then(dfd.callback(function (json: any) {
-								assert.deepEqual(json, { foo: 'bar' });
-							})
-						);
-					},
-					dfd.reject.bind(dfd)
-				);
+					response.json().then(
+						dfd.callback(function(json: any) {
+							assert.deepEqual(json, { foo: 'bar' });
+						})
+					);
+				}, dfd.reject.bind(dfd));
 			},
 
 			'"timeout"'(this: any): void {
 				const dfd = this.async();
-				nodeRequest(getRequestUrl('foo.json'), { timeout: 1 })
-					.then(
-						dfd.resolve.bind(dfd),
-						dfd.callback(function (error: Error): void {
-							assert.strictEqual(error.name, 'TimeoutError');
-						})
-					);
+				nodeRequest(getRequestUrl('foo.json'), { timeout: 1 }).then(
+					dfd.resolve.bind(dfd),
+					dfd.callback(function(error: Error): void {
+						assert.strictEqual(error.name, 'TimeoutError');
+					})
+				);
 			},
 			'upload monitoriting': {
 				'with a stream'(this: any) {
@@ -550,11 +575,11 @@ registerSuite('request/node', {
 						bodyStream: fs.createReadStream('tests/support/data/foo.json')
 					});
 
-					req.upload.subscribe(totalBytesUploaded => {
+					req.upload.subscribe((totalBytesUploaded) => {
 						events.push(totalBytesUploaded);
 					});
 
-					return req.then(res => {
+					return req.then((res) => {
 						assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
 						assert.equal(events[events.length - 1], 17);
 					});
@@ -567,11 +592,11 @@ registerSuite('request/node', {
 						body: '{ "foo": "bar" }\n'
 					});
 
-					req.upload.subscribe(totalBytesUploaded => {
+					req.upload.subscribe((totalBytesUploaded) => {
 						events.push(totalBytesUploaded);
 					});
 
-					return req.then(res => {
+					return req.then((res) => {
 						assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
 						assert.equal(events[events.length - 1], 17);
 					});
@@ -580,8 +605,8 @@ registerSuite('request/node', {
 			'download events'() {
 				let downloadEvents: number[] = [];
 
-				return nodeRequest(getRequestUrl('foo.json')).then(response => {
-					response.download.subscribe(totalBytesDownloaded => {
+				return nodeRequest(getRequestUrl('foo.json')).then((response) => {
+					response.download.subscribe((totalBytesDownloaded) => {
 						downloadEvents.push(totalBytesDownloaded);
 					});
 
@@ -594,8 +619,8 @@ registerSuite('request/node', {
 			'data events'() {
 				let data: number[] = [];
 
-				return nodeRequest(getRequestUrl('foo.json')).then(response => {
-					response.data.subscribe(chunk => {
+				return nodeRequest(getRequestUrl('foo.json')).then((response) => {
+					response.data.subscribe((chunk) => {
 						data.push(chunk);
 					});
 
@@ -614,8 +639,8 @@ registerSuite('request/node', {
 						someThingCrAzY: 'some-arbitrary-value'
 					}
 				}).then(
-					dfd.callback(function (response: NodeResponse) {
-						const header: any = (<any> response.nativeResponse).req._header;
+					dfd.callback(function(response: NodeResponse) {
+						const header: any = (<any>response.nativeResponse).req._header;
 
 						assert.notInclude(header, 'somethingcrazy: some-arbitrary-value');
 						assert.include(header, 'someThingCrAzY: some-arbitrary-value');
@@ -626,31 +651,34 @@ registerSuite('request/node', {
 			},
 
 			'user agent should be added if its not there'(this: any): any {
-				return nodeRequest(getRequestUrl('foo.json'), {}).then((response: any) => {
-					const header: any = response.nativeResponse.req._header;
+				return nodeRequest(getRequestUrl('foo.json'), {})
+					.then((response: any) => {
+						const header: any = response.nativeResponse.req._header;
 
-					assert.include(header, 'user-agent:');
+						assert.include(header, 'user-agent:');
 
-					return nodeRequest(getRequestUrl('food.json'), {
-						headers: {
-							'user-agent': 'already exists'
-						}
+						return nodeRequest(getRequestUrl('food.json'), {
+							headers: {
+								'user-agent': 'already exists'
+							}
+						});
+					})
+					.then((response: any) => {
+						const header: any = response.nativeResponse.req._header;
+
+						assert.include(header, 'user-agent: already exists');
+
+						return nodeRequest(getRequestUrl('food.json'), {
+							headers: {
+								'uSeR-AgEnT': 'mIxEd CaSe'
+							}
+						});
+					})
+					.then((response: any) => {
+						const header: any = response.nativeResponse.req._header;
+
+						assert.include(header, 'uSeR-AgEnT: mIxEd CaSe');
 					});
-				}).then((response: any) => {
-					const header: any = response.nativeResponse.req._header;
-
-					assert.include(header, 'user-agent: already exists');
-
-					return nodeRequest(getRequestUrl('food.json'), {
-						headers: {
-							'uSeR-AgEnT': 'mIxEd CaSe'
-						}
-					});
-				}).then((response: any) => {
-					const header: any = response.nativeResponse.req._header;
-
-					assert.include(header, 'uSeR-AgEnT: mIxEd CaSe');
-				});
 			},
 
 			'compression headers are present by default'() {
@@ -672,21 +700,18 @@ registerSuite('request/node', {
 			'response headers': {
 				'after response'(this: any): void {
 					const dfd = this.async();
-					nodeRequest(getRequestUrl('foo.json'))
-						.then(
-							dfd.callback(function (response: Response): void {
-								assert.strictEqual(response.headers.get('content-type'), 'application/json');
-							}),
-							dfd.reject.bind(dfd)
-						);
+					nodeRequest(getRequestUrl('foo.json')).then(
+						dfd.callback(function(response: Response): void {
+							assert.strictEqual(response.headers.get('content-type'), 'application/json');
+						}),
+						dfd.reject.bind(dfd)
+					);
 				}
 			},
 
 			'set cookie makes separate headers'() {
 				return nodeRequest(getRequestUrl('cookies')).then((response: any) => {
-					assert.deepEqual(response.headers.getAll('set-cookie'), [
-						'one'
-					]);
+					assert.deepEqual(response.headers.getAll('set-cookie'), ['one']);
 				});
 			}
 		},
@@ -694,13 +719,12 @@ registerSuite('request/node', {
 		'response object': {
 			properties(this: any): void {
 				const dfd = this.async();
-				nodeRequest(getRequestUrl('foo.json'))
-					.then(
-						dfd.callback(function (response: Response): void {
-							assert.strictEqual(response.status, 200);
-						}),
-						dfd.reject.bind(dfd)
-					);
+				nodeRequest(getRequestUrl('foo.json')).then(
+					dfd.callback(function(response: Response): void {
+						assert.strictEqual(response.status, 200);
+					}),
+					dfd.reject.bind(dfd)
+				);
 			},
 
 			'data cannot be used twice'() {
@@ -710,11 +734,14 @@ registerSuite('request/node', {
 					return response.json().then(() => {
 						assert.isTrue(response.bodyUsed);
 
-						return response.json().then(() => {
-							throw new Error('should not have succeeded');
-						}, () => {
-							return true;
-						});
+						return response.json().then(
+							() => {
+								throw new Error('should not have succeeded');
+							},
+							() => {
+								return true;
+							}
+						);
 					});
 				});
 			},
@@ -736,20 +763,23 @@ registerSuite('request/node', {
 					});
 				},
 
-				'blob'() {
+				blob() {
 					return nodeRequest(getRequestUrl('foo.json')).then((response: any) => {
-						return response.blob().then((blob: any) => {
-							assert.fail('should not have succeeded');
-						}, () => {
-							return true;
-						});
+						return response.blob().then(
+							(blob: any) => {
+								assert.fail('should not have succeeded');
+							},
+							() => {
+								return true;
+							}
+						);
 					});
 				}
 			}
 		},
 
 		'status codes': {
-			'Redirects': {
+			Redirects: {
 				'300 Multiple Choices': buildRedirectTests([
 					{
 						method: 'GET',
@@ -1006,7 +1036,6 @@ registerSuite('request/node', {
 						url: '304-redirect',
 						expectedPage: '304-redirect',
 						expectedCount: 0
-
 					},
 					{
 						method: 'PUT',
@@ -1028,7 +1057,7 @@ registerSuite('request/node', {
 						url: '305-redirect',
 						expectedCount: 1,
 						callback: (response) => {
-							assert.equal(response.nativeResponse.headers[ 'proxy-agent' ], 'nodejs');
+							assert.equal(response.nativeResponse.headers['proxy-agent'], 'nodejs');
 						}
 					},
 					{
@@ -1074,7 +1103,6 @@ registerSuite('request/node', {
 						url: '307-redirect',
 						expectedPage: 'redirect-success',
 						expectedCount: 1
-
 					},
 					{
 						method: 'PUT',
@@ -1099,22 +1127,24 @@ registerSuite('request/node', {
 					}
 				]),
 
-				'Infinite Redirects': function () {
+				'Infinite Redirects': function() {
 					let didError = false;
 
 					return nodeRequest(getRequestUrl('infinite-redirect'), {
 						redirectOptions: {
 							limit: 10
 						}
-					}).then((response) => {
-					}).catch(() => {
-						didError = true;
-					}).finally(() => {
-						assert.isTrue(didError, 'Expected an error to occur but none did');
-					});
+					})
+						.then((response) => {})
+						.catch(() => {
+							didError = true;
+						})
+						.finally(() => {
+							assert.isTrue(didError, 'Expected an error to occur but none did');
+						});
 				},
 
-				'Sensible Defaults': function () {
+				'Sensible Defaults': function() {
 					return nodeRequest(getRequestUrl('301-redirect'), {}).then((response: any) => {
 						assert.equal(response.url, getRequestUrl('redirect-success'));
 					});

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -13,7 +13,7 @@ registerSuite('request/providers/xhr', {
 		return xhrRequest('/__echo/', {
 			method: 'GET',
 			timeout: 10000
-		}).then(response => {
+		}).then((response) => {
 			if (response && response.status === 200) {
 				echoServerAvailable = true;
 				return;
@@ -27,42 +27,37 @@ registerSuite('request/providers/xhr', {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/foo.json', { method: 'get' })
-					.then(function (response: any) {
-						assert.strictEqual(response.requestOptions.method, 'get');
-					});
+				return xhrRequest('/__echo/foo.json', { method: 'get' }).then(function(response: any) {
+					assert.strictEqual(response.requestOptions.method, 'get');
+				});
 			},
 
-			'default'(this: any) {
+			default(this: any) {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/foo.json')
-					.then(function (response: any) {
-						assert.strictEqual(response.requestOptions.method, 'GET');
-					});
+				return xhrRequest('/__echo/foo.json').then(function(response: any) {
+					assert.strictEqual(response.requestOptions.method, 'GET');
+				});
 			},
 
 			'.get with URL query'(this: any) {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/xhr?color=blue&numbers=one&numbers=two').then(function (response: any) {
+				return xhrRequest('/__echo/xhr?color=blue&numbers=one&numbers=two').then(function(response: any) {
 					return response.json().then((data: any) => {
 						const query = data.query;
 						assert.deepEqual(query, {
 							color: 'blue',
-							numbers: [ 'one', 'two' ]
+							numbers: ['one', 'two']
 						});
-						assert.strictEqual(
-							response.url,
-							'/__echo/xhr?color=blue&numbers=one&numbers=two'
-						);
+						assert.strictEqual(response.url, '/__echo/xhr?color=blue&numbers=one&numbers=two');
 					});
 				});
 			},
 
-			'.post': function (this: any) {
+			'.post': function(this: any) {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
@@ -72,7 +67,7 @@ registerSuite('request/providers/xhr', {
 					headers: {
 						'Content-Type': 'application/x-www-form-urlencoded'
 					}
-				}).then(function (response: any) {
+				}).then(function(response: any) {
 					return response.json().then((data: any) => {
 						assert.strictEqual(data.method, 'POST');
 						const payload = data.payload;
@@ -89,15 +84,14 @@ registerSuite('request/providers/xhr', {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/xhr?delay=5000', { timeout: 10 })
-					.then(
-						function () {
-							assert(false, 'Should have timed out');
-						},
-						function (error: Error) {
-							assert.strictEqual(error.name, 'TimeoutError');
-						}
-					);
+				return xhrRequest('/__echo/xhr?delay=5000', { timeout: 10 }).then(
+					function() {
+						assert(false, 'Should have timed out');
+					},
+					function(error: Error) {
+						assert.strictEqual(error.name, 'TimeoutError');
+					}
+				);
 			},
 
 			'user and password'(this: any) {
@@ -107,7 +101,7 @@ registerSuite('request/providers/xhr', {
 				return xhrRequest('/__echo/foo.json', {
 					user: 'user',
 					password: 'password'
-				}).then(function (response: any) {
+				}).then(function(response: any) {
 					assert.strictEqual(response.requestOptions.user, 'user');
 					assert.strictEqual(response.requestOptions.password, 'password');
 				});
@@ -125,35 +119,35 @@ registerSuite('request/providers/xhr', {
 					body: '12345'
 				});
 
-				req.upload.subscribe(totalBytesUploaded => {
+				req.upload.subscribe((totalBytesUploaded) => {
 					events.push(totalBytesUploaded);
 				});
 
-				return req.then(res => {
+				return req.then((res) => {
 					assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
 					assert.equal(events[events.length - 1], 5);
 				});
 			},
 
-			'query': {
+			query: {
 				'.get with query URL and query option string'(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
 					return xhrRequest('/__echo/xhr?color=blue&numbers=one&numbers=two', {
 						query: new UrlSearchParams({
-							foo: [ 'bar', 'baz' ],
+							foo: ['bar', 'baz'],
 							thud: 'thonk',
 							xyzzy: '3'
 						}).toString()
-					}).then(function (response: any) {
+					}).then(function(response: any) {
 						return response.json().then((data: any) => {
 							const query = data.query;
 							assert.deepEqual(query, {
 								color: 'blue',
-								numbers: [ 'one', 'two' ],
+								numbers: ['one', 'two'],
 								thud: 'thonk',
-								foo: [ 'bar', 'baz' ],
+								foo: ['bar', 'baz'],
 								xyzzy: '3'
 							});
 							assert.strictEqual(
@@ -170,22 +164,19 @@ registerSuite('request/providers/xhr', {
 					}
 					return xhrRequest('/__echo/xhr', {
 						query: new UrlSearchParams({
-							foo: [ 'bar', 'baz' ],
+							foo: ['bar', 'baz'],
 							thud: 'thonk',
 							xyzzy: '3'
 						}).toString()
-					}).then(function (response: any) {
+					}).then(function(response: any) {
 						return response.json().then((data: any) => {
 							const query = data.query;
 							assert.deepEqual(query, {
-								foo: [ 'bar', 'baz' ],
+								foo: ['bar', 'baz'],
 								thud: 'thonk',
 								xyzzy: '3'
 							});
-							assert.strictEqual(
-								response.url,
-								'/__echo/xhr?foo=bar&foo=baz&thud=thonk&xyzzy=3'
-							);
+							assert.strictEqual(response.url, '/__echo/xhr?foo=bar&foo=baz&thud=thonk&xyzzy=3');
 						});
 					});
 				},
@@ -196,22 +187,19 @@ registerSuite('request/providers/xhr', {
 					}
 					return xhrRequest('/__echo/xhr', {
 						query: {
-							foo: [ 'bar', 'baz' ],
+							foo: ['bar', 'baz'],
 							thud: 'thonk',
 							xyzzy: '3'
 						}
-					}).then(function (response: any) {
+					}).then(function(response: any) {
 						return response.json().then((data: any) => {
 							const query = data.query;
 							assert.deepEqual(query, {
-								foo: [ 'bar', 'baz' ],
+								foo: ['bar', 'baz'],
 								thud: 'thonk',
 								xyzzy: '3'
 							});
-							assert.strictEqual(
-								response.url,
-								'/__echo/xhr?foo=bar&foo=baz&thud=thonk&xyzzy=3'
-							);
+							assert.strictEqual(response.url, '/__echo/xhr?foo=bar&foo=baz&thud=thonk&xyzzy=3');
 						});
 					});
 				},
@@ -224,24 +212,26 @@ registerSuite('request/providers/xhr', {
 					let cacheBustStringB: string;
 					return xhrRequest('/__echo/xhr?foo=bar', {
 						cacheBust: true
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
-						cacheBustStringA = response.url.split('&')[ 1 ];
-						assert.isFalse(isNaN(Number(cacheBustStringA)));
-						return new Promise<Response>(function (resolve, reject) {
-							setTimeout(function () {
-								xhrRequest('/__echo/xhr?foo=bar', {
-									cacheBust: true
-								}).then(resolve, reject);
-							}, 5);
-						});
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
-						cacheBustStringB = response.url.split('&')[ 1 ];
-						assert.isFalse(isNaN(Number(cacheBustStringB)));
+					})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
+							cacheBustStringA = response.url.split('&')[1];
+							assert.isFalse(isNaN(Number(cacheBustStringA)));
+							return new Promise<Response>(function(resolve, reject) {
+								setTimeout(function() {
+									xhrRequest('/__echo/xhr?foo=bar', {
+										cacheBust: true
+									}).then(resolve, reject);
+								}, 5);
+							});
+						})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
+							cacheBustStringB = response.url.split('&')[1];
+							assert.isFalse(isNaN(Number(cacheBustStringB)));
 
-						assert.notEqual(cacheBustStringA, cacheBustStringB);
-					});
+							assert.notEqual(cacheBustStringA, cacheBustStringB);
+						});
 				},
 
 				'.get with cacheBust w/query string w/query option'(this: any) {
@@ -255,28 +245,30 @@ registerSuite('request/providers/xhr', {
 						query: {
 							bar: 'baz'
 						}
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar&bar=baz'), 0);
-						cacheBustStringA = response.url.split('&')[ 2 ];
-						assert.isFalse(isNaN(Number(cacheBustStringA)));
+					})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar&bar=baz'), 0);
+							cacheBustStringA = response.url.split('&')[2];
+							assert.isFalse(isNaN(Number(cacheBustStringA)));
 
-						return new Promise<Response>(function (resolve, reject) {
-							setTimeout(function () {
-								xhrRequest('/__echo/xhr?foo=bar', {
-									cacheBust: true,
-									query: {
-										bar: 'baz'
-									}
-								}).then(resolve, reject);
-							}, 5);
+							return new Promise<Response>(function(resolve, reject) {
+								setTimeout(function() {
+									xhrRequest('/__echo/xhr?foo=bar', {
+										cacheBust: true,
+										query: {
+											bar: 'baz'
+										}
+									}).then(resolve, reject);
+								}, 5);
+							});
+						})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar&bar=baz'), 0);
+							cacheBustStringB = response.url.split('&')[2];
+							assert.isFalse(isNaN(Number(cacheBustStringB)));
+
+							assert.notEqual(cacheBustStringA, cacheBustStringB);
 						});
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar&bar=baz'), 0);
-						cacheBustStringB = response.url.split('&')[ 2 ];
-						assert.isFalse(isNaN(Number(cacheBustStringB)));
-
-						assert.notEqual(cacheBustStringA, cacheBustStringB);
-					});
 				},
 
 				'.get with cacheBust w/o/query string w/query option'(this: any) {
@@ -290,28 +282,30 @@ registerSuite('request/providers/xhr', {
 						query: {
 							foo: 'bar'
 						}
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
-						cacheBustStringA = response.url.split('&')[ 1 ];
-						assert.isFalse(isNaN(Number(cacheBustStringA)));
+					})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
+							cacheBustStringA = response.url.split('&')[1];
+							assert.isFalse(isNaN(Number(cacheBustStringA)));
 
-						return new Promise<Response>(function (resolve, reject) {
-							setTimeout(function () {
-								xhrRequest('/__echo/xhr', {
-									cacheBust: true,
-									query: {
-										foo: 'bar'
-									}
-								}).then(resolve, reject);
-							}, 5);
+							return new Promise<Response>(function(resolve, reject) {
+								setTimeout(function() {
+									xhrRequest('/__echo/xhr', {
+										cacheBust: true,
+										query: {
+											foo: 'bar'
+										}
+									}).then(resolve, reject);
+								}, 5);
+							});
+						})
+						.then(function(response: any) {
+							assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
+							cacheBustStringB = response.url.split('&')[1];
+							assert.isFalse(isNaN(Number(cacheBustStringB)));
+
+							assert.notEqual(cacheBustStringA, cacheBustStringB);
 						});
-					}).then(function (response: any) {
-						assert.strictEqual(response.url.indexOf('/__echo/xhr?foo=bar'), 0);
-						cacheBustStringB = response.url.split('&')[ 1 ];
-						assert.isFalse(isNaN(Number(cacheBustStringB)));
-
-						assert.notEqual(cacheBustStringA, cacheBustStringB);
-					});
 				},
 
 				'.get with cacheBust and no query'(this: any) {
@@ -322,24 +316,26 @@ registerSuite('request/providers/xhr', {
 					let cacheBustStringB: string;
 					return xhrRequest('/__echo/xhr', {
 						cacheBust: true
-					}).then(function (response: any) {
-						cacheBustStringA = response.url.split('?')[ 1 ];
-						assert.ok(cacheBustStringA);
-						assert.isFalse(isNaN(Number(cacheBustStringA)));
+					})
+						.then(function(response: any) {
+							cacheBustStringA = response.url.split('?')[1];
+							assert.ok(cacheBustStringA);
+							assert.isFalse(isNaN(Number(cacheBustStringA)));
 
-						return xhrRequest('/__echo/xhr', {
-							cacheBust: true
+							return xhrRequest('/__echo/xhr', {
+								cacheBust: true
+							});
+						})
+						.then(function(response: any) {
+							cacheBustStringB = response.url.split('?')[1];
+							assert.ok(cacheBustStringB);
+							assert.isFalse(isNaN(Number(cacheBustStringB)));
+							assert.notEqual(cacheBustStringA, cacheBustStringB);
 						});
-					}).then(function (response: any) {
-						cacheBustStringB = response.url.split('?')[ 1 ];
-						assert.ok(cacheBustStringB);
-						assert.isFalse(isNaN(Number(cacheBustStringB)));
-						assert.notEqual(cacheBustStringA, cacheBustStringB);
-					});
 				}
 			},
 
-			'headers': {
+			headers: {
 				'normalize header names'(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
@@ -349,12 +345,12 @@ registerSuite('request/providers/xhr', {
 							'CONTENT-TYPE': 'arbitrary-value',
 							'X-REQUESTED-WITH': 'test'
 						}
-					}).then(function (response: any) {
+					}).then(function(response: any) {
 						return response.json().then((data: any) => {
-							assert.isUndefined(data.headers[ 'CONTENT-TYPE' ]);
+							assert.isUndefined(data.headers['CONTENT-TYPE']);
 							assert.propertyVal(data.headers, 'content-type', 'arbitrary-value');
 
-							assert.isUndefined(data.headers[ 'X-REQUESTED-WITH' ]);
+							assert.isUndefined(data.headers['X-REQUESTED-WITH']);
 							assert.propertyVal(data.headers, 'x-requested-with', 'test');
 						});
 					});
@@ -368,21 +364,23 @@ registerSuite('request/providers/xhr', {
 						headers: {
 							'Content-Type': 'application/arbitrary-value'
 						}
-					}).then(function (response: any) {
-						return response.json().then((data: any) => {
-							assert.propertyVal(data.headers, 'content-type', 'application/arbitrary-value');
+					})
+						.then(function(response: any) {
+							return response.json().then((data: any) => {
+								assert.propertyVal(data.headers, 'content-type', 'application/arbitrary-value');
 
-							return xhrRequest('/__echo/custom', {
-								headers: {
-									'Range': 'bytes=0-1024'
-								}
+								return xhrRequest('/__echo/custom', {
+									headers: {
+										Range: 'bytes=0-1024'
+									}
+								});
+							});
+						})
+						.then((response: any) => {
+							return response.json().then((data: any) => {
+								assert.isDefined(data.headers, 'range');
 							});
 						});
-					}).then((response: any) => {
-						return response.json().then((data: any) => {
-							assert.isDefined(data.headers, 'range');
-						});
-					});
 				},
 
 				'default headers'(this: any) {
@@ -390,11 +388,11 @@ registerSuite('request/providers/xhr', {
 						this.skip('No echo server available');
 					}
 					const options = has('formdata') ? { body: new FormData() } : {};
-					return xhrRequest('/__echo/default', options).then(function (response: any) {
+					return xhrRequest('/__echo/default', options).then(function(response: any) {
 						return response.json().then((data: any) => {
-							assert.strictEqual(data.headers[ 'x-requested-with' ], 'XMLHttpRequest');
+							assert.strictEqual(data.headers['x-requested-with'], 'XMLHttpRequest');
 							if (has('formdata')) {
-								assert.include(data.headers[ 'content-type' ], 'application/x-www-form-urlencoded');
+								assert.include(data.headers['content-type'], 'application/x-www-form-urlencoded');
 							}
 						});
 					});
@@ -404,8 +402,8 @@ registerSuite('request/providers/xhr', {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
-					const options = {includeRequestedWithHeader: false};
-					return xhrRequest('/__echo/default?norequestedwith', options).then(function (response: any) {
+					const options = { includeRequestedWithHeader: false };
+					return xhrRequest('/__echo/default?norequestedwith', options).then(function(response: any) {
 						return response.json().then((data: any) => {
 							assert.isUndefined(data.headers['x-requested-with']);
 						});
@@ -419,7 +417,7 @@ registerSuite('request/providers/xhr', {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/foo.json').then(function (response: XhrResponse) {
+				return xhrRequest('/__echo/foo.json').then(function(response: XhrResponse) {
 					assert.strictEqual(response.status, 200);
 					assert.strictEqual(response.statusText, 'OK');
 					assert.isTrue(response.nativeResponse instanceof XMLHttpRequest);
@@ -432,7 +430,7 @@ registerSuite('request/providers/xhr', {
 				if (!echoServerAvailable) {
 					this.skip('No echo server available');
 				}
-				return xhrRequest('/__echo/foo.json').then(function (response: any) {
+				return xhrRequest('/__echo/foo.json').then(function(response: any) {
 					return response.text().then((data: any) => {
 						const length: number = Number(response.headers.get('content-length'));
 						assert.strictEqual(length, data.length);
@@ -451,17 +449,20 @@ registerSuite('request/providers/xhr', {
 					return response.text().then(() => {
 						assert.isTrue(response.bodyUsed);
 
-						return response.text().then(() => {
-							throw new Error('should not have succeeded');
-						}, () => {
-							return 'success';
-						});
+						return response.text().then(
+							() => {
+								throw new Error('should not have succeeded');
+							},
+							() => {
+								return 'success';
+							}
+						);
 					});
 				});
 			},
 
 			'response types': {
-				'arrayBuffer'(this: any) {
+				arrayBuffer(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
@@ -477,7 +478,7 @@ registerSuite('request/providers/xhr', {
 					});
 				},
 
-				'blob'(this: any) {
+				blob(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
@@ -493,7 +494,7 @@ registerSuite('request/providers/xhr', {
 					});
 				},
 
-				'formData'(this: any) {
+				formData(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
@@ -509,7 +510,7 @@ registerSuite('request/providers/xhr', {
 					});
 				},
 
-				'xml'(this: any) {
+				xml(this: any) {
 					if (!echoServerAvailable) {
 						this.skip('No echo server available');
 					}
@@ -530,8 +531,8 @@ registerSuite('request/providers/xhr', {
 
 					let timesCalled = 0;
 
-					return xhrRequest('/__echo/foo.json').then(response => {
-						response.data.subscribe(chunk => {
+					return xhrRequest('/__echo/foo.json').then((response) => {
+						response.data.subscribe((chunk) => {
 							assert.isNotNull(chunk);
 							timesCalled++;
 						});
@@ -549,8 +550,8 @@ registerSuite('request/providers/xhr', {
 
 					let downloadEvents: number[] = [];
 
-					return xhrRequest('/__echo/foo.json').then(response => {
-						response.download.subscribe(totalBytesDownloaded => {
+					return xhrRequest('/__echo/foo.json').then((response) => {
+						response.download.subscribe((totalBytesDownloaded) => {
 							downloadEvents.push(totalBytesDownloaded);
 						});
 
@@ -572,7 +573,9 @@ registerSuite('request/providers/xhr', {
 				const baseUrl = location.origin;
 				const dfd = this.async();
 
-				const blob = new Blob([ `(function() {
+				const blob = new Blob(
+					[
+						`(function() {
 self.addEventListener('message', function (event) {
 	testXhr(event.data.baseUrl, event.data.testUrl);
 });
@@ -594,7 +597,10 @@ function testXhr(baseUrl, testUrl) {
 		});
 	});
 }
-				})()` ], { type: 'application/javascript' });
+				})()`
+					],
+					{ type: 'application/javascript' }
+				);
 				const worker = new Worker(URL.createObjectURL(blob));
 				worker.addEventListener('error', (error) => {
 					dfd.reject(error.message);
@@ -604,8 +610,7 @@ function testXhr(baseUrl, testUrl) {
 
 					if (status === 'success') {
 						dfd.resolve();
-					}
-					else if (status === 'error') {
+					} else if (status === 'error') {
 						dfd.reject(result.message);
 					}
 				});

--- a/tests/unit/request_browser.ts
+++ b/tests/unit/request_browser.ts
@@ -5,18 +5,19 @@ import { Require } from '@dojo/interfaces/loader';
 
 declare const require: Require;
 
-const getRequestUrl = function (dataKey: string): string {
+const getRequestUrl = function(dataKey: string): string {
 	return require.toUrl('../support/data/' + dataKey);
 };
 
 registerSuite('request_browser', {
 	'.get'() {
-		return request.get(getRequestUrl('foo.json'))
-			.then(response => {
+		return request
+			.get(getRequestUrl('foo.json'))
+			.then((response) => {
 				return response.json();
-			}).then(json => {
-				assert.deepEqual(json, { foo: 'bar' });
 			})
-		;
+			.then((json) => {
+				assert.deepEqual(json, { foo: 'bar' });
+			});
 	}
 });

--- a/tests/unit/request_node.ts
+++ b/tests/unit/request_node.ts
@@ -12,7 +12,6 @@ let handle: any;
 const serverPort = 8124;
 const serverUrl = 'http://localhost:' + serverPort;
 let server: any;
-let nodeRequest: any;
 
 let getRequestUrl = function(dataKey: string): string {
 	return serverUrl + '?dataKey=' + dataKey;
@@ -33,7 +32,6 @@ registerSuite('request node', {
 
 		server = createServer(function(request, response) {
 			const body = getResponseData(request);
-			nodeRequest = request;
 
 			response.writeHead(200, {
 				'Content-Type': 'application/json'

--- a/tests/unit/request_node.ts
+++ b/tests/unit/request_node.ts
@@ -14,7 +14,7 @@ const serverUrl = 'http://localhost:' + serverPort;
 let server: any;
 let nodeRequest: any;
 
-let getRequestUrl = function (dataKey: string): string {
+let getRequestUrl = function(dataKey: string): string {
 	return serverUrl + '?dataKey=' + dataKey;
 };
 
@@ -31,7 +31,7 @@ registerSuite('request node', {
 			return responseData[urlInfo.query.dataKey];
 		}
 
-		server = createServer(function(request, response){
+		server = createServer(function(request, response) {
 			const body = getResponseData(request);
 			nodeRequest = request;
 
@@ -63,33 +63,34 @@ registerSuite('request node', {
 	tests: {
 		'.get': {
 			'simple request'(this: any) {
-				return request.get(getRequestUrl('foo.json'))
-					.then(response => {
+				return request
+					.get(getRequestUrl('foo.json'))
+					.then((response) => {
 						return response.text();
-					}).then(text => {
+					})
+					.then((text) => {
 						assert.equal(String(text), JSON.stringify({ foo: 'bar' }));
 					});
 			},
 
 			'custom headers'(this: any) {
 				const options = { headers: { 'Content-Type': 'application/json' } };
-				return request.get(getRequestUrl('foo.json'), options)
-					.then(
-						response => {
-							return response.text().then(text => {
-								assert.equal(String(text), JSON.stringify({ foo: 'bar' }));
-								assert.equal(response.headers.get('content-type'), 'application/json');
-							});
-						}
-					);
+				return request.get(getRequestUrl('foo.json'), options).then((response) => {
+					return response.text().then((text) => {
+						assert.equal(String(text), JSON.stringify({ foo: 'bar' }));
+						assert.equal(response.headers.get('content-type'), 'application/json');
+					});
+				});
 			}
 		},
 
 		'JSON responseType filter'() {
-			return request.get(getRequestUrl('foo.json'))
-				.then(response => {
+			return request
+				.get(getRequestUrl('foo.json'))
+				.then((response) => {
 					return response.json();
-				}).then(json => {
+				})
+				.then((json) => {
 					assert.deepEqual(json, { foo: 'bar' });
 				});
 		}

--- a/tests/unit/stringExtras.ts
+++ b/tests/unit/stringExtras.ts
@@ -5,7 +5,10 @@ import * as stringExtras from '../../src/stringExtras';
 registerSuite('string functions', {
 	'.escapeRegExp()'() {
 		assert.strictEqual(stringExtras.escapeRegExp(''), '');
-		assert.strictEqual(stringExtras.escapeRegExp('[]{}()|/\\^$.*+?'), '\\[\\]\\{\\}\\(\\)\\|\\/\\\\\\^\\$\\.\\*\\+\\?');
+		assert.strictEqual(
+			stringExtras.escapeRegExp('[]{}()|/\\^$.*+?'),
+			'\\[\\]\\{\\}\\(\\)\\|\\/\\\\\\^\\$\\.\\*\\+\\?'
+		);
 	},
 
 	'.escapeXml()'() {
@@ -13,6 +16,9 @@ registerSuite('string functions', {
 
 		assert.strictEqual(stringExtras.escapeXml(''), '');
 		assert.strictEqual(stringExtras.escapeXml(html, false), '&lt;p class="text">Fox &amp; Hound\'s&lt;/p>');
-		assert.strictEqual(stringExtras.escapeXml(html), '&lt;p class=&quot;text&quot;&gt;Fox &amp; Hound&#39;s&lt;/p&gt;');
+		assert.strictEqual(
+			stringExtras.escapeXml(html),
+			'&lt;p class=&quot;text&quot;&gt;Fox &amp; Hound&#39;s&lt;/p&gt;'
+		);
 	}
 });

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -16,51 +16,59 @@ declare const require: RootRequire;
 const basePath = (function() {
 	if (has('host-browser')) {
 		return '../../_build/tests/support/data/';
-	}
-	else if (has('host-node')) {
+	} else if (has('host-node')) {
 		return './_build/tests/support/data/';
 	}
 })();
 const absPathMock = (val: string) => val;
 
 registerSuite('text', {
-		'get'(this: any) {
-			text.get(basePath + 'correctText.txt').then(this.async().callback(function (text: string) {
+	get(this: any) {
+		text.get(basePath + 'correctText.txt').then(
+			this.async().callback(function(text: string) {
 				assert.strictEqual(text, 'abc');
-			}));
-		},
+			})
+		);
+	},
 
-		'normalize': {
-			'calls absMid function for relative path'() {
-				const absMidStub = stub().returns('test');
-				text.normalize('./test', absMidStub);
-				assert.isTrue(absMidStub.calledOnce, 'Abs mid function should be called');
-			},
-			'does not call absMid function for abs path'() {
-				const absMidStub = stub().returns('test');
-				text.normalize('test', absMidStub);
-				assert.isFalse(absMidStub.called, 'Abs mid function should not be called');
-			},
-			'should return passed strip flag for relative path'() {
-				const normalized = text.normalize('./test!strip', absPathMock);
-				assert.include(normalized, '!strip', 'Strip flag should be present');
-			},
-			'should return passed strip flag for abs path'() {
-				const normalized = text.normalize('test!strip', absPathMock);
-				assert.include(normalized, '!strip', 'Strip flag should be present');
-			}
+	normalize: {
+		'calls absMid function for relative path'() {
+			const absMidStub = stub().returns('test');
+			text.normalize('./test', absMidStub);
+			assert.isTrue(absMidStub.calledOnce, 'Abs mid function should be called');
 		},
-		'load': {
-			'should strip xml'(this: any) {
-				text.load('../support/data/strip.xml!strip', require, this.async().callback((val: string) => {
+		'does not call absMid function for abs path'() {
+			const absMidStub = stub().returns('test');
+			text.normalize('test', absMidStub);
+			assert.isFalse(absMidStub.called, 'Abs mid function should not be called');
+		},
+		'should return passed strip flag for relative path'() {
+			const normalized = text.normalize('./test!strip', absPathMock);
+			assert.include(normalized, '!strip', 'Strip flag should be present');
+		},
+		'should return passed strip flag for abs path'() {
+			const normalized = text.normalize('test!strip', absPathMock);
+			assert.include(normalized, '!strip', 'Strip flag should be present');
+		}
+	},
+	load: {
+		'should strip xml'(this: any) {
+			text.load(
+				'../support/data/strip.xml!strip',
+				require,
+				this.async().callback((val: string) => {
 					assert.strictEqual(val, 'abc', 'Should have stripped the XML');
-				}));
-			},
-			'should strip html'(this: any) {
-				text.load('../support/data/strip.html!strip', require, this.async().callback((val: string) => {
+				})
+			);
+		},
+		'should strip html'(this: any) {
+			text.load(
+				'../support/data/strip.html!strip',
+				require,
+				this.async().callback((val: string) => {
 					assert.strictEqual(val, 'abc', 'Should have stripped the XML');
-				}));
-			}
+				})
+			);
 		}
 	}
-);
+});

--- a/tests/unit/text_browser.ts
+++ b/tests/unit/text_browser.ts
@@ -6,12 +6,15 @@ import { RootRequire } from '@dojo/interfaces/loader';
 declare const require: RootRequire;
 
 registerSuite('text - browser', {
-		'load': {
-			'should return text'(this: any) {
-				text.load('../support/data/textLoad.txt', require, this.async().callback((val: string) => {
+	load: {
+		'should return text'(this: any) {
+			text.load(
+				'../support/data/textLoad.txt',
+				require,
+				this.async().callback((val: string) => {
 					assert.strictEqual(val, 'test', 'Correct text should be returned');
-				}));
-			}
+				})
+			);
 		}
 	}
-);
+});

--- a/tests/unit/text_node.ts
+++ b/tests/unit/text_node.ts
@@ -11,29 +11,36 @@ const basePath = '_build/tests/support/data/';
 let fsSpy: SinonSpy;
 
 registerSuite('text - node', {
-		'load': {
-			beforeEach() {
-				fsSpy = spy(fs, 'readFile');
-			},
+	load: {
+		beforeEach() {
+			fsSpy = spy(fs, 'readFile');
+		},
 
-			afterEach() {
-				fsSpy.restore && fsSpy.restore();
-			},
+		afterEach() {
+			fsSpy.restore && fsSpy.restore();
+		},
 
-			tests: {
-				'should return text and call fs'(this: any) {
-					text.load(basePath + 'textLoad.txt', require, this.async().callback((val: string) => {
+		tests: {
+			'should return text and call fs'(this: any) {
+				text.load(
+					basePath + 'textLoad.txt',
+					require,
+					this.async().callback((val: string) => {
 						assert.isTrue(fsSpy.calledOnce, 'Read file should be called once');
 						assert.strictEqual(val, 'test', 'Correct text should be returned');
-					}));
-				},
-				'should return text from cache'(this: any) {
-					text.load(basePath + 'textLoad.txt', require, this.async().callback((val: string) => {
+					})
+				);
+			},
+			'should return text from cache'(this: any) {
+				text.load(
+					basePath + 'textLoad.txt',
+					require,
+					this.async().callback((val: string) => {
 						assert.isTrue(fsSpy.notCalled, 'Read file should not be called');
 						assert.strictEqual(val, 'test', 'Correct text should be returned');
-					}));
-				}
+					})
+				);
 			}
 		}
 	}
-);
+});

--- a/tests/unit/util.ts
+++ b/tests/unit/util.ts
@@ -45,13 +45,16 @@ registerSuite('utility functions', {
 				const spy = sinon.spy();
 				timerHandle = util.createTimer(spy, 100);
 
-				setTimeout(function () {
+				setTimeout(function() {
 					destroyTimerHandle();
 				}, 50);
 
-				setTimeout(dfd.callback(function () {
-					assert.strictEqual(spy.callCount, 0);
-				}), 110);
+				setTimeout(
+					dfd.callback(function() {
+						assert.strictEqual(spy.callCount, 0);
+					}),
+					110
+				);
 			},
 
 			timeout(this: any) {
@@ -59,9 +62,12 @@ registerSuite('utility functions', {
 				const spy = sinon.spy();
 				timerHandle = util.createTimer(spy, 100);
 
-				setTimeout(dfd.callback(function () {
-					assert.strictEqual(spy.callCount, 1);
-				}), 110);
+				setTimeout(
+					dfd.callback(function() {
+						assert.strictEqual(spy.callCount, 1);
+					}),
+					110
+				);
 			}
 		},
 
@@ -71,36 +77,47 @@ registerSuite('utility functions', {
 				const spy = sinon.spy();
 				timerHandle = util.guaranteeMinimumTimeout(spy, 100);
 
-				setTimeout(function () {
+				setTimeout(function() {
 					destroyTimerHandle();
 				}, 50);
 
-				setTimeout(dfd.callback(function () {
-					assert.strictEqual(spy.callCount, 0);
-				}), 110);
+				setTimeout(
+					dfd.callback(function() {
+						assert.strictEqual(spy.callCount, 0);
+					}),
+					110
+				);
 			},
 
 			timeout(this: any) {
 				const dfd = this.async(1000);
 				const startTime = Date.now();
-				timerHandle = util.guaranteeMinimumTimeout(dfd.callback(function () {
-					const dif = Date.now() - startTime;
-					assert.isTrue(dif >= 100, 'Delay was ' + dif + 'ms.');
-				}), 100);
+				timerHandle = util.guaranteeMinimumTimeout(
+					dfd.callback(function() {
+						const dif = Date.now() - startTime;
+						assert.isTrue(dif >= 100, 'Delay was ' + dif + 'ms.');
+					}),
+					100
+				);
 			},
 
 			'timeout no delay'(this: any) {
 				const dfd = this.async(1000);
-				timerHandle = util.guaranteeMinimumTimeout(dfd.callback(function () {
-					// test will timeout if not called
-				}));
+				timerHandle = util.guaranteeMinimumTimeout(
+					dfd.callback(function() {
+						// test will timeout if not called
+					})
+				);
 			},
 
 			'timeout zero delay'(this: any) {
 				const dfd = this.async(1000);
-				timerHandle = util.guaranteeMinimumTimeout(dfd.callback(function () {
-					// test will timeout if not called
-				}), 0);
+				timerHandle = util.guaranteeMinimumTimeout(
+					dfd.callback(function() {
+						// test will timeout if not called
+					}),
+					0
+				);
 			}
 		},
 
@@ -109,9 +126,12 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				// FIXME
 				let foo = {
-					bar: util.debounce(dfd.callback(function (this: any) {
-						assert.strictEqual(this, foo, 'Function should be executed with correct context');
-					}), 0)
+					bar: util.debounce(
+						dfd.callback(function(this: any) {
+							assert.strictEqual(this, foo, 'Function should be executed with correct context');
+						}),
+						0
+					)
 				};
 
 				foo.bar();
@@ -121,24 +141,34 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				const testArg1 = 5;
 				const testArg2 = 'a';
-				const debouncedFunction = util.debounce(dfd.callback(function (a: number, b: string) {
-					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-				}), 0);
+				const debouncedFunction = util.debounce(
+					dfd.callback(function(a: number, b: string) {
+						assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+						assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+					}),
+					0
+				);
 
 				debouncedFunction(testArg1, testArg2);
 			},
 
 			'debounces callback'(this: any) {
 				const dfd = this.async(TIMEOUT);
-				const debouncedFunction = util.debounce(dfd.callback(function () {
-					assert.isAbove(Date.now() - lastCallTick, 10, 'Function should not be called until period has elapsed without further calls');
+				const debouncedFunction = util.debounce(
+					dfd.callback(function() {
+						assert.isAbove(
+							Date.now() - lastCallTick,
+							10,
+							'Function should not be called until period has elapsed without further calls'
+						);
 
-					// Typically, we expect the 3rd invocation to be the one that is executed.
-					// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may
-					// take longer. If 25+ ms has actually elapsed, then the first or second invocation may end up
-					// being eligible for execution.
-				}), 25);
+						// Typically, we expect the 3rd invocation to be the one that is executed.
+						// Although the setTimeout in 'run' specifies a delay of 5ms, a very slow test environment may
+						// take longer. If 25+ ms has actually elapsed, then the first or second invocation may end up
+						// being eligible for execution.
+					}),
+					25
+				);
 
 				let runCount = 1;
 				let lastCallTick: number;
@@ -162,9 +192,12 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				// FIXME
 				const foo = {
-					bar: util.throttle(dfd.callback(function (this: any) {
-						assert.strictEqual(this, foo, 'Function should be executed with correct context');
-					}), 0)
+					bar: util.throttle(
+						dfd.callback(function(this: any) {
+							assert.strictEqual(this, foo, 'Function should be executed with correct context');
+						}),
+						0
+					)
 				};
 
 				foo.bar();
@@ -174,10 +207,13 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				const testArg1 = 5;
 				const testArg2 = 'a';
-				const throttledFunction = util.throttle(dfd.callback(function (a: number, b: string) {
-					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-				}), 0);
+				const throttledFunction = util.throttle(
+					dfd.callback(function(a: number, b: string) {
+						assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+						assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+					}),
+					0
+				);
 
 				throttledFunction(testArg1, testArg2);
 			},
@@ -186,22 +222,28 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				let callCount = 0;
 				let cleared = false;
-				const throttledFunction = util.throttle(dfd.rejectOnError(function (a: string) {
-					callCount++;
-					assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
-					// Rounding errors?
-					// Technically, the time diff should be greater than 24ms, but in some cases
-					// it is equal to 24ms.
-					assert.isAbove(Date.now() - lastRunTick, 23,
-						'Function should not be called until throttle delay has elapsed');
+				const throttledFunction = util.throttle(
+					dfd.rejectOnError(function(a: string) {
+						callCount++;
+						assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
+						// Rounding errors?
+						// Technically, the time diff should be greater than 24ms, but in some cases
+						// it is equal to 24ms.
+						assert.isAbove(
+							Date.now() - lastRunTick,
+							23,
+							'Function should not be called until throttle delay has elapsed'
+						);
 
-					lastRunTick = Date.now();
-					if (callCount > 1) {
-						destroyTimerHandle();
-						cleared = true;
-						dfd.resolve();
-					}
-				}), 25);
+						lastRunTick = Date.now();
+						if (callCount > 1) {
+							destroyTimerHandle();
+							cleared = true;
+							dfd.resolve();
+						}
+					}),
+					25
+				);
 
 				let runCount = 1;
 				let lastRunTick = 0;
@@ -217,8 +259,7 @@ registerSuite('utility functions', {
 				}
 
 				run();
-				assert.strictEqual(callCount, 1,
-					'Function should be called as soon as it is first invoked');
+				assert.strictEqual(callCount, 1, 'Function should be called as soon as it is first invoked');
 			}
 		},
 
@@ -227,9 +268,12 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				// FIXME
 				const foo = {
-					bar: util.throttleAfter(dfd.callback(function (this: any) {
-						assert.strictEqual(this, foo, 'Function should be executed with correct context');
-					}), 0)
+					bar: util.throttleAfter(
+						dfd.callback(function(this: any) {
+							assert.strictEqual(this, foo, 'Function should be executed with correct context');
+						}),
+						0
+					)
 				};
 
 				foo.bar();
@@ -239,10 +283,13 @@ registerSuite('utility functions', {
 				const dfd = this.async(TIMEOUT);
 				const testArg1 = 5;
 				const testArg2 = 'a';
-				const throttledFunction = util.throttleAfter(dfd.callback(function (a: number, b: string) {
-					assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
-					assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
-				}), 0);
+				const throttledFunction = util.throttleAfter(
+					dfd.callback(function(a: number, b: string) {
+						assert.strictEqual(a, testArg1, 'Function should receive correct arguments');
+						assert.strictEqual(b, testArg2, 'Function should receive correct arguments');
+					}),
+					0
+				);
 
 				throttledFunction(testArg1, testArg2);
 			},
@@ -252,18 +299,24 @@ registerSuite('utility functions', {
 
 				let callCount = 0;
 				let lastRunTick = 0;
-				const throttledFunction = util.throttleAfter(dfd.rejectOnError(function (a: string) {
-					callCount++;
-					assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
-					assert.isAbove(Date.now() - lastRunTick, 23,
-						'Function should not be called until throttle delay has elapsed');
+				const throttledFunction = util.throttleAfter(
+					dfd.rejectOnError(function(a: string) {
+						callCount++;
+						assert.notStrictEqual(a, 'b', 'Second invocation should be throttled');
+						assert.isAbove(
+							Date.now() - lastRunTick,
+							23,
+							'Function should not be called until throttle delay has elapsed'
+						);
 
-					lastRunTick = Date.now();
-					if (callCount > 2) {
-						destroyTimerHandle();
-						dfd.resolve();
-					}
-				}), 25);
+						lastRunTick = Date.now();
+						if (callCount > 2) {
+							destroyTimerHandle();
+							dfd.resolve();
+						}
+					}),
+					25
+				);
 
 				function run() {
 					throttledFunction('a');
@@ -273,8 +326,7 @@ registerSuite('utility functions', {
 				}
 
 				run();
-				assert.strictEqual(callCount, 0,
-					'Function should not be called as soon as it is first invoked');
+				assert.strictEqual(callCount, 0, 'Function should not be called as soon as it is first invoked');
 			}
 		}
 	}

--- a/tests/unit/uuid.ts
+++ b/tests/unit/uuid.ts
@@ -8,11 +8,17 @@ registerSuite('uuid functions', {
 		const firstId = uuid();
 
 		assert.isDefined(firstId);
-		assert.match(firstId, new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig'));
+		assert.match(
+			firstId,
+			new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig')
+		);
 
 		const secondId = uuid();
 
-		assert.match(secondId, new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig'));
+		assert.match(
+			secondId,
+			new RegExp('^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$', 'ig')
+		);
 		assert.notEqual(firstId, secondId);
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		],
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,

--- a/tslint.json
+++ b/tslint.json
@@ -30,14 +30,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -57,7 +55,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
 		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ]
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -36,7 +36,6 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
 		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {

--- a/tslint.json
+++ b/tslint.json
@@ -59,7 +59,6 @@
 			"variable-declaration": "onespace"
 		} ],
 		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
