### PR TITLE
fix docs/on formatting for dojo.io

### DIFF
--- a/docs/on.md
+++ b/docs/on.md
@@ -2,7 +2,7 @@
 
 `dojo-core/on` provides event handling support with methods to attach and emit events.
 
-## 'emit'
+## `emit`
 
 Dispatch event to target.
 
@@ -19,7 +19,7 @@ var DOMEventObject = {
 emit(button, DOMEventObject);
 
 ```
-## 'on'
+## `on`
 
 Adds event listener to target.
 
@@ -33,7 +33,7 @@ on(button, 'click', function (event) {
 });
 
 ```
-## 'once'
+## `once`
 
 Attach an event that can only be called once to a target.
 
@@ -47,7 +47,7 @@ once(button, 'click', function (event) {
 });
 
 ```
-## 'pausable'
+## `pausable`
 
 Attach an event that can be paused to a target.
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This is just a small formatting fix for docs/on.md.