### PR TITLE
Add standardized default and named exports for Constructors - #404

### DIFF
--- a/src/DateObject.ts
+++ b/src/DateObject.ts
@@ -58,7 +58,7 @@ const operationHash: Hash<string> = Object.create(null, {
 	years: { value: 'FullYear' }
 });
 
-export default class DateObject implements DateProperties {
+export class DateObject implements DateProperties {
 	static parse(str: string): DateObject {
 		return new DateObject(Date.parse(str));
 	}
@@ -346,3 +346,5 @@ export default class DateObject implements DateProperties {
 		return this._date.valueOf();
 	}
 }
+
+export default DateObject;

--- a/src/IdentityRegistry.ts
+++ b/src/IdentityRegistry.ts
@@ -31,7 +31,7 @@ export type Identity = string | symbol;
 /**
  * A registry of values, mapped by identities.
  */
-export default class IdentityRegistry<V extends object> implements Iterable<[Identity, V]> {
+export class IdentityRegistry<V extends object> implements Iterable<[Identity, V]> {
 	constructor() {
 		privateStateMap.set(this, {
 			entryMap: new Map<Identity, Entry<V>>(),
@@ -176,3 +176,5 @@ export default class IdentityRegistry<V extends object> implements Iterable<[Ide
 		return this.entries();
 	}
 }
+
+export default IdentityRegistry;

--- a/src/List.ts
+++ b/src/List.ts
@@ -7,7 +7,7 @@ function getListItems<T>(list: List<T>): T[] {
 	return (listItems.get(list) || []) as T[];
 }
 
-export default class List<T> {
+export class List<T> {
 	[Symbol.iterator]() {
 		return this.values();
 	}
@@ -102,3 +102,5 @@ export default class List<T> {
 		return new ShimIterator<T>(getListItems(this).map<T>((value) => value));
 	}
 }
+
+export default List;

--- a/src/MatchRegistry.ts
+++ b/src/MatchRegistry.ts
@@ -12,7 +12,7 @@ interface Entry<T> {
 /**
  * A registry of values tagged with matchers.
  */
-export default class MatchRegistry<T> {
+export class MatchRegistry<T> {
 	protected _defaultValue: T | undefined;
 	private readonly _entries: Entry<T>[] | null;
 
@@ -85,3 +85,5 @@ export default class MatchRegistry<T> {
 export interface Test {
 	(...args: any[]): boolean | null;
 }
+
+export default MatchRegistry;

--- a/src/MultiMap.ts
+++ b/src/MultiMap.ts
@@ -8,7 +8,7 @@ import '@dojo/shim/Symbol';
  *
  * @param T Accepts the type of the value
  */
-export default class MultiMap<T> implements Map<any[], T> {
+export class MultiMap<T> implements Map<any[], T> {
 	private _map: Map<any, any>;
 	private _key: symbol;
 
@@ -233,3 +233,5 @@ export default class MultiMap<T> implements Map<any[], T> {
 
 	[Symbol.toStringTag] = 'MultiMap';
 }
+
+export default MultiMap;

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -16,7 +16,7 @@ export interface KwArgs {
 	queueFunction?: (callback: (...args: any[]) => any) => Handle;
 }
 
-export default class Scheduler {
+export class Scheduler {
 	protected readonly _boundDispatch: () => void;
 	protected _deferred: QueueItem[] | null = null;
 	protected _isProcessing: boolean;
@@ -111,3 +111,5 @@ export default class Scheduler {
 		return getQueueHandle(item);
 	}
 }
+
+export default Scheduler;

--- a/src/async/ExtensiblePromise.ts
+++ b/src/async/ExtensiblePromise.ts
@@ -34,7 +34,7 @@ export type ListOfPromises<T> = Iterable<T | Thenable<T>>;
  * An extensible base to allow Promises to be extended in ES5. This class basically wraps a native Promise object,
  * giving an API like a native promise.
  */
-export default class ExtensiblePromise<T> {
+export class ExtensiblePromise<T> {
 	/**
 	 * Return a rejected promise wrapped in an ExtensiblePromise
 	 *
@@ -245,3 +245,5 @@ export default class ExtensiblePromise<T> {
 
 	readonly [Symbol.toStringTag]: 'Promise';
 }
+
+export default ExtensiblePromise;

--- a/src/async/Task.ts
+++ b/src/async/Task.ts
@@ -33,7 +33,7 @@ export function isThenable<T>(value: any): value is Thenable<T> {
 /**
  * Task is an extension of Promise that supports cancellation and the Task#finally method.
  */
-export default class Task<T> extends ExtensiblePromise<T> {
+export class Task<T> extends ExtensiblePromise<T> {
 	/**
 	 * Return a Task that resolves when one of the passed in objects have resolved
 	 *
@@ -380,3 +380,5 @@ export default class Task<T> extends ExtensiblePromise<T> {
 		return task;
 	}
 }
+
+export default Task;

--- a/src/request/Headers.ts
+++ b/src/request/Headers.ts
@@ -10,7 +10,7 @@ function isHeadersLike(object: any): object is HeadersInterface {
 	);
 }
 
-export default class Headers implements HeadersInterface {
+export class Headers implements HeadersInterface {
 	protected map = new Map<string, string[]>();
 
 	constructor(headers?: { [key: string]: string } | HeadersInterface) {
@@ -97,3 +97,5 @@ export default class Headers implements HeadersInterface {
 		return this.entries();
 	}
 }
+
+export default Headers;

--- a/src/request/ProviderRegistry.ts
+++ b/src/request/ProviderRegistry.ts
@@ -2,7 +2,7 @@ import { Provider, ProviderTest } from './interfaces';
 import MatchRegistry, { Test } from '../MatchRegistry';
 import { Handle } from '../interfaces';
 
-export default class ProviderRegistry extends MatchRegistry<Provider> {
+export class ProviderRegistry extends MatchRegistry<Provider> {
 	setDefaultProvider(provider: Provider) {
 		this._defaultValue = provider;
 	}
@@ -23,3 +23,5 @@ export default class ProviderRegistry extends MatchRegistry<Provider> {
 		return super.register(entryTest, value, first);
 	}
 }
+
+export default ProviderRegistry;

--- a/src/request/SubscriptionPool.ts
+++ b/src/request/SubscriptionPool.ts
@@ -1,6 +1,6 @@
 import { SubscriptionObserver } from '@dojo/shim/Observable';
 
-export default class SubscriptionPool<T> {
+export class SubscriptionPool<T> {
 	private _observers: SubscriptionObserver<T>[] = [];
 	private _queue: T[] = [];
 	private _queueMaxLength: number;
@@ -42,3 +42,5 @@ export default class SubscriptionPool<T> {
 		});
 	}
 }
+
+export default SubscriptionPool;

--- a/src/request/TimeoutError.ts
+++ b/src/request/TimeoutError.ts
@@ -1,4 +1,4 @@
-export default class TimeoutError implements Error {
+export class TimeoutError implements Error {
 	readonly message: string;
 
 	get name(): string {
@@ -10,3 +10,5 @@ export default class TimeoutError implements Error {
 		this.message = message;
 	}
 }
+
+export default TimeoutError;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ x] There is a related issue
* [ x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This standardizes all the Constructor exports with named and default entries for dojo/core.
Resolves #404 
