### PR TITLE
Move createHandle’s destroy from context to a flag

### DIFF
--- a/src/lang.ts
+++ b/src/lang.ts
@@ -364,7 +364,7 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
  * @return The handle object
  */
 export function createHandle(destructor: () => void): Handle {
-	var called = false;
+	let called = false;
 	return {
 		destroy: function(this: Handle) {
 			if (!called) {

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -364,10 +364,13 @@ export function partial(targetFunction: (...args: any[]) => any, ...suppliedArgs
  * @return The handle object
  */
 export function createHandle(destructor: () => void): Handle {
+	var called = false;
 	return {
 		destroy: function(this: Handle) {
-			this.destroy = function() {};
-			destructor.call(this);
+			if (!called) {
+				called = true;
+				destructor();
+			}
 		}
 	};
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

If the destroy function in the response object from `createHandle` was called in a different context than the original, `destroy` would be assigned to the call object and the `destructor` function would also be called in that context. By using a flag, we can guarantee the destructor is only called once regardless of associated context.