### PR TITLE
Provide total and lengthComputable data for xhr requests

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -37,7 +37,8 @@ const req = request.post('http://www.example.com/', {
 	body: someLargeString
 });
 
-req.upload.subscribe(totalUploadedBytes => {
+req.upload.subscribe(uploadData => {
+  const { loaded } = uploadData;
 	// do something with uploaded bytes
 })
 ```
@@ -48,6 +49,21 @@ Note that while the Node.js provider will emit a single upload event when it is 
 request.post('http://www.example.com/', {
 	bodyStream: fs.createReadStream('some-large-file')
 });
+```
+
+Progress events will always provide a `loaded` property that contains bytes uploaded, but the XMLHttpRequest provider will also emit data for `total` and `lengthComputable`:
+
+```typescript
+const xhr = xhr.post('http://www.example.com/', {
+	body: someLargeString
+});
+
+xhr.upload.subscribe(uploadData => {
+  const { loaded, total, lengthComputable } = uploadData;
+	if (lengthComputable) {
+    const percentComplete = loaded / total * 100;
+  }
+})
 ```
 
 ### Monitoring Download Progress

--- a/src/request/interfaces.d.ts
+++ b/src/request/interfaces.d.ts
@@ -26,8 +26,12 @@ export interface Headers {
 	[Symbol.iterator](): IterableIterator<[string, string]>;
 }
 
-export interface UploadObservableTask<T> extends Task<T> {
-	upload: Observable<number>;
+export interface RequestUploadData {
+	loaded: number;
+}
+
+export interface UploadObservableTask<T, U = RequestUploadData> extends Task<T> {
+	upload: Observable<U>;
 }
 
 export type Provider = (url: string, options?: RequestOptions) => UploadObservableTask<Response>;

--- a/src/request/providers/xhr.ts
+++ b/src/request/providers/xhr.ts
@@ -6,7 +6,7 @@ import has from '../../has';
 import Observable from '../../Observable';
 import { createTimer } from '../../util';
 import Headers from '../Headers';
-import { RequestOptions, UploadObservableTask } from '../interfaces';
+import { RequestOptions, UploadObservableTask, RequestUploadData } from '../interfaces';
 import Response, { getArrayBufferFromBlob, getTextFromBlob } from '../Response';
 import SubscriptionPool from '../SubscriptionPool';
 import TimeoutError from '../TimeoutError';
@@ -30,6 +30,14 @@ export interface XhrRequestOptions extends RequestOptions {
 	 * to be preflighted (https://xhr.spec.whatwg.org/#request)
 	 */
 	includeUploadProgress?: boolean;
+}
+
+/**
+ * Upload event data specific to an XHR request
+ */
+export interface XhrRequestUploadData extends RequestUploadData {
+	total: number;
+	lengthComputable: boolean;
 }
 
 interface RequestData {
@@ -184,7 +192,10 @@ function setOnError(request: XMLHttpRequest, reject: Function) {
 	});
 }
 
-export default function xhr(url: string, options: XhrRequestOptions = {}): UploadObservableTask<XhrResponse> {
+export default function xhr(
+	url: string,
+	options: XhrRequestOptions = {}
+): UploadObservableTask<XhrResponse, XhrRequestUploadData> {
 	const request = new XMLHttpRequest();
 	const requestUrl = generateRequestUrl(url, options);
 
@@ -207,7 +218,7 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 	let timeoutHandle: Handle;
 	let timeoutReject: Function;
 
-	const task = <UploadObservableTask<XhrResponse>>new Task<XhrResponse>((resolve, reject) => {
+	const task = <UploadObservableTask<XhrResponse, XhrRequestUploadData>>new Task<XhrResponse>((resolve, reject) => {
 		timeoutReject = reject;
 
 		request.onreadystatechange = function() {
@@ -317,12 +328,13 @@ export default function xhr(url: string, options: XhrRequestOptions = {}): Uploa
 	});
 
 	if (includeUploadProgress) {
-		const uploadObserverPool = new SubscriptionPool<number>();
-		task.upload = new Observable<number>((observer) => uploadObserverPool.add(observer));
+		const uploadObserverPool = new SubscriptionPool<XhrRequestUploadData>();
+		task.upload = new Observable<XhrRequestUploadData>((observer) => uploadObserverPool.add(observer));
 
 		if (has('host-browser') || has('web-worker-xhr-upload')) {
 			request.upload.addEventListener('progress', (event) => {
-				uploadObserverPool.next(event.loaded);
+				const { loaded, total, lengthComputable } = event;
+				uploadObserverPool.next({ loaded, total, lengthComputable });
 			});
 		}
 	}

--- a/tests/unit/request.ts
+++ b/tests/unit/request.ts
@@ -2,6 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import Task from '../../src/async/Task';
 import request, { providerRegistry, Response, Headers, RequestOptions, UploadObservableTask } from '../../src/request';
+import { RequestUploadData } from '../../src/request/interfaces';
 import ResponseClass from '../../src/request/Response';
 import Observable from '../../src/Observable';
 
@@ -40,7 +41,7 @@ function mockProvider(url: string, options?: RequestOptions): UploadObservableTa
 		}()
 	);
 
-	task.upload = new Observable<number>(() => {});
+	task.upload = new Observable<RequestUploadData>(() => {});
 
 	return task;
 }

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -581,7 +581,7 @@ registerSuite('request/node', {
 
 					return req.then((res) => {
 						assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
-						assert.equal(events[events.length - 1], 17);
+						assert.deepEqual(events[events.length - 1], { loaded: 17 });
 					});
 				},
 				'without a stream'(this: any) {
@@ -598,7 +598,7 @@ registerSuite('request/node', {
 
 					return req.then((res) => {
 						assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
-						assert.equal(events[events.length - 1], 17);
+						assert.deepEqual(events[events.length - 1], { loaded: 17 });
 					});
 				}
 			},

--- a/tests/unit/request/node.ts
+++ b/tests/unit/request/node.ts
@@ -568,7 +568,7 @@ registerSuite('request/node', {
 			},
 			'upload monitoriting': {
 				'with a stream'(this: any) {
-					let events: number[] = [];
+					let events: any[] = [];
 
 					const req = nodeRequest(getRequestUrl('foo.json'), {
 						method: 'POST',
@@ -585,7 +585,7 @@ registerSuite('request/node', {
 					});
 				},
 				'without a stream'(this: any) {
-					let events: number[] = [];
+					let events: any[] = [];
 
 					const req = nodeRequest(getRequestUrl('foo.json'), {
 						method: 'POST',

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -112,7 +112,7 @@ registerSuite('request/providers/xhr', {
 					this.skip('No echo server available');
 				}
 
-				let events: number[] = [];
+				let events: any[] = [];
 
 				const req = xhrRequest('/__echo/post', {
 					method: 'POST',

--- a/tests/unit/request/xhr.ts
+++ b/tests/unit/request/xhr.ts
@@ -125,7 +125,9 @@ registerSuite('request/providers/xhr', {
 
 				return req.then((res) => {
 					assert.isTrue(events.length > 0, 'was expecting at least one monitor event');
-					assert.equal(events[events.length - 1], 5);
+					assert.equal(events[events.length - 1].loaded, 5);
+					assert.equal(events[events.length - 1].total, 5);
+					assert.equal(events[events.length - 1].lengthComputable, true);
 				});
 			},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

When specifically using the `xhr` provider, the upload events allow access to data available from the native `xhr` progress event:
```typescript
const xhr = xhr.post('http://www.example.com/', {
	body: someLargeString
});

xhr.upload.subscribe(uploadData => {
  const { loaded, total, lengthComputable } = uploadData;
	if (lengthComputable) {
		const percentComplete = loaded / total * 100;
	}
});
```
The `node` provider has also been updated for consistency:
```typescript
const req = request.post('http://www.example.com/', {
	body: someLargeString
});

req.upload.subscribe(uploadData => {
	const { loaded } = uploadData;
	// do something with uploaded bytes
})
```
