### PR TITLE
Make test request using currently active protocol

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -19,7 +19,7 @@ add(
 		}
 
 		const request = new global.XMLHttpRequest();
-		request.open('GET', 'http://www.google.com', true);
+		request.open('GET', global.location.protocol + '//www.google.com', true);
 		request.responseType = 'blob';
 		request.abort();
 		return request.responseType === 'blob';


### PR DESCRIPTION
For the blob test, make the test request using the active protocol rather than always using http. At least IE11 will throw an exception when making an http request from an https domain.

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR (N/A)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #387
