### PR TITLE
Remove aspect#on from `Evented`

### DIFF
--- a/src/QueuingEvented.ts
+++ b/src/QueuingEvented.ts
@@ -14,15 +14,9 @@ class QueuingEvented<M extends {} = {}, T = EventType, O extends EventObject<T> 
 	T,
 	O
 > {
-	private _queue: Map<string | symbol, EventObject[]>;
+	private _queue: Map<string | symbol, EventObject[]> = new Map();
 
-	maxEvents = 0;
-
-	constructor() {
-		super();
-
-		this._queue = new Map();
-	}
+	public maxEvents = 0;
 
 	emit<K extends keyof M>(event: M[K]): void;
 	emit(event: O): void;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Removes the unnecessary usage of `@dojo/core/aspect#on` in `Evented` which removes indirection of stack traces and also reduce the size of the class.

**The API remains unchanged, although would be tempted to remove support for glob matches and subscribing multiple handlers at the same time for a specific event....**

Resolves #379 
