### PR TITLE
add support for signal request option

### DIFF
--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -1,3 +1,4 @@
+import { AbortSignal } from '@dojo/shim/AbortController';
 import { IterableIterator } from '@dojo/shim/iterator';
 import Task from '../async/Task';
 import UrlSearchParams, { ParamList } from '../UrlSearchParams';
@@ -57,6 +58,10 @@ export interface RequestOptions {
 	 * Password for HTTP authentication
 	 */
 	password?: string;
+	/**
+	 * Abort signal, allowing for cancelable requests
+	 */
+	signal?: AbortSignal;
 	/**
 	 * Number of milliseconds before the request times out and is canceled
 	 */

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -654,6 +654,15 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 					timeoutReject && timeoutReject(new TimeoutError('The request timed out'));
 				}, options.timeout);
 			}
+
+			if (options.signal) {
+				options.signal.addEventListener('abort', () => {
+					const abortError = new Error('Aborted');
+					abortError.name = 'AbortError';
+					reject(abortError);
+				});
+			}
+
 		},
 		() => {
 			request.abort();
@@ -670,10 +679,6 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 		error.message = '[' + requestOptions.method + ' ' + sanitizedUrl + '] ' + error.message;
 		throw error;
 	});
-
-	if (options.signal) {
-		options.signal.addEventListener('abort', () => requestTask.cancel());
-	}
 
 	requestTask.upload = new Observable<number>((observer) => uploadObserverPool.add(observer));
 

--- a/src/request/providers/node.ts
+++ b/src/request/providers/node.ts
@@ -671,6 +671,10 @@ export default function node(url: string, options: NodeRequestOptions = {}): Upl
 		throw error;
 	});
 
+	if (options.signal) {
+		options.signal.addEventListener('abort', () => requestTask.cancel());
+	}
+
 	requestTask.upload = new Observable<number>((observer) => uploadObserverPool.add(observer));
 
 	return requestTask;

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -263,6 +263,10 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 		setOnError(request, reject);
 	}, abort);
 
+	if (options.signal) {
+		options.signal.addEventListener('abort', () => task.cancel());
+	}
+
 	request.open(options.method, requestUrl, !options.blockMainThread, options.user, options.password);
 
 	if (has('filereader') && has('blob')) {

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -214,7 +214,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 					abortError = new Error('Aborted');
 					abortError.name = 'AbortError';
 				}
-				reject(new DOMException('Aborted', 'AbortError'));
+				reject(abortError);
 			});
 		}
 

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -205,6 +205,19 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 	const task = <UploadObservableTask<XhrResponse>>new Task<XhrResponse>((resolve, reject) => {
 		timeoutReject = reject;
 
+		if (options.signal) {
+			options.signal.addEventListener('abort', () => {
+				let abortError: Error;
+				try {
+					abortError = new DOMException('Aborted', 'AbortError');
+				} catch {
+					abortError = new Error('Aborted');
+					abortError.name = 'AbortError';
+				}
+				reject(new DOMException('Aborted', 'AbortError'));
+			});
+		}
+
 		request.onreadystatechange = function() {
 			if (isAborted) {
 				return;
@@ -262,10 +275,6 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 
 		setOnError(request, reject);
 	}, abort);
-
-	if (options.signal) {
-		options.signal.addEventListener('abort', () => task.cancel());
-	}
 
 	request.open(options.method, requestUrl, !options.blockMainThread, options.user, options.password);
 

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -7,7 +7,6 @@ import * as zlib from 'zlib';
 import { Response } from '../../../src/request/interfaces';
 import { default as nodeRequest, NodeResponse } from '../../../src/request/providers/node';
 import TimeoutError from '../../../src/request/TimeoutError';
-import { State } from '../../../src/async/Task';
 import AbortController from '@dojo/shim/AbortController';
 
 const serverPort = 8124;
@@ -471,9 +470,9 @@ registerSuite('request/node', {
 				const controller = new AbortController();
 				const { signal } = controller;
 				const request = nodeRequest(url, { signal });
-				request.finally(
-					dfd.callback(() => {
-						assert.strictEqual(request.state, State.Canceled);
+				request.catch(
+					dfd.callback((error: Error) => {
+						assert.strictEqual(error.name, 'AbortError');
 					})
 				);
 				controller.abort();

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -7,6 +7,8 @@ import * as zlib from 'zlib';
 import { Response } from '../../../src/request/interfaces';
 import { default as nodeRequest, NodeResponse } from '../../../src/request/providers/node';
 import TimeoutError from '../../../src/request/TimeoutError';
+import { State } from '../../../src/async/Task';
+import AbortController from '@dojo/shim/AbortController';
 
 const serverPort = 8124;
 const serverUrl = 'http://localhost:' + serverPort;
@@ -461,6 +463,20 @@ registerSuite('request/node', {
 					}),
 					dfd.reject.bind(dfd)
 				);
+			},
+
+			signal(this: any) {
+				const dfd = this.async();
+				const url = getRequestUrl('foo.json');
+				const controller = new AbortController();
+				const { signal } = controller;
+				const request = nodeRequest(url, { signal });
+				request.finally(
+					dfd.callback(() => {
+						assert.strictEqual(request.state, State.Canceled);
+					})
+				);
+				controller.abort();
 			},
 
 			'user and password': {

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -7,7 +7,6 @@ import { Response } from '../../../src/request/interfaces';
 import UrlSearchParams from '../../../src/UrlSearchParams';
 import has from '../../../src/has';
 import Promise from '@dojo/shim/Promise';
-import { State } from '../../../src/async/Task';
 
 let echoServerAvailable = false;
 registerSuite('request/providers/xhr', {
@@ -104,9 +103,9 @@ registerSuite('request/providers/xhr', {
 				const controller = new AbortController();
 				const { signal } = controller;
 				const request = xhrRequest('/__echo/foo.json', { signal, timeout: 100 });
-				request.finally(
-					dfd.callback(() => {
-						assert.strictEqual(request.state, State.Canceled);
+				request.catch(
+					dfd.callback((error: Error) => {
+						assert.strictEqual(error.name, 'AbortError');
 					})
 				);
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

**Note:** This PR is dependent on dojo/shim#143.

Resolves #390

add support for a `signal: AbortSignal` property in the request options. When provided, the request can be aborted by calling the `AbortController#abort` method, similar to the fetch API. When a request is aborted, the `Promise` is rejected with an `AbortError`, if possible.

