### PR TITLE
Remove @dojo/interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@dojo/shim": "~0.2.3"
   },
   "devDependencies": {
-    "@dojo/interfaces": "~0.2.0",
     "@dojo/loader": "~0.1.1",
     "@theintern/leadfoot": "~2.0.2",
     "@types/benchmark": "~1.0.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -64,3 +64,224 @@ export interface Hash<T> {
 export interface StylesMap {
 	[style: string]: string;
 }
+
+/**
+ * The interfaces to the `@dojo/loader` AMD loader
+ */
+
+export interface AmdConfig {
+	/**
+	 * The base URL that the loader will use to resolve modules
+	 */
+	baseUrl?: string;
+
+	/**
+	 * A map of module identifiers and their replacement meta data
+	 */
+	map?: AmdModuleMap;
+
+	/**
+	 * An array of packages that the loader should use when resolving a module ID
+	 */
+	packages?: AmdPackage[];
+
+	/**
+	 * A map of paths to use when resolving modules names
+	 */
+	paths?: { [path: string]: string };
+
+	/**
+	 * A map of packages that the loader should use when resolving a module ID
+	 */
+	pkgs?: { [path: string]: AmdPackage };
+}
+
+export interface AmdDefine {
+	/**
+	 * Define a module
+	 *
+	 * @param moduleId the MID to use for the module
+	 * @param dependencies an array of MIDs this module depends upon
+	 * @param factory the factory function that will return the module
+	 */
+	(moduleId: string, dependencies: string[], factory: AmdFactory): void;
+
+	/**
+	 * Define a module
+	 *
+	 * @param dependencies an array of MIDs this module depends upon
+	 * @param factory the factory function that will return the module
+	 */
+	(dependencies: string[], factory: AmdFactory): void;
+
+	/**
+	 * Define a module
+	 *
+	 * @param factory the factory function that will return the module
+	 */
+	(factory: AmdFactory): void;
+
+	/**
+	 * Define a module
+	 *
+	 * @param value the value for the module
+	 */
+	(value: any): void;
+
+	/**
+	 * Meta data about this particular AMD loader
+	 */
+	amd: { [prop: string]: string | number | boolean };
+}
+
+export interface AmdFactory {
+	/**
+	 * The module factory
+	 *
+	 * @param modules The arguments that represent the resolved versions of the module dependencies
+	 */
+	(...modules: any[]): any;
+}
+
+export interface AmdHas {
+	/**
+	 * Determine if a feature is present
+	 *
+	 * @param name the feature name to check
+	 */
+	(name: string): any;
+
+	/**
+	 * Register a feature test
+	 *
+	 * @param name The name of the feature to register
+	 * @param value The test for the feature
+	 * @param now If `true` the test will be executed immediatly, if not, it will be lazily executed
+	 * @param force If `true` the test value will be overwritten if already registered
+	 */
+	add(
+		name: string,
+		value: (global: Window, document?: HTMLDocument, element?: HTMLDivElement) => any,
+		now?: boolean,
+		force?: boolean
+	): void;
+	add(name: string, value: any, now?: boolean, force?: boolean): void;
+}
+
+export interface AmdModuleMap extends AmdModuleMapItem {
+	[sourceMid: string]: AmdModuleMapReplacement;
+}
+
+export interface AmdModuleMapItem {
+	[mid: string]: any;
+}
+
+export interface AmdModuleMapReplacement extends AmdModuleMapItem {
+	[findMid: string]: string;
+}
+
+export interface NodeRequire {
+	(moduleId: string): any;
+	resolve(moduleId: string): string;
+}
+
+export interface AmdPackage {
+	/**
+	 * The path to the root of the package
+	 */
+	location?: string;
+
+	/**
+	 * The main module of the package (defaults to `main.js`)
+	 */
+	main?: string;
+
+	/**
+	 * The package name
+	 */
+	name?: string;
+}
+
+export interface AmdRequire {
+	/**
+	 * Resolve a list of module dependencies and pass them to the callback
+	 *
+	 * @param dependencies The array of MIDs to resolve
+	 * @param callback The function to invoke with the resolved dependencies
+	 */
+	(dependencies: string[], callback: AmdRequireCallback): void;
+
+	/**
+	 * Resolve and return a single module (compatability with CommonJS `require`)
+	 *
+	 * @param moduleId The module ID to resolve and return
+	 */
+	<ModuleType>(moduleId: string): ModuleType;
+
+	/**
+	 * If running in the node environment, a reference to the original NodeJS `require`
+	 */
+	nodeRequire?: NodeRequire;
+
+	/**
+	 * Take a relative MID and return an absolute MID
+	 *
+	 * @param moduleId The relative module ID to resolve
+	 */
+	toAbsMid(moduleId: string): string;
+
+	/**
+	 * Take a path and resolve the full URL for the path
+	 *
+	 * @param path The path to resolve and return as a URL
+	 */
+	toUrl(path: string): string;
+}
+
+export interface AmdRequireCallback {
+	/**
+	 * The `require` callback
+	 *
+	 * @param modules The arguments that represent the resolved versions of dependencies
+	 */
+	(...modules: any[]): void;
+}
+
+export interface AmdRootRequire extends AmdRequire {
+	/**
+	 * The minimalist `has` API integrated with the `@dojo/loader`
+	 */
+	has: AmdHas;
+
+	/**
+	 * Register an event listener
+	 *
+	 * @param type The event type to listen for
+	 * @param listener The listener to call when the event is emitted
+	 */
+	on(type: AmdRequireOnSignalType, listener: any): { remove: () => void };
+
+	/**
+	 * Configure the loader
+	 *
+	 * @param config The configuration to apply to the loader
+	 */
+	config(config: AmdConfig): void;
+
+	/**
+	 * Return internal values of loader for debug purposes
+	 *
+	 * @param name The name of the internal label
+	 */
+	inspect?(name: string): any;
+
+	/**
+	 * Undefine a module, based on absolute MID that should be removed from the loader cache
+	 */
+	undef(moduleId: string): void;
+}
+
+/**
+ * The signal type for the `require.on` API
+ */
+export type AmdRequireOnSignalType = 'error';

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,5 +1,5 @@
 import Promise from '@dojo/shim/Promise';
-import { Require as AmdRequire, Define as AmdDefine, NodeRequire } from '@dojo/interfaces/loader';
+import { AmdRequire, AmdDefine, NodeRequire } from './interfaces';
 import { isPlugin, useDefault } from './load/util';
 
 export type Require = AmdRequire | NodeRequire;

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,7 +1,7 @@
 import Promise from '@dojo/shim/Promise';
 import has from './has';
 import request from './request';
-import { NodeRequire, Require as AmdRequire, Config } from '@dojo/interfaces/loader';
+import { NodeRequire, AmdRequire, AmdConfig } from './interfaces';
 import { Require, isAmdRequire } from './load';
 
 declare const require: Require;
@@ -82,7 +82,7 @@ export function normalize(id: string, toAbsMid: (moduleId: string) => string): s
 	return (/^\./.test(url) ? toAbsMid(url) : url) + (parts[1] ? '!' + parts[1] : '');
 }
 
