### PR TITLE
Fix web-worker-xhr-upload check on legacy browsers

### DIFF
--- a/src/has.ts
+++ b/src/has.ts
@@ -33,12 +33,13 @@ add('fetch', 'fetch' in global && typeof global.fetch === 'function', true);
 
 add(
 	'web-worker-xhr-upload',
-	new Promise((resolve) => {
-		try {
-			if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
-				const blob = new Blob(
-					[
-						`(function () {
+	typeof global.Promise !== 'undefined' &&
+		new Promise((resolve) => {
+			try {
+				if (global.Worker !== undefined && global.URL && global.URL.createObjectURL) {
+					const blob = new Blob(
+						[
+							`(function () {
 self.addEventListener('message', function () {
 	var xhr = new XMLHttpRequest();
 	try {
@@ -49,21 +50,21 @@ self.addEventListener('message', function () {
 	}
 });
 		})()`
-					],
-					{ type: 'application/javascript' }
-				);
-				const worker = new Worker(URL.createObjectURL(blob));
-				worker.addEventListener('message', ({ data: result }) => {
-					resolve(result === 'true');
-				});
-				worker.postMessage({});
-			} else {
+						],
+						{ type: 'application/javascript' }
+					);
+					const worker = new Worker(URL.createObjectURL(blob));
+					worker.addEventListener('message', ({ data: result }) => {
+						resolve(result === 'true');
+					});
+					worker.postMessage({});
+				} else {
+					resolve(false);
+				}
+			} catch (e) {
+				// IE11 on Winodws 8.1 encounters a security error.
 				resolve(false);
 			}
-		} catch (e) {
-			// IE11 on Winodws 8.1 encounters a security error.
-			resolve(false);
-		}
-	}),
+		}),
 	true
 );


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
The web-worker-xhr-upload check presumes a promise exists in the global. If this is evaluated before our promise shim is required in a legacy browser it blows up.