-export function load(id: string, require: AmdRequire, load: (value?: any) => void, config?: Config): void {
+export function load(id: string, require: AmdRequire, load: (value?: any) => void, config?: AmdConfig): void {
 	let parts = id.split('!');
 	let stripFlag = parts.length > 1;
 	let mid = parts[0];

--- a/tests/unit/load.ts
+++ b/tests/unit/load.ts
@@ -5,11 +5,11 @@ import { ObjectSuiteDescriptor } from 'intern/lib/interfaces/object';
 import * as sinon from 'sinon';
 import has from '../../src/has';
 import load, { isPlugin, useDefault } from '../../src/load';
-import { RootRequire } from '@dojo/interfaces/loader';
+import { AmdRootRequire } from '../../src/interfaces';
 import { isPlugin as utilIsPlugin, useDefault as utilUseDefault } from '../../src/load/util';
 import mockPlugin from '../support/load/plugin-default';
 
-declare const require: RootRequire;
+declare const require: AmdRootRequire;
 
 const suite: ObjectSuiteDescriptor = {
 	before() {

--- a/tests/unit/request_browser.ts
+++ b/tests/unit/request_browser.ts
@@ -1,9 +1,9 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import request from '../../src/request';
-import { Require } from '@dojo/interfaces/loader';
+import { AmdRequire } from '../../src/interfaces';
 
-declare const require: Require;
+declare const require: AmdRequire;
 
 const getRequestUrl = function (dataKey: string): string {
 	return require.toUrl('../support/data/' + dataKey);

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -3,9 +3,9 @@ const { assert } = intern.getPlugin('chai');
 import has from '../../src/has';
 import * as text from '../../src/text';
 import { stub } from 'sinon';
-import { RootRequire } from '@dojo/interfaces/loader';
+import { AmdRootRequire } from '../../src/interfaces';
 
-declare const require: RootRequire;
+declare const require: AmdRootRequire;
 
 // The exported get function from the text module
 // uses fs.readFile on node systems, which resolves

--- a/tests/unit/text_browser.ts
+++ b/tests/unit/text_browser.ts
@@ -1,9 +1,9 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as text from '../../src/text';
-import { RootRequire } from '@dojo/interfaces/loader';
+import { AmdRootRequire } from '../../src/interfaces';
 
-declare const require: RootRequire;
+declare const require: AmdRootRequire;
 
 registerSuite('text - browser', {
 		'load': {

--- a/tests/unit/text_node.ts
+++ b/tests/unit/text_node.ts
@@ -3,9 +3,9 @@ const { assert } = intern.getPlugin('chai');
 import * as text from '../../src/text';
 import { spy, SinonSpy } from 'sinon';
 import * as fs from 'fs';
-import { RootRequire } from '@dojo/interfaces/loader';
+import { AmdRootRequire } from '../../src/interfaces';
 
-declare const require: RootRequire;
+declare const require: AmdRootRequire;
 
 const basePath = '_build/tests/support/data/';
 let fsSpy: SinonSpy;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Removes `@dojo/interfaces`. This has always been incorrect anyway as it should've been an actual dependency and not a dev dep (as the types are used in dist code). Given we are about to get rid of `@dojo/interfaces` I've simply inlined the loader types into the interfaces in `@dojo/core` for now. In the future the modules that depend on those in here might not exist anyway (we are going to deprecate/remove `@dojo/core/load` at the very least)